### PR TITLE
ci: add node_image version to kind-action

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -76,9 +76,9 @@ jobs:
           version: v3.7.2
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.2.0
-        # with:
-        #   node_image: "kindest/node:v1.27.1"
+        uses: helm/kind-action@v1.8.0
+        with:
+          node_image: "kindest/node:v1.27.1"
 
       - name: Testing
         run: |


### PR DESCRIPTION
Fixes #311 

https://github.com/grafana/k6-operator/actions/runs/6512492225/job/17690286747
```
Run helm/kind-action@v1.2.0
  with:
    node_image: kindest/node:v1.27.1
Installing kind...
Adding kind directory to PATH...
Installing kubectl...
Adding kubectl directory to PATH...
kind v0.11.1
```
The log said that we use the old `kind` despite `kindest/node` is newer one.
It can be fixed to select the old kindest/node version.
https://github.com/helm/kind-action/blob/v1.2.0/action.yml#L12-L13