### PR TITLE
fix helm template indentation for deployment.env

### DIFF
--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.0.10"
 description: A Helm chart to install the k6-operator
 name: k6-operator
-version: 1.0.0
+version: 1.0.1
 kubeVersion: ">=1.16.0-0"
 home: https://k6.io
 sources:

--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -63,7 +63,7 @@ spec:
           {{- if .Values.manager.env }}
           env:
             {{- with .Values.manager.env }}
-              {{- toYaml . | nindent 10 }}
+              {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
           command:


### PR DESCRIPTION
This is a simple yaml typo fix.  Helm template indentation for `env` needs to be incremented.  

**before**:
```
          env:
          foo: bar
```

**after fix**:
```
          env:
            foo: bar
```

I take the liberty to update chart version, but feel free to let me know if that's not desired.