### PR TITLE
Minor change on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ image using github.com/szkiba/xk6-prometheus as an extension:
 
 ```Dockerfile
 # Build the k6 binary with the extension
-FROM golang:1.16.4-buster as builder
+FROM golang:1.18.1 as builder
 
 RUN go install go.k6.io/xk6/cmd/xk6@latest
 RUN xk6 build --output /k6 --with github.com/szkiba/xk6-prometheus@latest


### PR DESCRIPTION
Running `docker build -t k6 -f Dockerfile .` with `golang:1.16.4-buster` is throwing an error:

```sh
=> ERROR [builder 3/3] RUN xk6 build --output /k6 --with github.com/szkiba/xk6-prometheus@latest                                                                                                   0.3s
------
 > [builder 3/3] RUN xk6 build --output /k6 --with github.com/szkiba/xk6-prometheus@latest:
#10 0.257 2022/05/13 09:54:32 [INFO] Temporary folder: /tmp/buildenv_2022-05-13-0954.394442619
#10 0.257 2022/05/13 09:54:32 [INFO] Initializing Go module
#10 0.257 2022/05/13 09:54:32 [INFO] exec (timeout=10s): /usr/local/go/bin/go mod init k6 
#10 0.261 go: creating new go.mod: module k6
#10 0.263 2022/05/13 09:54:32 [INFO] Pinning versions
#10 0.263 2022/05/13 09:54:32 [INFO] exec (timeout=0s): /usr/local/go/bin/go mod edit -require github.com/szkiba/xk6-prometheus@latest 
#10 0.270 2022/05/13 09:54:32 [INFO] exec (timeout=0s): /usr/local/go/bin/go mod tidy -compat=1.17 
#10 0.275 flag provided but not defined: -compat
#10 0.275 usage: go mod tidy [-e] [-v]
#10 0.275 Run 'go help mod tidy' for details.
#10 0.276 2022/05/13 09:54:32 [INFO] Cleaning up temporary folder: /tmp/buildenv_2022-05-13-0954.394442619
#10 0.277 2022/05/13 09:54:32 [FATAL] exit status 2
------
executor failed running [/bin/sh -c xk6 build --output /k6 --with github.com/szkiba/xk6-prometheus@latest]: exit code: 1
```

Running the same command with `golang:1.18.1` the image is built successfully.