### PR TITLE
chore: remove top newline from `config/crd` yaml

### DIFF
--- a/config/crd/bases/k6.io_k6s.yaml
+++ b/config/crd/bases/k6.io_k6s.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/config/crd/bases/k6.io_privateloadzones.yaml
+++ b/config/crd/bases/k6.io_privateloadzones.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/config/crd/bases/k6.io_testruns.yaml
+++ b/config/crd/bases/k6.io_testruns.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition


### PR DESCRIPTION
#### What?
- kept running into the issue where copying _CRD_ directly from _k6-operator_ repo would always have an extra newline at top before YAML starts (_not sure if this is intentional, left for future comments maybe?!_) but this does cause a minor inconvenience when copying/pasting. 

#### Why?
- to allow copy/pasting without extra newline

