### PR TITLE
support optional env which dictates status check url format

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ Install the operator by running the command below:
 $ make deploy
 ```
 
+_note:_ by default K6 assumes your kubernetes cluster domain is .cluster.local.
+If your Kubernetes cluster uses something else, e.g. `.cluster.example` you can
+override this with the environment variable `K6_CLUSTER_DOMAIN`. e.g.
+
+```bash
+export K6_CLUSTER_DOMAIN=.cluster.example
+make deploy
+```
+
 ### Installing the CRD
 
 The k6 operator includes one custom resource called `K6`. This will be automatically installed when you do a

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,6 +32,9 @@ spec:
             - --enable-leader-election
           image: controller:latest
           name: manager
+          env:
+            - name: K6_CLUSTER_DOMAIN
+              value: $K6_CLUSTER_DOMAIN
           resources:
             limits:
               cpu: 100m


### PR DESCRIPTION
**What does this PR do?**

Allows the user to (optionally) specify a custom cluster domain for their kubernetes cluster.

*why?*

Upon deploying this to one of my clusters I noticed the operator was complaining about not being able to get a status from the service:

![err](https://user-images.githubusercontent.com/641429/185456488-96839bd2-b341-40fa-bf46-25cfcbec56fa.png)

On inspection I realised the cluster domain in my kubernetes cluster and the one hardcoded here https://github.com/grafana/k6-operator/blob/main/controllers/k6_start.go#L20 were different.

*other items of note*

I've updated the yaml manifest and Makefile to support passing this variable through during `make deploy`. The approach I took here was to use `envsubstr` - this is a new dependency for this repository but at a glance it appears to be in use on other projects in this org so I hope that's ok. source: https://github.com/search?q=org%3Agrafana+envsubst&type=code

*testing*
I have tested this with and without `K6_CLUSTER_DOMAIN` env set and confirmed:
 - with no K6_CLUSTER_DOMAIN value set the default ...svc.cluster.local address is used
 - with K6_CLUSTER_DOMAIN value set the url ...svc$K6_CLUSTER_DOMAIN address is used. Further - I've tested that this patch results in a successful deployment on our clusters.