### PR TITLE
Fix 'no such file or directory' issue in initializer

### DIFF
--- a/pkg/resources/jobs/initializer.go
+++ b/pkg/resources/jobs/initializer.go
@@ -77,8 +77,8 @@ func NewInitializerJob(k6 *v1alpha1.K6, argLine string) (*batchv1.Job, error) {
 		// printing JSON as usual. Then parse temp file only for errors, ignoring
 		// any other log messages.
 		// Related: https://github.com/grafana/k6-docs/issues/877
-		"k6 archive %s -O %s %s 2> /tmp/k6logs && k6 inspect --execution-requirements %s 2> /tmp/k6logs ; ! cat /tmp/k6logs | grep 'level=error'",
-		scriptName, archiveName, argLine,
+		"mkdir -p $(dirname %s) && k6 archive %s -O %s %s 2> /tmp/k6logs && k6 inspect --execution-requirements %s 2> /tmp/k6logs ; ! cat /tmp/k6logs | grep 'level=error'",
+		archiveName, scriptName, archiveName, argLine,
 		archiveName))
 
 	env := append(newIstioEnvVar(k6.Spec.Scuttle, istioEnabled), k6.Spec.Initializer.Env...)

--- a/pkg/resources/jobs/initializer_test.go
+++ b/pkg/resources/jobs/initializer_test.go
@@ -61,7 +61,7 @@ func TestNewInitializerJob(t *testing.T) {
 							Name:            "k6",
 							Command: []string{
 								"sh", "-c",
-								"k6 archive /test/test.js -O /tmp/test.js.archived.tar --out cloud 2> /tmp/k6logs && k6 inspect --execution-requirements /tmp/test.js.archived.tar 2> /tmp/k6logs ; ! cat /tmp/k6logs | grep 'level=error'",
+								"mkdir -p $(dirname /tmp/test.js.archived.tar) && k6 archive /test/test.js -O /tmp/test.js.archived.tar --out cloud 2> /tmp/k6logs && k6 inspect --execution-requirements /tmp/test.js.archived.tar 2> /tmp/k6logs ; ! cat /tmp/k6logs | grep 'level=error'",
 							},
 							Env:          []corev1.EnvVar{},
 							Resources:    corev1.ResourceRequirements{},


### PR DESCRIPTION
# Summary

This pr creates a directory where js test file is located to fix an issue when js test file is stored in volume (PVC/PV resources).

# How to reproduce

- create k6 CRD resource
```
apiVersion: k6.io/v1alpha1
kind: K6
metadata:
  name: test
spec:
  arguments: --vus 1 --iteration 1
  parallelism: 1
  runner:
    image: ...
  script:
    volumeClaim:
      file: some-dir/1/test.js
      name: k6-pvc
  scuttle:
    enabled: "false"
```

# Result

Initializer pod will be failed with `no such file or directory` error while trying to run:
```
k6 archive some-dir/1/test.js -O /tmp/some-dir/1/test.js.archived.tar ...
```
Because the `/tmp/some-dir/1/` directory doesn't exist