### PR TITLE
Add runner=true label to matchedExpressions in podAntiAffinity

### DIFF
--- a/pkg/resources/jobs/runner.go
+++ b/pkg/resources/jobs/runner.go
@@ -231,6 +231,13 @@ func newAntiAffinity() *corev1.Affinity {
 									"k6",
 								},
 							},
+							{
+								Key:      "runner",
+								Operator: "In",
+								Values: []string{
+									"true",
+								},
+							},
 						},
 					},
 					TopologyKey: "kubernetes.io/hostname",

--- a/pkg/resources/jobs/runner_test.go
+++ b/pkg/resources/jobs/runner_test.go
@@ -174,6 +174,13 @@ func TestNewAntiAffinity(t *testing.T) {
 									"k6",
 								},
 							},
+							{
+								Key:      "runner",
+								Operator: "In",
+								Values: []string{
+									"true",
+								},
+							},
 						},
 					},
 					TopologyKey: "kubernetes.io/hostname",


### PR DESCRIPTION
Hi,
this PR fixes scheduling of starter-Pod when using `spec.separater=true` by adding `runner=true` to matched Label-Expressions in podAntiAffinity.


Fixes #168 