### PR TITLE
fix: improve test startup logic

### DIFF
--- a/controllers/k6_start.go
+++ b/controllers/k6_start.go
@@ -17,6 +17,9 @@ import (
 )
 
 func isPodReady(pod *v1.Pod) bool {
+        if len(pod.Status.HostIP) < 1 {
+            return false
+        }
 	resp, err := http.Get(fmt.Sprintf("%v/v1/status", pod.Status.HostIP))
 
 	if err != nil {

--- a/controllers/k6_start.go
+++ b/controllers/k6_start.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strconv"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -24,13 +23,7 @@ func isPodReady(pod *v1.Pod) bool {
 		return false
 	}
 
-	status, err := strconv.Atoi(resp.Status)
-
-	if err != nil {
-		return false
-	}
-
-	return status < 400
+	return resp.StatusCode < 400
 }
 
 // StartJobs in the Ready phase using a curl container


### PR DESCRIPTION
Hello everyone,

We've been using this operator for a while and we observed a strange behavior on tests that took a long time on init phase. We noticed that they remained in "paused state" because the k6 http server was not ready yet. So, we've added a simple verification to make sure the http server is up before sending the start requests to the jobs. It's a simple fix, but the results were very effective.

