### PR TITLE
feat: add initializer envFrom field

### DIFF
--- a/pkg/resources/jobs/initializer.go
+++ b/pkg/resources/jobs/initializer.go
@@ -123,6 +123,7 @@ func NewInitializerJob(k6 v1alpha1.TestRunI, argLine string) (*batchv1.Job, erro
 							Env:             env,
 							Resources:       k6.GetSpec().Initializer.Resources,
 							VolumeMounts:    volumeMounts,
+							EnvFrom:         k6.GetSpec().Initializer.EnvFrom,
 							Ports:           ports,
 						},
 					},

--- a/pkg/resources/jobs/initializer_test.go
+++ b/pkg/resources/jobs/initializer_test.go
@@ -65,7 +65,16 @@ func TestNewInitializerJob(t *testing.T) {
 								"sh", "-c",
 								"mkdir -p $(dirname /tmp/test.js.archived.tar) && k6 archive /test/test.js -O /tmp/test.js.archived.tar --out cloud 2> /tmp/k6logs && k6 inspect --execution-requirements /tmp/test.js.archived.tar 2> /tmp/k6logs ; ! cat /tmp/k6logs | grep 'level=error'",
 							},
-							Env:          []corev1.EnvVar{},
+							Env: []corev1.EnvVar{},
+							EnvFrom: []corev1.EnvFromSource{
+								{
+									ConfigMapRef: &corev1.ConfigMapEnvSource{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "env",
+										},
+									},
+								},
+							},
 							Resources:    corev1.ResourceRequirements{},
 							VolumeMounts: script.VolumeMount(),
 							Ports:        []corev1.ContainerPort{{ContainerPort: 6565}},
@@ -97,6 +106,15 @@ func TestNewInitializerJob(t *testing.T) {
 					},
 					Annotations: map[string]string{
 						"awesomeAnnotation": "dope",
+					},
+				},
+				EnvFrom: []corev1.EnvFromSource{
+					{
+						ConfigMapRef: &corev1.ConfigMapEnvSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "env",
+							},
+						},
 					},
 				},
 			},


### PR DESCRIPTION
As discussed, this is a very small PR adding the `envFrom` field for initializer and should fix #348 

This is my first time going through the k6-operator source code so if I missed anything (helm chart version bump or test cases in `initializer_test.go`) then let me know. 