### PR TITLE
Removing the k6 run on the starter pod

### DIFF
--- a/pkg/resources/jobs/helpers.go
+++ b/pkg/resources/jobs/helpers.go
@@ -14,7 +14,7 @@ func newLabels(name string) map[string]string {
 	}
 }
 
-func newCommand(istioEnabled string) ([]string, bool) {
+func newIstioCommand(istioEnabled string, inheritedCommands []string) ([]string, bool) {
 	istio := true
 	if istioEnabled != "" {
 		istio, _ = strconv.ParseBool(istioEnabled)
@@ -24,7 +24,12 @@ func newCommand(istioEnabled string) ([]string, bool) {
 	if istio {
 		command = append(command, "scuttle")
 	}
-	return append(command, "k6", "run"), istio
+
+	for _, inheritedCommand := range inheritedCommands {
+		command = append(command, inheritedCommand)
+	}
+
+	return command, istio
 }
 
 func newIstioEnvVar(istio v1alpha1.K6Scuttle, istioEnabled bool) []corev1.EnvVar {

--- a/pkg/resources/jobs/helpers_test.go
+++ b/pkg/resources/jobs/helpers_test.go
@@ -21,21 +21,21 @@ func TestNewLabels(t *testing.T) {
 	}
 }
 
-func TestNewCommandIfTrue(t *testing.T) {
+func TestNewIstioCommandIfTrue(t *testing.T) {
 	expectedOutcome := []string{"scuttle", "k6", "run"}
-	command, _ := newCommand("true")
+	command, _ := newIstioCommand("true", []string{"k6", "run"})
 
 	if diff := deep.Equal(expectedOutcome, command); diff != nil {
-		t.Errorf("newCommand returned unexpected data, diff: %s", diff)
+		t.Errorf("newIstioCommand returned unexpected data, diff: %s", diff)
 	}
 }
 
-func TestNewCommandIfFalse(t *testing.T) {
+func TestNewIstioCommandIfFalse(t *testing.T) {
 	expectedOutcome := []string{"k6", "run"}
-	command, _ := newCommand("false")
+	command, _ := newIstioCommand("false", []string{"k6", "run"})
 
 	if diff := deep.Equal(expectedOutcome, command); diff != nil {
-		t.Errorf("newCommand returned unexpected data, diff: %s", diff)
+		t.Errorf("newIstioCommand returned unexpected data, diff: %s", diff)
 	}
 }
 

--- a/pkg/resources/jobs/runner.go
+++ b/pkg/resources/jobs/runner.go
@@ -24,7 +24,9 @@ type Script struct {
 // NewRunnerJob creates a new k6 job from a CRD
 func NewRunnerJob(k6 *v1alpha1.K6, index int) (*batchv1.Job, error) {
 	name := fmt.Sprintf("%s-%d", k6.Name, index)
-	command, istioEnabled := newCommand(k6.Spec.Scuttle.Enabled)
+	postCommand := []string{"k6", "run"}
+
+	command, istioEnabled := newIstioCommand(k6.Spec.Scuttle.Enabled, postCommand)
 
 	quiet := true
 	if k6.Spec.Quiet != "" {

--- a/pkg/resources/jobs/starter.go
+++ b/pkg/resources/jobs/starter.go
@@ -39,7 +39,7 @@ func NewStarterJob(k6 *v1alpha1.K6, hostname []string) *batchv1.Job {
 	if k6.Spec.Starter.AutomountServiceAccountToken != "" {
 		automountServiceAccountToken, _ = strconv.ParseBool(k6.Spec.Starter.AutomountServiceAccountToken)
 	}
-	command, istioEnabled := newCommand(k6.Spec.Scuttle.Enabled, []string{"sh", "-c"})
+	command, istioEnabled := newIstioCommand(k6.Spec.Scuttle.Enabled, []string{"sh", "-c"})
 	env := newIstioEnvVar(k6.Spec.Scuttle, istioEnabled)
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/resources/jobs/starter.go
+++ b/pkg/resources/jobs/starter.go
@@ -39,7 +39,7 @@ func NewStarterJob(k6 *v1alpha1.K6, hostname []string) *batchv1.Job {
 	if k6.Spec.Starter.AutomountServiceAccountToken != "" {
 		automountServiceAccountToken, _ = strconv.ParseBool(k6.Spec.Starter.AutomountServiceAccountToken)
 	}
-	command, istioEnabled := newCommand(k6.Spec.Scuttle.Enabled)
+	command, istioEnabled := newCommand(k6.Spec.Scuttle.Enabled, []string{"sh", "-c"})
 	env := newIstioEnvVar(k6.Spec.Scuttle, istioEnabled)
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/resources/jobs/starter_test.go
+++ b/pkg/resources/jobs/starter_test.go
@@ -47,7 +47,7 @@ func TestNewStarterJob(t *testing.T) {
 					NodeSelector:                 nil,
 					RestartPolicy:                corev1.RestartPolicyNever,
 					Containers: []corev1.Container{
-						containers.NewCurlContainer([]string{"testing"}, "image", []string{"scuttle", "k6", "run"}, []corev1.EnvVar{
+						containers.NewCurlContainer([]string{"testing"}, "image", []string{"scuttle", "sh", "-c"}, []corev1.EnvVar{
 							{
 								Name:  "ENVOY_ADMIN_API",
 								Value: "http://127.0.0.1:15000",


### PR DESCRIPTION
Hi, 
  After some testing why the starter pod is always failiing on `0.0.7-rc`. I found my mistake on #56 when running the starter pod. I've replaced the original command `['scuttle', 'sh', '-c']` with `['scuttle', 'k6', '-run']`. This PR will solve this.

![1628287991](https://user-images.githubusercontent.com/11935541/128576143-490b97bc-4d4a-4394-a10f-44d94a63b172.png)
