### PR TITLE
CI: limit Helm linting to branches only

### DIFF
--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -1,8 +1,15 @@
 ---
 name: Helm Lint
-on: [push]
+on:
+  # `ct lint` does not work well with tag references on releases.
+  # OTOH, Helm linting on tags is not necessary so long as it
+  # happens on push to branches.
+  push:
+    branches:
+      - '**'
+
 jobs:
-  lintAllTheThings:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
On releases `ct lint` fails to find a git tag:
![image](https://github.com/grafana/k6-operator/assets/2552297/9b96b641-16f5-4746-bf87-1a41bba99c0c)

Probably because the tag doesn't exist at that point yet. We don't exactly require this workflow for release as it's sufficient to run it on main branch. So limiting this GA to branches only.
