### PR TITLE
Set k6 env vars for metrics aggregation by default for cloud output

### DIFF
--- a/api/v1alpha1/conditions.go
+++ b/api/v1alpha1/conditions.go
@@ -148,6 +148,11 @@ func (k6status *K6Status) SetIfNewer(proposedStatus K6Status) (isNewer bool) {
 			isNewer = true
 		}
 		// log if proposedStatus.TestRunID is empty here?
+
+		// similarly with aggregation vars
+		if len(proposedStatus.AggregationVars) > 0 && len(k6status.AggregationVars) == 0 {
+			k6status.AggregationVars = proposedStatus.AggregationVars
+		}
 	}
 
 	// If a change in stage is proposed, confirm that it is consistent with

--- a/api/v1alpha1/k6_types.go
+++ b/api/v1alpha1/k6_types.go
@@ -100,8 +100,9 @@ type Stage string
 
 // K6Status defines the observed state of K6
 type K6Status struct {
-	Stage     Stage  `json:"stage,omitempty"`
-	TestRunID string `json:"testRunId,omitempty"`
+	Stage           Stage  `json:"stage,omitempty"`
+	TestRunID       string `json:"testRunId,omitempty"`
+	AggregationVars string `json:"aggregationVars,omitempty"`
 
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }

--- a/config/crd/bases/k6.io_k6s.yaml
+++ b/config/crd/bases/k6.io_k6s.yaml
@@ -4064,6 +4064,8 @@ spec:
           status:
             description: K6Status defines the observed state of K6
             properties:
+              aggregationVars:
+                type: string
               conditions:
                 items:
                   description: "Condition contains details for one aspect of the current

