### PR TITLE
Be able to use a custom Go image to build apps

### DIFF
--- a/Dockerfile.controller
+++ b/Dockerfile.controller
@@ -1,5 +1,6 @@
+ARG GO_BUILDER_IMG
 # Build the manager binary
-FROM golang:1.17 as builder
+FROM ${GO_BUILDER_IMG} as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ BUNDLE_DEFAULT_CHANNEL := --default-channel=$(DEFAULT_CHANNEL)
 endif
 BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 
+# Image to use for building Go
+GO_BUILDER_IMG ?= "golang:1.17"
 # Image URL to use all building/pushing image targets
 IMG ?= ghcr.io/grafana/operator:latest
 # Default dockerfile to build
@@ -100,7 +102,7 @@ generate: controller-gen
 
 # Build the docker image
 docker-build: test
-	docker build . -t ${IMG} -f ${DOCKERFILE}
+	docker build . -t ${IMG} -f ${DOCKERFILE} --build-arg GO_BUILDER_IMG=${GO_BUILDER_IMG}
 
 # Push the docker image
 docker-push:


### PR DESCRIPTION
This PR adds the ability to build the go app using a custom Go builder image. I use it to be able to build the operator in a corp network.