### PR TITLE
fix: Use standard naming for nodeSelector definition

### DIFF
--- a/api/v1alpha1/k6_types.go
+++ b/api/v1alpha1/k6_types.go
@@ -36,7 +36,7 @@ type Pod struct {
 	ImagePullSecrets             []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 	ImagePullPolicy              corev1.PullPolicy             `json:"imagePullPolicy,omitempty"`
 	Metadata                     PodMetadata                   `json:"metadata,omitempty"`
-	NodeSelector                 map[string]string             `json:"nodeselector,omitempty"`
+	NodeSelector                 map[string]string             `json:"nodeSelector,omitempty"`
 	Tolerations                  []corev1.Toleration           `json:"tolerations,omitempty"`
 	Resources                    corev1.ResourceRequirements   `json:"resources,omitempty"`
 	ServiceAccountName           string                        `json:"serviceAccountName,omitempty"`

--- a/config/crd/bases/k6.io_k6s.yaml
+++ b/config/crd/bases/k6.io_k6s.yaml
@@ -704,7 +704,7 @@ spec:
                           type: string
                         type: object
                     type: object
-                  nodeselector:
+                  nodeSelector:
                     additionalProperties:
                       type: string
                     type: object
@@ -2299,7 +2299,7 @@ spec:
                           type: string
                         type: object
                     type: object
-                  nodeselector:
+                  nodeSelector:
                     additionalProperties:
                       type: string
                     type: object
@@ -3916,7 +3916,7 @@ spec:
                           type: string
                         type: object
                     type: object
-                  nodeselector:
+                  nodeSelector:
                     additionalProperties:
                       type: string
                     type: object


### PR DESCRIPTION
As it was exposed [here](https://github.com/grafana/k6-operator/issues/206), `nodeselector` uses wrong notation and breaks with Kubernetes standard naming. This PR renames the section to `nodeSelector`

**This is a breaking change**, if you want to maintain backward compatibility, I can update the PR adding support to both and a deprecation message on the wrong one

Fixes https://github.com/grafana/k6-operator/issues/206