### PR TITLE
CI: use main branch of helm-charts

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -13,7 +13,7 @@ jobs:
   call-update-helm-repo:
     permissions:
       contents: write
-    uses: grafana/helm-charts/.github/workflows/update-helm-repo.yaml@ci/fix-for-github-apps-jwt
+    uses: grafana/helm-charts/.github/workflows/update-helm-repo.yaml@main
     with:
       charts_dir: charts
       cr_configfile: charts/cr.yaml


### PR DESCRIPTION
PR to helm-charts was merged in: https://github.com/grafana/helm-charts/pull/2728
Updating CI to use `main` branch.