### PR TITLE
Increased wait time for initialize, runner and start jobs ready status.

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 - manager.yaml
 images:
 - name: controller
-  newName: ghcr.io/prashanth-volvocars/operator
+  newName: ghcr.io/grafana/operator
   newTag: latest
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,9 +1,9 @@
 ---
 resources:
-  - manager.yaml
+- manager.yaml
 images:
-  - name: controller
-    newName: ghcr.io/grafana/operator
-    newTag: latest
+- name: controller
+  newName: ghcr.io/prashanth-volvocars/operator
+  newTag: latest
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/controllers/k6_finish.go
+++ b/controllers/k6_finish.go
@@ -31,7 +31,7 @@ func FinishJobs(ctx context.Context, log logr.Logger, k6 *v1alpha1.K6, r *K6Reco
 
 	testDuration := inspectOutput.TotalDuration.TimeDuration()
 
-	err := wait.PollImmediate(time.Second*30, testDuration+time.Minute*2, func() (done bool, err error) {
+	err := wait.PollImmediate(time.Second*30, testDuration+time.Minute*5, func() (done bool, err error) {
 		selector := labels.SelectorFromSet(map[string]string{
 			"app":    "k6",
 			"k6_cr":  k6.Name,

--- a/controllers/k6_initialize.go
+++ b/controllers/k6_initialize.go
@@ -61,7 +61,7 @@ func InitializeJobs(ctx context.Context, log logr.Logger, k6 *v1alpha1.K6, r *K6
 		log.Error(err, "Failed to launch k6 test initializer")
 		return
 	}
-	err = wait.PollImmediate(time.Second*5, time.Second*60, func() (done bool, err error) {
+	err = wait.PollImmediate(time.Second*5, time.Second*180, func() (done bool, err error) {
 		var (
 			listOpts = &client.ListOptions{
 				Namespace: k6.Namespace,

--- a/controllers/k6_start.go
+++ b/controllers/k6_start.go
@@ -31,7 +31,7 @@ func isServiceReady(log logr.Logger, service *v1.Service) bool {
 func StartJobs(ctx context.Context, log logr.Logger, k6 *v1alpha1.K6, r *K6Reconciler) (ctrl.Result, error) {
 	log.Info("Waiting for pods to get ready")
 
-	err := wait.PollImmediate(time.Second*5, time.Second*60, func() (done bool, err error) {
+	err := wait.PollImmediate(time.Second*5, time.Second*180, func() (done bool, err error) {
 		selector := labels.SelectorFromSet(map[string]string{
 			"app":    "k6",
 			"k6_cr":  k6.Name,


### PR DESCRIPTION
When K6-operator is installed in EKS Fargate, the test doesn't start as it takes longer than the default 60 seconds for the pods to become ready. Increased timeout will help operator to work normally in environments that take longer time for provisioning pods like EKS Fargate.