### PR TITLE
Fix: use Cluster IP instead of service name

### DIFF
--- a/controllers/k6_start.go
+++ b/controllers/k6_start.go
@@ -69,7 +69,7 @@ func StartJobs(ctx context.Context, log logr.Logger, k6 *v1alpha1.K6, r *K6Recon
 		}
 
 		for _, service := range sl.Items {
-			hostnames = append(hostnames, service.ObjectMeta.Name)
+			hostnames = append(hostnames, service.Spec.ClusterIP)
 
 			if !isServiceReady(log, &service) {
 				log.Info(fmt.Sprintf("%v service is not ready, aborting", service.ObjectMeta.Name))


### PR DESCRIPTION
Uses the Cluster IP to connect to services instead of the service name. Credits to @pekavau for finding the issue and workaround.

fixes  #132