### PR TITLE
Fix default name of test runs in cloud output

### DIFF
--- a/controllers/k6_initialize.go
+++ b/controllers/k6_initialize.go
@@ -132,6 +132,13 @@ func SetupCloudTest(ctx context.Context, log logr.Logger, k6 *v1alpha1.K6, r *K6
 			return ctrl.Result{RequeueAfter: time.Second * 2}, nil
 		}
 
+		if len(inspectOutput.External.Loadimpact.Name) < 1 {
+			// script has already been parsed for initializer job definition,
+			// so this is safe
+			script, _ := k6.Spec.Script.Parse()
+			inspectOutput.External.Loadimpact.Name = script.Filename
+		}
+
 		if testRunData, err := cloud.CreateTestRun(inspectOutput, k6.Spec.Parallelism, host, token, log); err != nil {
 			log.Error(err, "Failed to create a new cloud test run.")
 			return res, nil

--- a/pkg/cloud/cloud_output.go
+++ b/pkg/cloud/cloud_output.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"go.k6.io/k6/cloudapi"
 	"go.k6.io/k6/lib/consts"
-	"gopkg.in/guregu/null.v3"
+	null "gopkg.in/guregu/null.v3"
 )
 
 var client *cloudapi.Client
@@ -25,10 +25,6 @@ type TestRun struct {
 }
 
 func CreateTestRun(opts InspectOutput, instances int32, host, token string, log logr.Logger) (*cloudapi.CreateTestRunResponse, error) {
-	if len(opts.External.Loadimpact.Name) < 1 {
-		opts.External.Loadimpact.Name = "k6-operator-test"
-	}
-
 	cloudConfig := cloudapi.NewConfig()
 
 	if opts.External.Loadimpact.ProjectID > 0 {
@@ -57,7 +53,7 @@ func CreateTestRun(opts InspectOutput, instances int32, host, token string, log 
 		client = cloudapi.NewClient(logger, token, host, consts.Version, time.Duration(time.Minute))
 	}
 
-	return createTestRun(client, host, &TestRun{
+	tr := TestRun{
 		Name:              opts.External.Loadimpact.Name,
 		ProjectID:         cloudConfig.ProjectID.Int64,
 		VUsMax:            int64(opts.MaxVUs),
@@ -65,7 +61,8 @@ func CreateTestRun(opts InspectOutput, instances int32, host, token string, log 
 		Duration:          int64(opts.TotalDuration.TimeDuration().Seconds()),
 		ProcessThresholds: true,
 		Instances:         instances,
-	})
+	}
+	return createTestRun(client, host, &tr)
 }
 
 // We cannot use cloudapi.TestRun struct and cloudapi.Client.CreateTestRun call because they're not aware of


### PR DESCRIPTION
Logic around test names in case of cloud output now corresponds to default in k6. It's also more straight-forward overall.