### PR TITLE
Call `setup` and `teardown` only once for PLZ

### DIFF
--- a/api/v1alpha1/k6conditions.go
+++ b/api/v1alpha1/k6conditions.go
@@ -16,6 +16,10 @@ const (
 	// - if True, it's after successful starter but before all runners have finished
 	TestRunRunning = "TestRunRunning"
 
+	// TeardownExecuted indicates whether the `teardown()` has been executed on one of the runners.
+	// This condition can be used only in PLZ test runs.
+	TeardownExecuted = "TeardownExecuted"
+
 	// CloudTestRun indicates if this test run is supposed to be a cloud test run
 	// (i.e. with `--out cloud` option).
 	// - if empty / Unknown, the type of test is unknown yet
@@ -69,6 +73,13 @@ func Initialize(k6 TestRunI) {
 			Status:             metav1.ConditionUnknown,
 			LastTransitionTime: t,
 			Reason:             "TestRunPreparation",
+			Message:            "",
+		},
+		metav1.Condition{
+			Type:               TeardownExecuted,
+			Status:             metav1.ConditionFalse,
+			LastTransitionTime: t,
+			Reason:             "TeardownExecutedFalse",
 			Message:            "",
 		},
 	}

--- a/api/v1alpha1/testruni.go
+++ b/api/v1alpha1/testruni.go
@@ -2,6 +2,7 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -30,4 +31,14 @@ func TestRunID(k6 TestRunI) string {
 		return specId
 	}
 	return k6.GetStatus().TestRunID
+}
+
+func ListOptions(k6 TestRunI) *client.ListOptions {
+	selector := labels.SelectorFromSet(map[string]string{
+		"app":    "k6",
+		"k6_cr":  k6.NamespacedName().Name,
+		"runner": "true",
+	})
+
+	return &client.ListOptions{LabelSelector: selector, Namespace: k6.NamespacedName().Namespace}
 }

--- a/controllers/k6_stopped_jobs.go
+++ b/controllers/k6_stopped_jobs.go
@@ -44,7 +44,7 @@ func isJobRunning(log logr.Logger, service *v1.Service) bool {
 		return true
 	}
 
-	return status.Status().Stopped
+	return status.Status().Running
 }
 
 // StoppedJobs checks if the runners pods have stopped execution.
@@ -70,17 +70,17 @@ func StoppedJobs(ctx context.Context, log logr.Logger, k6 v1alpha1.TestRunI, r *
 		return
 	}
 
-	var count int32
+	var runningJobs int32
 	for _, service := range sl.Items {
 
 		if isJobRunning(log, &service) {
-			count++
+			runningJobs++
 		}
 	}
 
-	log.Info(fmt.Sprintf("%d/%d runners stopped execution", k6.GetSpec().Parallelism-count, k6.GetSpec().Parallelism))
+	log.Info(fmt.Sprintf("%d/%d runners stopped execution", k6.GetSpec().Parallelism-runningJobs, k6.GetSpec().Parallelism))
 
-	if count > 0 {
+	if runningJobs > 0 {
 		return
 	}
 

--- a/pkg/resources/jobs/runner.go
+++ b/pkg/resources/jobs/runner.go
@@ -67,13 +67,15 @@ func NewRunnerJob(k6 v1alpha1.TestRunI, index int, token string) (*batchv1.Job, 
 		command = append(command, "--paused")
 	}
 
-	command = append(command, "--no-setup")
-
 	// Add an instance tag: in case metrics are stored, they need to be distinguished by instance
 	command = append(command, "--tag", fmt.Sprintf("instance_id=%d", index))
 
 	// Add an job tag: in case metrics are stored, they need to be distinguished by job
 	command = append(command, "--tag", fmt.Sprintf("job_name=%s", name))
+
+	if v1alpha1.IsTrue(k6, v1alpha1.CloudPLZTestRun) {
+		command = append(command, "--no-setup", "--no-teardown", "--linger")
+	}
 
 	command = script.UpdateCommand(command)
 

--- a/pkg/resources/jobs/runner.go
+++ b/pkg/resources/jobs/runner.go
@@ -67,6 +67,8 @@ func NewRunnerJob(k6 v1alpha1.TestRunI, index int, token string) (*batchv1.Job, 
 		command = append(command, "--paused")
 	}
 
+	command = append(command, "--no-setup")
+
 	// Add an instance tag: in case metrics are stored, they need to be distinguished by instance
 	command = append(command, "--tag", fmt.Sprintf("instance_id=%d", index))
 

--- a/pkg/resources/jobs/runner_test.go
+++ b/pkg/resources/jobs/runner_test.go
@@ -1593,3 +1593,147 @@ func TestNewRunnerJobWithVolume(t *testing.T) {
 		t.Errorf("NewRunnerJob returned unexpected data, diff: %s", diff)
 	}
 }
