### PR TITLE
fix(docs): use valid, conventional syntax in JS example

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,20 +64,23 @@ spec:
 │   │   ├── stress-test.js
 │   ├── test.js
 ```
-In the above example, `test.js` imports a function from `stress-test.js` and they would look like this:
-```js
-// stress-test.js
-import stress-test from "./requests/stress-test.js";
 
-export let options = {
-      vus: 50,
-      duration: '10s'
-    };
+In the above example, `test.js` imports a function from `stress-test.js` and they would look like this:
+
+```js
+// test.js
+import stressTest from "./requests/stress-test.js";
+
+export const options = {
+  vus: 50,
+  duration: '10s'
+};
 
 export default function () {
-      stress-test();
+  stressTest();
 }
 ```
+
 ```js
 // stress-test.js
 import { sleep, check } from 'k6';
@@ -91,7 +94,6 @@ export default () => {
   });
   sleep(1);
 };
-
 ```
 
 #### LocalFile


### PR DESCRIPTION
## Summary

Fix up the JS example in the README

## Details

- `-` in the middle of a variable name is not valid in nearly all programming languages, including [JS](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Grammar_and_types#variables)
  - use conventional JS camelCase (instead of invalid kebab-case)

- fix comment headings -- the first file is `test.js`, the second file is `stress-test.js`
  - can't both be `stress-test.js` 😅

- use `const` instead of `let` for options
  - consistent with [k6 docs](https://github.com/grafana/k6/blob/a2fe0a8e824423262e7029c3853dc0fa5ce9f9b6/README.md?plain=1#L48)

- consistently use 2 space indentation
  - same as the rest of this file

- add new lines between code blocks
  - consistent with the rest of this file (and easier on the eyes + passes `markdownlint`)