### PR TITLE
feat: making operator image configurable

### DIFF
--- a/pkg/resources/jobs/helpers.go
+++ b/pkg/resources/jobs/helpers.go
@@ -2,6 +2,7 @@ package jobs
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 
 	"github.com/grafana/k6-operator/pkg/types"
@@ -144,4 +145,13 @@ func getInitContainers(k6Spec *v1alpha1.TestRunSpec, script *types.Script) []cor
 	}
 
 	return initContainers
+}
+
+func getOperatorImageName() string {
+	image, ok := os.LookupEnv("OPERATOR_IMAGE_NAME")
+	if ok {
+		return image
+	} else {
+		return "ghcr.io/grafana/k6-operator"
+	}
 }

--- a/pkg/resources/jobs/initializer.go
+++ b/pkg/resources/jobs/initializer.go
@@ -18,7 +18,7 @@ func NewInitializerJob(k6 v1alpha1.TestRunI, argLine string) (*batchv1.Job, erro
 	}
 
 	var (
-		image                        = "ghcr.io/grafana/k6-operator:latest-runner"
+		image                        = getOperatorImageName() + ":latest-runner"
 		annotations                  = make(map[string]string)
 		labels                       = newLabels(k6.NamespacedName().Name)
 		serviceAccountName           = "default"

--- a/pkg/resources/jobs/runner.go
+++ b/pkg/resources/jobs/runner.go
@@ -80,7 +80,7 @@ func NewRunnerJob(k6 v1alpha1.TestRunI, index int, token string) (*batchv1.Job, 
 		zero32 int32 = 0
 	)
 
-	image := "ghcr.io/grafana/k6-operator:latest-runner"
+	image := getOperatorImageName() + ":latest-runner"
 	if k6.GetSpec().Runner.Image != "" {
 		image = k6.GetSpec().Runner.Image
 	}

--- a/pkg/resources/jobs/starter.go
+++ b/pkg/resources/jobs/starter.go
@@ -19,7 +19,7 @@ func NewStarterJob(k6 v1alpha1.TestRunI, hostname []string) *batchv1.Job {
 		starterAnnotations = k6.GetSpec().Starter.Metadata.Annotations
 	}
 
-	starterImage := "ghcr.io/grafana/k6-operator:latest-starter"
+	starterImage := getOperatorImageName() + ":latest-starter"
 	if k6.GetSpec().Starter.Image != "" {
 		starterImage = k6.GetSpec().Starter.Image
 	}

--- a/pkg/resources/jobs/stopper.go
+++ b/pkg/resources/jobs/stopper.go
@@ -16,7 +16,7 @@ func NewStopJob(k6 v1alpha1.TestRunI, hostname []string) *batchv1.Job {
 
 	job.Name = fmt.Sprintf("%s-stopper", k6.NamespacedName().Name)
 
-	image := "ghcr.io/grafana/k6-operator:latest-starter"
+	image := getOperatorImageName() + ":latest-starter"
 	if k6.GetSpec().Starter.Image != "" {
 		image = k6.GetSpec().Starter.Image
 	}

--- a/pkg/testrun/plz.go
+++ b/pkg/testrun/plz.go
@@ -2,6 +2,7 @@ package testrun
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/grafana/k6-operator/api/v1alpha1"
 	"github.com/grafana/k6-operator/pkg/cloud"
@@ -30,7 +31,7 @@ func NewPLZTestRun(plz *v1alpha1.PrivateLoadZone, trData *cloud.TestRunData, ing
 
 	initContainer := containers.NewS3InitContainer(
 		trData.ArchiveURL,
-		"ghcr.io/grafana/k6-operator:latest-starter",
+		getOperatorImageName()+":latest-starter",
 		volumeMount,
 	)
 
@@ -74,5 +75,14 @@ func NewPLZTestRun(plz *v1alpha1.PrivateLoadZone, trData *cloud.TestRunData, ing
 			TestRunID: trData.TestRunID(),
 			Token:     plz.Spec.Token,
 		},
+	}
+}
+
+func getOperatorImageName() string {
+	image, ok := os.LookupEnv("OPERATOR_IMAGE_NAME")
+	if ok {
+		return image
+	} else {
+		return "ghcr.io/grafana/k6-operator"
 	}
 }


### PR DESCRIPTION
This PR makes the otherwise hard-coded operator image url configurable using the newly introduced environment variable `OPERATOR_IMAGE_NAME`. This configuration option is required when using a private registry behind a corporate firewall. The helm `values.yaml` entry `manager.image.name` indicates that this is desired behaviour, but up until now a configuration option was lacking in the operator code itself.  
I'd be happy to also contribute this option in the helm chart's `values.yaml` but would do so in a separate PR