+
+func TestNewRunnerJobPLZTestRun(t *testing.T) {
+	// NewRunnerJob does not validate the type of Script for
+	// internal consistency (like in PLZ case) so it can be anything.
+	script := &types.Script{
+		Name:     "test",
+		Filename: "thing.js",
+		Type:     "ConfigMap",
+	}
+
+	var zero int64 = 0
+	automountServiceAccountToken := true
+
+	expectedLabels := map[string]string{
+		"app":    "k6",
+		"k6_cr":  "test",
+		"runner": "true",
+		"label1": "awesome",
+	}
+
+	expectedOutcome := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-1",
+			Namespace: "test",
+			Labels:    expectedLabels,
+			Annotations: map[string]string{
+				"awesomeAnnotation": "dope",
+			},
+		},
+		Spec: batchv1.JobSpec{
+			BackoffLimit: new(int32),
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: expectedLabels,
+					Annotations: map[string]string{
+						"awesomeAnnotation": "dope",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Hostname:                     "test-1",
+					RestartPolicy:                corev1.RestartPolicyNever,
+					SecurityContext:              &corev1.PodSecurityContext{},
+					Affinity:                     nil,
+					NodeSelector:                 nil,
+					Tolerations:                  nil,
+					TopologySpreadConstraints:    nil,
+					ServiceAccountName:           "default",
+					AutomountServiceAccountToken: &automountServiceAccountToken,
+					Containers: []corev1.Container{{
+						Image:           "ghcr.io/grafana/k6-operator:latest-runner",
+						ImagePullPolicy: corev1.PullNever,
+						Name:            "k6",
+						Command:         []string{"k6", "run", "--quiet", "/test/test.js", "--address=0.0.0.0:6565", "--paused", "--tag", "instance_id=1", "--tag", "job_name=test-1", "--no-setup", "--no-teardown", "--linger"},
+						Env:             []corev1.EnvVar{},
+						Resources:       corev1.ResourceRequirements{},
+						VolumeMounts:    script.VolumeMount(),
+						Ports:           []corev1.ContainerPort{{ContainerPort: 6565}},
+						EnvFrom: []corev1.EnvFromSource{
+							{
+								ConfigMapRef: &corev1.ConfigMapEnvSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "env",
+									},
+								},
+							},
+						},
+						LivenessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								HTTPGet: &corev1.HTTPGetAction{
+									Path:   "/v1/status",
+									Port:   intstr.IntOrString{IntVal: 6565},
+									Scheme: "HTTP",
+								},
+							},
+						},
+						ReadinessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								HTTPGet: &corev1.HTTPGetAction{
+									Path:   "/v1/status",
+									Port:   intstr.IntOrString{IntVal: 6565},
+									Scheme: "HTTP",
+								},
+							},
+						},
+					}},
+					TerminationGracePeriodSeconds: &zero,
+					Volumes:                       script.Volume(),
+				},
+			},
+		},
+	}
+	k6 := &v1alpha1.TestRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+		Spec: v1alpha1.TestRunSpec{
+			Script: v1alpha1.K6Script{
+				ConfigMap: v1alpha1.K6Configmap{
+					Name: "test",
+					File: "test.js",
+				},
+			},
+			Runner: v1alpha1.Pod{
+				Metadata: v1alpha1.PodMetadata{
+					Labels: map[string]string{
+						"label1": "awesome",
+					},
+					Annotations: map[string]string{
+						"awesomeAnnotation": "dope",
+					},
+				},
+				EnvFrom: []corev1.EnvFromSource{
+					{
+						ConfigMapRef: &corev1.ConfigMapEnvSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "env",
+							},
+						},
+					},
+				},
+				ImagePullPolicy: corev1.PullNever,
+			},
+		},
+		Status: v1alpha1.TestRunStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:               v1alpha1.CloudPLZTestRun,
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.Now(),
+					//					Reason:             "CloudPLZTestRunTrue",
+				},
+			},
+		},
+	}
+
+	job, err := NewRunnerJob(k6, 1, "")
+	if err != nil {
+		t.Errorf("NewRunnerJob errored, got: %v", err)
+	}
+	if diff := deep.Equal(job, expectedOutcome); diff != nil {
+		t.Errorf("NewRunnerJob returned unexpected data, diff: %s", diff)
+	}
+}

