### PR TITLE
update clusterrole template to be compatible with OpenShift

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -65,6 +65,7 @@ rules:
       - k6.io
     resources:
       - k6s/status
+      - k6s/finalizers
     verbs:
       - get
       - patch


### PR DESCRIPTION
After I installed the operator on OpenShift 4.9 cluster, I got the following error after I created a k6 resource:

```
2022-02-19T14:35:11.261Z	INFO	controllers.K6	Creating test jobs	{"k6": "k6-operator-system/k6-sample"}
2022-02-19T14:35:11.261Z	INFO	controllers.K6	Launching k6 test #1	{"k6": "k6-operator-system/k6-sample"}
2022-02-19T14:35:11.266Z	ERROR	controllers.K6	Failed to launch k6 test	{"k6": "k6-operator-system/k6-sample", "error": "jobs.batch \"k6-sample-1\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>"}
github.com/go-logr/zapr.(*zapLogger).Error
```

The serviceaccount requires patch priv on `k6s/finalizers`, added it to RBAC definition.