### PR TITLE
Remove hardcoded cluster domain

### DIFF
--- a/controllers/k6_start.go
+++ b/controllers/k6_start.go
@@ -17,7 +17,7 @@ import (
 )
 
 func isServiceReady(log logr.Logger, service *v1.Service) bool {
-	resp, err := http.Get(fmt.Sprintf("http://%v.%v.svc.cluster.local:6565/v1/status", service.ObjectMeta.Name, service.ObjectMeta.Namespace))
+	resp, err := http.Get(fmt.Sprintf("http://%v.%v.svc:6565/v1/status", service.ObjectMeta.Name, service.ObjectMeta.Namespace))
 
 	if err != nil {
 		log.Error(err, fmt.Sprintf("failed to get status from %v", service.ObjectMeta.Name))

--- a/controllers/k6_stopped_jobs.go
+++ b/controllers/k6_stopped_jobs.go
@@ -18,7 +18,7 @@ import (
 )
 
 func isJobRunning(log logr.Logger, service *v1.Service) bool {
-	resp, err := http.Get(fmt.Sprintf("http://%v.%v.svc.cluster.local:6565/v1/status", service.ObjectMeta.Name, service.ObjectMeta.Namespace))
+	resp, err := http.Get(fmt.Sprintf("http://%v.%v.svc:6565/v1/status", service.ObjectMeta.Name, service.ObjectMeta.Namespace))
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
This contribution allows to execute the `k6-operator` in clusters with different cluster name than `cluster.local`.
If the requirement is to have a full qualified name, a better approach would be to create an specific helm value for that, using the same pattern than bitnami charts [clusterDomain](https://github.com/bitnami/charts/blob/main/bitnami/elasticsearch/values.yaml#L50)