### PR TITLE
fix issue with service monitor

### DIFF
--- a/charts/k6-operator/templates/deployment.yaml
+++ b/charts/k6-operator/templates/deployment.yaml
@@ -18,6 +18,7 @@ spec:
   template:
     metadata:
       labels:
+        control-plane: "controller-manager"
         {{- include "k6-operator.selectorLabels" . | nindent 8 }}
         {{- include "k6-operator.podLabels" . | nindent 8 }}
     spec:

--- a/charts/k6-operator/templates/prometheus/serviceMonitor.yaml
+++ b/charts/k6-operator/templates/prometheus/serviceMonitor.yaml
@@ -12,8 +12,11 @@ metadata:
   annotations:
     {{- include "k6-operator.customAnnotations" . | default "" | nindent 4 }}
   name: controller-manager-metrics-monitor
-  namespace: system
+  namespace: {{- include "k6-operator.namespace" . }}
 spec:
+  namespaceSelector:
+    matchNames:
+      - {{- include "k6-operator.namespace" . }}
   endpoints:
     - path: /metrics
       port: https


### PR DESCRIPTION
Fixes #324 where helm install with flag `--set prometheus.enabled=true` fails unless the `system` namespace exists.  Set this to the same namespace as all the other resources installed via the chart. Additionally, restrict the namespace selector to be within the same namespace as well so there is chance of accidental cross namespace lookup and drag in another service by chance.

Furthermore, fixes the selector label on the service itself as the current select 

```yaml
selector:
  control-plane: "controller-manager"
```

points to nothing. This can be easily verified without the need of a `ServiceMonitor` by port forwarding to the service and perform a simply curl against the endpoint. The change is to use the `selectorLabels` that is used under `.spec.template.metadata.labels` in the `Deployment`.