### PR TITLE
Enable custom pod labels for helm chart

### DIFF
--- a/charts/k6-operator/Chart.yaml
+++ b/charts/k6-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.0.11"
 description: A Helm chart to install the k6-operator
 name: k6-operator
-version: 1.2.0
+version: 2.0.0
 kubeVersion: ">=1.16.0-0"
 home: https://k6.io
 sources:

--- a/charts/k6-operator/samples/customAnnotationsAndLabels.yaml
+++ b/charts/k6-operator/samples/customAnnotationsAndLabels.yaml
@@ -4,6 +4,10 @@ customAnnotations:
 customLabels:
   "customized-labels": "k6-operator"
 
+podLabels:
+  environment: production
+  owner: development
+
 certManager:
   enabled: true
 

--- a/charts/k6-operator/templates/_helpers.tpl
+++ b/charts/k6-operator/templates/_helpers.tpl
@@ -72,6 +72,14 @@ Create the name of the service account to use
   {{- end }}
 {{- end -}}
 
+{{- define "k6-operator.podLabels" -}}
+  {{- if .Values.podLabels }}
+    {{- with .Values.podLabels }}
+      {{- toYaml . }}
+    {{- end }}
+  {{- end }}
+{{- end -}}
+
 {{- define "k6-operator.customAnnotations" -}}
   {{- if .Values.customAnnotations }}
     {{- with .Values.customAnnotations }}

--- a/charts/k6-operator/templates/deployment.yaml
+++ b/charts/k6-operator/templates/deployment.yaml
@@ -19,6 +19,7 @@ spec:
     metadata:
       labels:
         {{- include "k6-operator.selectorLabels" . | nindent 8 }}
+        {{- include "k6-operator.podLabels" . | nindent 8 }}
     spec:
       containers:
         {{- if .Values.authProxy.enabled }}

--- a/charts/k6-operator/values.yaml
+++ b/charts/k6-operator/values.yaml
@@ -4,6 +4,9 @@ customAnnotations: {}
 # customLabels -- Custom Label to be applied on all resources
 customLabels: {}
 
+# podLabels -- Custom Label to be applied on all pods
+podLabels: {}
+
 # nodeSelector -- Node Selector to be applied on all containers
 nodeSelector: {}
 


### PR DESCRIPTION
Hey, we leverage tooling that requires certain labels to be present. While deploying into our ecosystem I noticed the pods don't have the capability to have custom labels. This PR is meant to include that annotation and feature for others that require specific pods labels