### PR TITLE
docs: add missing YAML syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ There is a sample avaiable in `config/samples/k6_v1alpha1_k6_with_volumeClaim.ya
 
 If you have a PVC with the name `stress-test-volumeClaim` containing your script and any other supporting file(s), you can pass it to the test like this:
 
-```
+```yaml
 spec:
   parallelism: 2
   script:
@@ -213,12 +213,12 @@ k6 supports [output to its Cloud](https://k6.io/docs/results-visualization/cloud
 To use this option in k6-operator, set the argument in yaml:
 
 ```yaml
-...
+# ...
   script:
     configMap:
       name: "<configmap>"
   arguments: --out cloud
-...
+# ...
 ```
 
 Then uncomment cloud output section in `config/default/kustomization.yaml` and copy your token from the Cloud there:
@@ -240,7 +240,7 @@ This is sufficient to run k6 with the Cloud output and default values of `projec
 
 ```js
 export let options = {
-  ...
+  // ...
   ext: {
     loadimpact: {
       name: 'Configured k6-operator test',
@@ -280,8 +280,8 @@ kubectl create configmap scenarios-test --from-file=archive.tar
 
 In case of using an archive it must be additionally specified in your yaml for K6 deployment:
 
-```bash
-...
+```yaml
+# ...
 spec:
   parallelism: 1
   script:


### PR DESCRIPTION
## Summary

Improve syntax highlighting in the README

## Details

- 2 code blocks that were missing highlighting
  - 1 of the blocks was incorrectly labeled as `bash` instead of `yaml` syntax

- also comment out all ellipses ("...") in code blocks
  - for more valid sample code that can be more easily copy+pasted