### PR TITLE
Scuttle config: change scuttleLogging to disableLogging

### DIFF
--- a/api/v1alpha1/k6_types.go
+++ b/api/v1alpha1/k6_types.go
@@ -45,7 +45,7 @@ type K6Scuttle struct {
 	EnvoyAdminApi           string `json:"envoyAdminApi,omitempty"`
 	NeverKillIstio          bool   `json:"neverKillIstio,omitempty"`
 	NeverKillIstioOnFailure bool   `json:"neverKillIstioOnFailure,omitempty"`
-	ScuttleLogging          bool   `json:"scuttleLogging,omitempty"`
+	DisableLogging          bool   `json:"disableLogging,omitempty"`
 	StartWithoutEnvoy       bool   `json:"startWithoutEnvoy,omitempty"`
 	WaitForEnvoyTimeout     string `json:"waitForEnvoyTimeout,omitempty"`
 	IstioQuitApi            string `json:"istioQuitApi,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -214,6 +214,13 @@ func (in *Pod) DeepCopyInto(out *Pod) {
 			(*out)[key] = val
 		}
 	}
+	if in.Tolerations != nil {
+		in, out := &in.Tolerations, &out.Tolerations
+		*out = make([]v1.Toleration, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	in.Resources.DeepCopyInto(&out.Resources)
 	in.SecurityContext.DeepCopyInto(&out.SecurityContext)
 	if in.EnvFrom != nil {

--- a/config/crd/bases/k6.io_k6s.yaml
+++ b/config/crd/bases/k6.io_k6s.yaml
@@ -848,6 +848,10 @@ spec:
                     type: array
                   image:
                     type: string
+                  imagePullPolicy:
+                    description: PullPolicy describes a policy for if/when to pull
+                      a container image
+                    type: string
                   imagePullSecrets:
                     items:
                       description: LocalObjectReference contains enough information
@@ -1102,6 +1106,8 @@ spec:
                 type: object
               scuttle:
                 properties:
+                  disableLogging:
+                    type: boolean
                   enabled:
                     type: string
                   envoyAdminApi:
@@ -1116,8 +1122,6 @@ spec:
                     type: boolean
                   quitWithoutEnvoyTimeout:
                     type: string
-                  scuttleLogging:
-                    type: boolean
                   startWithoutEnvoy:
                     type: boolean
                   waitForEnvoyTimeout:
@@ -1887,6 +1891,10 @@ spec:
                       type: object
                     type: array
                   image:
+                    type: string
+                  imagePullPolicy:
+                    description: PullPolicy describes a policy for if/when to pull
+                      a container image
                     type: string
                   imagePullSecrets:
                     items:

--- a/pkg/resources/jobs/helpers.go
+++ b/pkg/resources/jobs/helpers.go
@@ -84,10 +84,10 @@ func newIstioEnvVar(istio v1alpha1.K6Scuttle, istioEnabled bool) []corev1.EnvVar
 			})
 		}
 
-		if istio.ScuttleLogging {
+		if istio.DisableLogging {
 			env = append(env, corev1.EnvVar{
 				Name:  "SCUTTLE_LOGGING",
-				Value: strconv.FormatBool(istio.ScuttleLogging),
+				Value: strconv.FormatBool(false),
 			})
 		}
 

--- a/pkg/resources/jobs/helpers_test.go
+++ b/pkg/resources/jobs/helpers_test.go
@@ -110,7 +110,7 @@ func TestNewIstioEnvVarTrueValues(t *testing.T) {
 		},
 		{
 			Name:  "SCUTTLE_LOGGING",
-			Value: "true",
+			Value: "false",
 		},
 	}
 
@@ -118,7 +118,7 @@ func TestNewIstioEnvVarTrueValues(t *testing.T) {
 		EnvoyAdminApi:       "",
 		IstioQuitApi:        "",
 		WaitForEnvoyTimeout: "",
-		ScuttleLogging:      true,
+		DisableLogging:      true,
 	}, true)
 
 	if !reflect.DeepEqual(envVars, expectedOutcome) {
@@ -146,7 +146,7 @@ func TestNewIstioEnvVarFalseValues(t *testing.T) {
 		EnvoyAdminApi:       "",
 		IstioQuitApi:        "",
 		WaitForEnvoyTimeout: "",
-		ScuttleLogging:      false,
+		DisableLogging:      false,
 	}, true)
 
 	if !reflect.DeepEqual(envVars, expectedOutcome) {


### PR DESCRIPTION
Scuttle logging is enabled by default:
https://github.com/redboxllc/scuttle/blob/1c2b697935c10ef4b3e5e0dc0cf573a4d8766269/scuttle_config.go#L31

So the setting for it should be "disable logging" instead of "enable logging" as it has been so far.

This is a breaking change for those who rely on `scuttle` configuration.

This PR also contains cleaned up manifests (after `make manifests`) as it appears some of previous changes weren't properly applied before.