### PR TITLE
Update README memory limit resources typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ spec:
     resources:
       limits:
         cpu: 200m
-        memory: 1000mi
+        memory: 1000Mi
       requests:
         cpu: 100m
         memory: 500Mi


### PR DESCRIPTION
Current documentation provides an invalid value for memory limit.

`The K6 "k6-sample-1" is invalid: spec.runner.resources.limits.memory: Invalid value: "1000mi": spec.runner.resources.limits.memory in body should match '^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$'`