--- a/pkg/cloud/aggregation.go
+++ b/pkg/cloud/aggregation.go
@@ -1,0 +1,49 @@
+package cloud
+
+import (
+	"fmt"
+	"strings"
+
+	"go.k6.io/k6/cloudapi"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var aggregationVarNames = []string{
+	"K6_CLOUD_AGGREGATION_MIN_SAMPLES",
+	"K6_CLOUD_AGGREGATION_PERIOD",
+	"K6_CLOUD_AGGREGATION_WAIT_PERIOD",
+	"K6_CLOUD_METRIC_PUSH_INTERVAL",
+	"K6_CLOUD_MAX_METRIC_SAMPLES_PER_PACKAGE",
+	"K6_CLOUD_MAX_METRIC_PUSH_CONCURRENCY",
+}
+
+func EncodeAggregationConfig(testRun *cloudapi.CreateTestRunResponse) string {
+	return fmt.Sprintf("%d|%s|%s|%s|%d|%d",
+		testRun.ConfigOverride.AggregationMinSamples.Int64,
+		testRun.ConfigOverride.AggregationPeriod.String(),
+		testRun.ConfigOverride.AggregationWaitPeriod.String(),
+		testRun.ConfigOverride.MetricPushInterval.String(),
+		testRun.ConfigOverride.MaxMetricSamplesPerPackage.Int64,
+		testRun.ConfigOverride.MetricPushConcurrency.Int64)
+}
+
+func DecodeAggregationConfig(encoded string) ([]corev1.EnvVar, error) {
+	values := strings.Split(encoded, "|")
+	if len(values) != len(aggregationVarNames) {
+		return nil, fmt.Errorf(
+			"Aggregation vars got corrupted: there are %d values instead of %d. Encoded value: `%s`.",
+			len(values),
+			len(aggregationVarNames),
+			encoded)
+	}
+
+	vars := make([]corev1.EnvVar, len(values))
+	for i := range values {
+		vars[i] = corev1.EnvVar{
+			Name:  aggregationVarNames[i],
+			Value: values[i],
+		}
+	}
+
+	return vars, nil
+}

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -38,7 +38,7 @@ type TestRun struct {
 	Instances         int32               `json:"instances"`
 }
 
-func CreateTestRun(opts InspectOutput, instances int32, host, token string, log logr.Logger) (string, error) {
+func CreateTestRun(opts InspectOutput, instances int32, host, token string, log logr.Logger) (*cloudapi.CreateTestRunResponse, error) {
 	if len(opts.External.Loadimpact.Name) < 1 {
 		opts.External.Loadimpact.Name = "k6-operator-test"
 	}
@@ -71,7 +71,7 @@ func CreateTestRun(opts InspectOutput, instances int32, host, token string, log 
 		client = cloudapi.NewClient(logger, token, host, consts.Version, time.Duration(time.Minute))
 	}
 
-	resp, err := createTestRun(client, host, &TestRun{
+	return createTestRun(client, host, &TestRun{
 		Name:              opts.External.Loadimpact.Name,
 		ProjectID:         cloudConfig.ProjectID.Int64,
 		VUsMax:            int64(opts.MaxVUs),
@@ -80,12 +80,6 @@ func CreateTestRun(opts InspectOutput, instances int32, host, token string, log 
 		ProcessThresholds: true,
 		Instances:         instances,
 	})
-
-	if err != nil {
-		return "", err
-	}
-
-	return resp.ReferenceID, nil
 }
 
 // We cannot use cloudapi.TestRun struct and cloudapi.Client.CreateTestRun call because they're not aware of

--- a/pkg/resources/jobs/runner.go
+++ b/pkg/resources/jobs/runner.go
@@ -117,13 +117,33 @@ func NewRunnerJob(k6 *v1alpha1.K6, index int, token string) (*batchv1.Job, error
 
 	// this is a cloud output run
 	if len(k6.Status.TestRunID) > 0 {
-		env = append(env, corev1.EnvVar{
-			Name:  "K6_CLOUD_PUSH_REF_ID",
-			Value: k6.Status.TestRunID,
-		}, corev1.EnvVar{
-			Name:  "K6_CLOUD_TOKEN",
-			Value: token,
-		})
+		env = append(env,
+			corev1.EnvVar{
+				Name:  "K6_CLOUD_AGGREGATION_MIN_SAMPLES",
+				Value: "50",
+			}, corev1.EnvVar{
+				Name:  "K6_CLOUD_AGGREGATION_PERIOD",
+				Value: "3s",
+			}, corev1.EnvVar{
+				Name:  "K6_CLOUD_AGGREGATION_WAIT_PERIOD",
+				Value: "8s",
+			}, corev1.EnvVar{
+				Name:  "K6_CLOUD_METRIC_PUSH_INTERVAL",
+				Value: "6s",
+			}, corev1.EnvVar{
+				Name:  "K6_CLOUD_MAX_METRIC_SAMPLES_PER_PACKAGE",
+				Value: "10000",
+			}, corev1.EnvVar{
+				Name:  "K6_CLOUD_MAX_METRIC_PUSH_CONCURRENCY",
+				Value: "10",
+			}, corev1.EnvVar{
+				Name:  "K6_CLOUD_PUSH_REF_ID",
+				Value: k6.Status.TestRunID,
+			}, corev1.EnvVar{
+				Name:  "K6_CLOUD_TOKEN",
+				Value: token,
+			},
+		)
 	}
 
 	env = append(env, k6.Spec.Runner.Env...)

--- a/pkg/resources/jobs/runner_test.go
+++ b/pkg/resources/jobs/runner_test.go
@@ -15,6 +15,28 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+var aggregationEnvVars = []corev1.EnvVar{
+	corev1.EnvVar{
+		Name:  "K6_CLOUD_AGGREGATION_MIN_SAMPLES",
+		Value: "50",
+	}, corev1.EnvVar{
+		Name:  "K6_CLOUD_AGGREGATION_PERIOD",
+		Value: "3s",
+	}, corev1.EnvVar{
+		Name:  "K6_CLOUD_AGGREGATION_WAIT_PERIOD",
+		Value: "8s",
+	}, corev1.EnvVar{
+		Name:  "K6_CLOUD_METRIC_PUSH_INTERVAL",
+		Value: "6s",
+	}, corev1.EnvVar{
+		Name:  "K6_CLOUD_MAX_METRIC_SAMPLES_PER_PACKAGE",
+		Value: "10000",
+	}, corev1.EnvVar{
+		Name:  "K6_CLOUD_MAX_METRIC_PUSH_CONCURRENCY",
+		Value: "10",
+	},
+}
+
 func TestNewScriptVolumeClaim(t *testing.T) {
 	expectedOutcome := &types.Script{
 		Name:     "Test",
@@ -1014,16 +1036,16 @@ func TestNewRunnerJobCloud(t *testing.T) {
 						ImagePullPolicy: "",
 						Name:            "k6",
 						Command:         []string{"k6", "run", "--quiet", "--out", "cloud", "/test/test.js", "--address=0.0.0.0:6565", "--paused", "--tag", "instance_id=1", "--tag", "job_name=test-1"},
-						Env: []corev1.EnvVar{
-							{
+						Env: append(aggregationEnvVars,
+							corev1.EnvVar{
 								Name:  "K6_CLOUD_PUSH_REF_ID",
 								Value: "testrunid",
 							},
-							{
+							corev1.EnvVar{
 								Name:  "K6_CLOUD_TOKEN",
 								Value: "token",
 							},
-						},
+						),
 						Resources:    corev1.ResourceRequirements{},
 						VolumeMounts: script.VolumeMount(),
 						Ports:        []corev1.ContainerPort{{ContainerPort: 6565}},

--- a/pkg/resources/jobs/runner_test.go
+++ b/pkg/resources/jobs/runner_test.go
@@ -15,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// these are default values hard-coded in k6
 var aggregationEnvVars = []corev1.EnvVar{
 	corev1.EnvVar{
 		Name:  "K6_CLOUD_AGGREGATION_MIN_SAMPLES",
@@ -1098,7 +1099,8 @@ func TestNewRunnerJobCloud(t *testing.T) {
 		// Since this test only creates a runner's spec so
 		// testrunid has to be set hard-coded here.
 		Status: v1alpha1.K6Status{
-			TestRunID: "testrunid",
+			TestRunID:       "testrunid",
+			AggregationVars: "50|3s|8s|6s|10000|10",
 		},
 	}
 


### PR DESCRIPTION
Fixing #228 

This branch with env vars for aggregation was already on my local so pushing it here.

Adding the env vars to the runners like this is a workaround which is not a good solution. This shouldn't be fixed on k6-operator side: it should be fixed on k6 side by making aggregation turned on by default, at least in case of `-out cloud` option.

@esquonk, please check if the numbers are correct: if they are, I'll merge it in the evening and make a release.

Related issue: #192 