### PR TITLE
[feat] Add option for disabling fragmentation

### DIFF
--- a/api/v1alpha1/k6_types.go
+++ b/api/v1alpha1/k6_types.go
@@ -50,16 +50,17 @@ type K6Scuttle struct {
 
 // K6Spec defines the desired state of K6
 type K6Spec struct {
-	Script      K6Script               `json:"script"`
-	Parallelism int32                  `json:"parallelism"`
-	Separate    bool                   `json:"separate,omitempty"`
-	Arguments   string                 `json:"arguments,omitempty"`
-	Ports       []corev1.ContainerPort `json:"ports,omitempty"`
-	Starter     Pod                    `json:"starter,omitempty"`
-	Runner      Pod                    `json:"runner,omitempty"`
-	Quiet       string                 `json:"quiet,omitempty"`
-	Paused      string                 `json:"paused,omitempty"`
-	Scuttle     K6Scuttle              `json:"scuttle,omitempty"`
+	Script               K6Script               `json:"script"`
+	Parallelism          int32                  `json:"parallelism"`
+	Separate             bool                   `json:"separate,omitempty"`
+	Arguments            string                 `json:"arguments,omitempty"`
+	Ports                []corev1.ContainerPort `json:"ports,omitempty"`
+	Starter              Pod                    `json:"starter,omitempty"`
+	Runner               Pod                    `json:"runner,omitempty"`
+	Quiet                string                 `json:"quiet,omitempty"`
+	Paused               string                 `json:"paused,omitempty"`
+	Scuttle              K6Scuttle              `json:"scuttle,omitempty"`
+	DisableFragmentation bool                   `json:"disableFragmentation,omitempty"`
 	//	Cleanup     Cleanup `json:"cleanup,omitempty"` // TODO
 }
 

--- a/config/crd/bases/k6.io_k6s.yaml
+++ b/config/crd/bases/k6.io_k6s.yaml
@@ -38,6 +38,8 @@ spec:
             properties:
               arguments:
                 type: string
+              disableFragmentation:
+                type: boolean
               parallelism:
                 format: int32
                 type: integer

--- a/pkg/resources/jobs/runner.go
+++ b/pkg/resources/jobs/runner.go
@@ -37,7 +37,7 @@ func NewRunnerJob(k6 *v1alpha1.K6, index int) (*batchv1.Job, error) {
 		command = append(command, "--quiet")
 	}
 
-	if k6.Spec.Parallelism > 1 {
+	if k6.Spec.Parallelism > 1 && !k6.Spec.DisableFragmentation {
 		var args []string
 		var err error
 


### PR DESCRIPTION
Happy to rename the option to something more suitable. Status quo should be the default (fragment if parallelism > 1). User can disable by setting `disableFragmentation: true` in their spec.

Closes #90