### PR TITLE
Assigning securityContext in k6 initializer

### DIFF
--- a/pkg/resources/jobs/initializer.go
+++ b/pkg/resources/jobs/initializer.go
@@ -104,6 +104,7 @@ func NewInitializerJob(k6 *v1alpha1.K6, argLine string) (*batchv1.Job, error) {
 					Affinity:                     k6.Spec.Initializer.Affinity,
 					NodeSelector:                 k6.Spec.Initializer.NodeSelector,
 					Tolerations:                  k6.Spec.Initializer.Tolerations,
+					SecurityContext:              &k6.Spec.Initializer.SecurityContext,
 					RestartPolicy:                corev1.RestartPolicyNever,
 					ImagePullSecrets:             k6.Spec.Initializer.ImagePullSecrets,
 					Containers: []corev1.Container{

--- a/pkg/resources/jobs/initializer_test.go
+++ b/pkg/resources/jobs/initializer_test.go
@@ -53,6 +53,7 @@ func TestNewInitializerJob(t *testing.T) {
 					Affinity:                     nil,
 					NodeSelector:                 nil,
 					RestartPolicy:                corev1.RestartPolicyNever,
+					SecurityContext:              &corev1.PodSecurityContext{},
 					Containers: []corev1.Container{
 						{
 							Image:           "ghcr.io/grafana/operator:latest-runner",


### PR DESCRIPTION
for https://github.com/grafana/k6-operator/issues/210
