### PR TITLE
Do not add annotations to initializer based upon runner specification

### DIFF
--- a/pkg/resources/jobs/initializer.go
+++ b/pkg/resources/jobs/initializer.go
@@ -20,7 +20,6 @@ func NewInitializerJob(k6 *v1alpha1.K6, argLine string) (*batchv1.Job, error) {
 
 	var (
 		image                        = "ghcr.io/grafana/operator:latest-runner"
-		annotations                  = make(map[string]string)
 		labels                       = newLabels(k6.Name)
 		serviceAccountName           = "default"
 		automountServiceAccountToken = true
@@ -29,10 +28,6 @@ func NewInitializerJob(k6 *v1alpha1.K6, argLine string) (*batchv1.Job, error) {
 
 	if k6.Spec.Runner.Image != "" {
 		image = k6.Spec.Runner.Image
-	}
-
-	if k6.Spec.Runner.Metadata.Annotations != nil {
-		annotations = k6.Spec.Runner.Metadata.Annotations
 	}
 
 	if k6.Spec.Runner.Metadata.Labels != nil {
@@ -66,16 +61,14 @@ func NewInitializerJob(k6 *v1alpha1.K6, argLine string) (*batchv1.Job, error) {
 
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        fmt.Sprintf("%s-initializer", k6.Name),
-			Namespace:   k6.Namespace,
-			Labels:      labels,
-			Annotations: annotations,
+			Name:      fmt.Sprintf("%s-initializer", k6.Name),
+			Namespace: k6.Namespace,
+			Labels:    labels,
 		},
 		Spec: batchv1.JobSpec{
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      labels,
-					Annotations: annotations,
+					Labels: labels,
 				},
 				Spec: corev1.PodSpec{
 					AutomountServiceAccountToken: &automountServiceAccountToken,

--- a/pkg/resources/jobs/initializer_test.go
+++ b/pkg/resources/jobs/initializer_test.go
@@ -29,9 +29,6 @@ func TestNewInitializerJob(t *testing.T) {
 				"k6_cr":  "test",
 				"label1": "awesome",
 			},
-			Annotations: map[string]string{
-				"awesomeAnnotation": "dope",
-			},
 		},
 		Spec: batchv1.JobSpec{
 			Template: corev1.PodTemplateSpec{
@@ -40,9 +37,6 @@ func TestNewInitializerJob(t *testing.T) {
 						"app":    "k6",
 						"k6_cr":  "test",
 						"label1": "awesome",
-					},
-					Annotations: map[string]string{
-						"awesomeAnnotation": "dope",
 					},
 				},
 				Spec: corev1.PodSpec{


### PR DESCRIPTION
Thanks to the awesome investigation/write-up by @mcandeia, this update no longer copies annotations from the runner specification. Each runner pod will still receive annotations as desired. If annotations support in initializer pod is desired, we'll probably need to incorporate an `Initializer Pod` entry within the [`K6Spec`](https://github.com/grafana/k6-operator/blob/main/api/v1alpha1/k6_types.go#L63-L64).

Signed-off-by: javaducky <javaducky@gmail.com>

Fixes #164 