### PR TITLE
Updates README and adds an example for volumeClaim testing usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ spec:
 │   │   ├── stress-test.js
 │   ├── test.js
 ```
-In the above example, `test.js` imports a function from `stress-test.js` and, They would look like this:
+In the above example, `test.js` imports a function from `stress-test.js` and they would look like this:
 ```js
 // stress-test.js
 import stress-test from "./requests/stress-test.js";

--- a/config/samples/k6_v1alpha1_k6_with_volumeClaim.yaml
+++ b/config/samples/k6_v1alpha1_k6_with_volumeClaim.yaml
@@ -12,5 +12,3 @@ spec:
       # And, All the js files and directories test.js
       # is importing from should be inside the same directory as well.
       file: test.js
-  runner:
-    image: <custom-image>

--- a/config/samples/k6_v1alpha1_k6_with_volumeClaim.yaml
+++ b/config/samples/k6_v1alpha1_k6_with_volumeClaim.yaml
@@ -1,0 +1,16 @@
+apiVersion: k6.io/v1alpha1
+kind: K6
+metadata:
+  name: k6-sample
+  namespace: load-test
+spec:
+  parallelism: 4
+  script:
+    volumeClaim:
+      name: stress-test-volumeClaim
+      # test.js should exist inside /test/ folder.
+      # And, All the js files and directories test.js
+      # is importing from should be inside the same directory as well.
+      file: test.js
+  runner:
+    image: <custom-image>


### PR DESCRIPTION
## What does this PR do?
* Adds a volumeClaim example: `config/samples/k6_v1alpha1_k6_with_volumeClaim.yaml`.
* Updates the readme with a more thorough explanation on how to use volumeClaims and also adds a directory example.

## Why?
* After taking some time debugging and experimenting with running k6 tests using volumeClaims, I believe having more concrete examples and explanations like this would help folks working with it in the future.