### PR TITLE
Fix builx version in e2e workflow

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -10,6 +10,8 @@ jobs:
         uses: actions/checkout@v2
       - name: "Build:buildx"
         uses: docker/setup-buildx-action@v1
+        with:
+          version: v0.9.1 # Buildx version
       - name: "Build:login"
         uses: docker/login-action@v1
         with:


### PR DESCRIPTION
`buildx` version was pinned only in push workflow so images built during e2e workflow have been Linux-only.