### PR TITLE
feat: add support for Service Account Name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 
 # Image URL to use all building/pushing image targets
 IMG ?= ghcr.io/k6io/operator:latest
+# Default dockerfile to build
+DOCKERFILE ?= "Dockerfile.controller"
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 
@@ -98,7 +100,7 @@ generate: controller-gen
 
 # Build the docker image
 docker-build: test
-	docker build . -t ${IMG}
+	docker build . -t ${IMG} -f ${DOCKERFILE}
 
 # Push the docker image
 docker-push:

--- a/api/v1alpha1/k6_types.go
+++ b/api/v1alpha1/k6_types.go
@@ -37,14 +37,13 @@ type Pod struct {
 
 // K6Spec defines the desired state of K6
 type K6Spec struct {
-	Script             K6Script               `json:"script"`
-	Parallelism        int32                  `json:"parallelism"`
-	Separate           bool                   `json:"separate,omitempty"`
-	Arguments          string                 `json:"arguments,omitempty"`
-	Ports              []corev1.ContainerPort `json:"ports,omitempty"`
-	ServiceAccountName string                 `json:"serviceaccount,omitempty"`
-	Starter            Pod                    `json:"starter,omitempty"`
-	Runner             Pod                    `json:"runner,omitempty"`
+	Script      K6Script               `json:"script"`
+	Parallelism int32                  `json:"parallelism"`
+	Separate    bool                   `json:"separate,omitempty"`
+	Arguments   string                 `json:"arguments,omitempty"`
+	Ports       []corev1.ContainerPort `json:"ports,omitempty"`
+	Starter     Pod                    `json:"starter,omitempty"`
+	Runner      Pod                    `json:"runner,omitempty"`
 	//	Cleanup     Cleanup `json:"cleanup,omitempty"` // TODO
 }
 

--- a/api/v1alpha1/k6_types.go
+++ b/api/v1alpha1/k6_types.go
@@ -32,7 +32,7 @@ type Pod struct {
 	Metadata                     PodMetadata                 `json:"metadata,omitempty"`
 	NodeSelector                 map[string]string           `json:"nodeselector,omitempty"`
 	Resources                    corev1.ResourceRequirements `json:"resources,omitempty"`
-	ServiceAccountName           string                      `json:"serviceAccountname,omitempty"`
+	ServiceAccountName           string                      `json:"serviceAccountName,omitempty"`
 }
 
 // K6Spec defines the desired state of K6

--- a/api/v1alpha1/k6_types.go
+++ b/api/v1alpha1/k6_types.go
@@ -25,12 +25,14 @@ type PodMetadata struct {
 }
 
 type Pod struct {
-	Affinity     *corev1.Affinity            `json:"affinity,omitempty"`
-	Env          []corev1.EnvVar             `json:"env,omitempty"`
-	Image        string                      `json:"image,omitempty"`
-	Metadata     PodMetadata                 `json:"metadata,omitempty"`
-	NodeSelector map[string]string           `json:"nodeselector,omitempty"`
-	Resources    corev1.ResourceRequirements `json:"resources,omitempty"`
+	Affinity                     *corev1.Affinity            `json:"affinity,omitempty"`
+	AutomountServiceAccountToken string                      `json:"automountServiceAccountToken,omitempty"`
+	Env                          []corev1.EnvVar             `json:"env,omitempty"`
+	Image                        string                      `json:"image,omitempty"`
+	Metadata                     PodMetadata                 `json:"metadata,omitempty"`
+	NodeSelector                 map[string]string           `json:"nodeselector,omitempty"`
+	Resources                    corev1.ResourceRequirements `json:"resources,omitempty"`
+	ServiceAccountName           string                      `json:"serviceAccountname,omitempty"`
 }
 
 // K6Spec defines the desired state of K6

--- a/config/crd/bases/k6.io_k6s.yaml
+++ b/config/crd/bases/k6.io_k6s.yaml
@@ -674,6 +674,8 @@ spec:
                           type: array
                       type: object
                   type: object
+                automountServiceAccountToken:
+                  type: string
                 env:
                   items:
                     description: EnvVar represents an environment variable present
@@ -823,6 +825,8 @@ spec:
                         to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                       type: object
                   type: object
+                serviceAccountname:
+                  type: string
               type: object
             script:
               description: K6Script describes where the script to execute the tests
@@ -1454,6 +1458,8 @@ spec:
                           type: array
                       type: object
                   type: object
+                automountServiceAccountToken:
+                  type: string
                 env:
                   items:
                     description: EnvVar represents an environment variable present
@@ -1603,6 +1609,8 @@ spec:
                         to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                       type: object
                   type: object
+                serviceAccountname:
+                  type: string
               type: object
           required:
           - parallelism

--- a/config/crd/bases/k6.io_k6s.yaml
+++ b/config/crd/bases/k6.io_k6s.yaml
@@ -855,8 +855,6 @@ spec:
               type: object
             separate:
               type: boolean
-            serviceaccount:
-              type: string
             starter:
               properties:
                 affinity:

--- a/config/crd/bases/k6.io_k6s.yaml
+++ b/config/crd/bases/k6.io_k6s.yaml
@@ -825,7 +825,7 @@ spec:
                         to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                       type: object
                   type: object
-                serviceAccountname:
+                serviceAccountName:
                   type: string
               type: object
             script:
@@ -1607,7 +1607,7 @@ spec:
                         to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                       type: object
                   type: object
-                serviceAccountname:
+                serviceAccountName:
                   type: string
               type: object
           required:

--- a/pkg/resources/jobs/runner.go
+++ b/pkg/resources/jobs/runner.go
@@ -78,8 +78,6 @@ func NewRunnerJob(k6 *v1alpha1.K6, index int) (*batchv1.Job, error) {
 	serviceAccountName := "default"
 	if k6.Spec.Runner.ServiceAccountName != "" {
 		serviceAccountName = k6.Spec.Runner.ServiceAccountName
-	} else if k6.Spec.ServiceAccountName != "" {
-		serviceAccountName = k6.Spec.ServiceAccountName
 	}
 
 	automountServiceAccountToken := true

--- a/pkg/resources/jobs/starter.go
+++ b/pkg/resources/jobs/starter.go
@@ -36,8 +36,8 @@ func NewStarterJob(k6 *v1alpha1.K6, hostname []string) *batchv1.Job {
 		serviceAccountName = k6.Spec.Starter.ServiceAccountName
 	}
 	automountServiceAccountToken := true
-	if k6.Spec.Runner.AutomountServiceAccountToken != "" {
-		automountServiceAccountToken, _ = strconv.ParseBool(k6.Spec.Runner.AutomountServiceAccountToken)
+	if k6.Spec.Starter.AutomountServiceAccountToken != "" {
+		automountServiceAccountToken, _ = strconv.ParseBool(k6.Spec.Starter.AutomountServiceAccountToken)
 	}
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/resources/jobs/starter.go
+++ b/pkg/resources/jobs/starter.go
@@ -34,8 +34,6 @@ func NewStarterJob(k6 *v1alpha1.K6, hostname []string) *batchv1.Job {
 	serviceAccountName := "default"
 	if k6.Spec.Starter.ServiceAccountName != "" {
 		serviceAccountName = k6.Spec.Starter.ServiceAccountName
-	} else if k6.Spec.ServiceAccountName != "" {
-		serviceAccountName = k6.Spec.ServiceAccountName
 	}
 	automountServiceAccountToken := true
 	if k6.Spec.Runner.AutomountServiceAccountToken != "" {


### PR DESCRIPTION
Hi everyone,
Currently I'm trying to use the k6-operator to build a chart for load testing on the company I work, in our case we need to set a custom service account name to be used by the job/pod to enable the vault sidecar to inject the volumes on the pod.

Please let me know whether I can improve anything and I'll do it asap!