### PR TITLE
Added to readme section about cluster setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ Read also the [complete tutorial](https://k6.io/blog/running-distributed-tests-o
 
 ## Setup
 
+### Cluster requirements
+To be able to spawn runner pods, k6-operator needs Istio enabled in namespace, where it operates.
+
 ### Deploying the operator
 Install the operator by running the command below:
 


### PR DESCRIPTION
As I am trying to use k6, on k8s, I've found that there is lack of mentions, about Istio & Envoy being enabled on cluster. 
Here is fix to Readme. 