### PR TITLE
Fix dockerfile user and remove k8s cluster domain suffix from status url

### DIFF
--- a/Dockerfile.controller
+++ b/Dockerfile.controller
@@ -25,6 +25,8 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager 
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
-USER nonroot:nonroot
+
+# as defined by distroless for nonroot
+USER 65532:65532
 
 ENTRYPOINT ["/manager"]

--- a/Dockerfile.starter
+++ b/Dockerfile.starter
@@ -1,3 +1,5 @@
 FROM radial/busyboxplus:curl
 
+# as defined by distroless for nonroot
+USER 65532:65532
 COPY --from=redboxoss/scuttle:latest /scuttle /bin/scuttle


### PR DESCRIPTION
- user nonroot/root may not work in some k8s environments.
- k8s domain may differ from `cluster.local`.