--- a/pkg/testrun/k6client.go
+++ b/pkg/testrun/k6client.go
@@ -1,0 +1,62 @@
+package testrun
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/grafana/k6-operator/pkg/types"
+	k6Client "go.k6.io/k6/api/v1/client"
+)
+
+// This will probably be removed once distributed mode in k6 is implemented.
+
+func RunSetup(ctx context.Context, hostname string) (_ json.RawMessage, err error) {
+	c, err := k6Client.New(fmt.Sprintf("%v:6565", hostname), k6Client.WithHTTPClient(&http.Client{
+		Timeout: 0,
+	}))
+
+	var response types.SetupData
+	if err := c.CallAPI(ctx, "POST", &url.URL{Path: "/v1/setup"}, nil, &response); err != nil {
+		return nil, err
+	}
+
+	if response.Data.Attributes.Data != nil {
+		var tmpSetupDataObj interface{}
+		if err := json.Unmarshal(response.Data.Attributes.Data, &tmpSetupDataObj); err != nil {
+			return nil, err
+		}
+	}
+
+	return response.Data.Attributes.Data, nil
+}
+
+func SetSetupData(ctx context.Context, hostnames []string, data json.RawMessage) (err error) {
+	for _, hostname := range hostnames {
+		c, err := k6Client.New(fmt.Sprintf("%v:6565", hostname), k6Client.WithHTTPClient(&http.Client{
+			Timeout: 0,
+		}))
+		if err != nil {
+			return err
+		}
+
+		if err = c.CallAPI(ctx, "PUT", &url.URL{Path: "/v1/setup"}, data, nil); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func RunTeardown(ctx context.Context, hostname string, data json.RawMessage) (err error) {
+	c, err := k6Client.New(fmt.Sprintf("%v:6565", hostname), k6Client.WithHTTPClient(&http.Client{
+		Timeout: 0,
+	}))
+	if err != nil {
+		return
+	}
+
+	return c.CallAPI(ctx, "POST", &url.URL{Path: "/v1/teardown"}, nil, nil)
+}

--- a/pkg/types/conditions.go
+++ b/pkg/types/conditions.go
@@ -70,6 +70,10 @@ var reasons = map[string]string{
 	"TestRunRunningTrue":    "TestRunRunningTrue",
 	"TestRunRunningFalse":   "TestRunRunningFalse",
 
+	"TeardownExecutedUnknown": "TestRunPreparation",
+	"TeardownExecutedFalse":   "TeardownExecutedFalse",
+	"TeardownExecutedTrue":    "TeardownExecutedTrue",
+
 	"CloudTestRunUnknown": "TestRunTypeUnknown",
 	"CloudTestRunTrue":    "CloudTestRunTrue",
 	"CloudTestRunFalse":   "CloudTestRunFalse",

--- a/pkg/types/k6status.go
+++ b/pkg/types/k6status.go
@@ -1,5 +1,7 @@
 package types
 
+import "encoding/json"
+
 // k6 REST API types.
 // TODO: refactor with existing definitions in k6 api/v1?
 
@@ -16,4 +18,18 @@ type StatusAPIRequestData struct {
 type StatusAPIRequestDataAttributes struct {
 	Paused  bool `json:"paused"`
 	Stopped bool `json:"stopped"`
+}
+
+type SetupData struct {
+	Data setUpData `json:"data"`
+}
+
+type setUpData struct {
+	Type       string                  `json:"type"`
+	ID         string                  `json:"id"`
+	Attributes setupResponseAttributes `json:"attributes"`
+}
+
+type setupResponseAttributes struct {
+	Data json.RawMessage `json:"data"`
 }


### PR DESCRIPTION
Issue: #223 

This PR implements the necessary logic **only for PLZ test runs**, thus leaving all other test runs as they have been executed so far.

Rationale: for a general case of OSS distributed test run, this logic is rather convoluted and implementing it in full would require to rather drastically intrude into standard logic of Kubernetes Job controller. From the design perspective, it would be preferable to implement full solution for `setup` and `teardown` via native distributed mode in k6 instead. Once that happens, PLZ test runs could also switch to using the logic of k6 distributed mode.