### PR TITLE
Improve initializer logs on k6 errors

### DIFF
--- a/pkg/resources/jobs/initializer.go
+++ b/pkg/resources/jobs/initializer.go
@@ -58,7 +58,7 @@ func NewInitializerJob(k6 *v1alpha1.K6, argLine string) (*batchv1.Job, error) {
 	)
 	command, istioEnabled := newIstioCommand(k6.Spec.Scuttle.Enabled, []string{"sh", "-c"})
 	command = append(command, fmt.Sprintf(
-		"k6 archive --log-output=none %s -O %s %s && k6 inspect --execution-requirements --log-output=none %s",
+		"k6 archive %s -O %s %s 2> /tmp/k6logs && k6 inspect --execution-requirements %s 2> /tmp/k6logs ; cat /tmp/k6logs | grep 'level=error' || true",
 		scriptName, archiveName, argLine,
 		archiveName))
 

--- a/pkg/resources/jobs/initializer_test.go
+++ b/pkg/resources/jobs/initializer_test.go
@@ -19,6 +19,7 @@ func TestNewInitializerJob(t *testing.T) {
 	}
 
 	automountServiceAccountToken := true
+	zero := int32(0)
 
 	expectedOutcome := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
@@ -34,6 +35,7 @@ func TestNewInitializerJob(t *testing.T) {
 			},
 		},
 		Spec: batchv1.JobSpec{
+			BackoffLimit: &zero,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
@@ -58,7 +60,7 @@ func TestNewInitializerJob(t *testing.T) {
 							Name:            "k6",
 							Command: []string{
 								"sh", "-c",
-								"k6 archive --log-output=none /test/test.js -O ./test.js.archived.tar --out cloud && k6 inspect --execution-requirements --log-output=none ./test.js.archived.tar",
+								"k6 archive /test/test.js -O ./test.js.archived.tar --out cloud 2> /tmp/k6logs && k6 inspect --execution-requirements ./test.js.archived.tar 2> /tmp/k6logs ; ! cat /tmp/k6logs | grep 'level=error'",
 							},
 							Env:          []corev1.EnvVar{},
 							Resources:    corev1.ResourceRequirements{},


### PR DESCRIPTION
This PR adds a CLI workaround for initializer pod so that it terminates with error exit code and error log line in case of errors logged by k6. Initializer pod is to be started only once: if there's an error from k6, then the script or setup requires fixes. Otherwise, initializer logs the JSON output of `inspect` command and terminates with zero exit code.

Fixes #167 