### PR TITLE
adds global registry and imagepullsecrets override to helm chart

### DIFF
--- a/charts/k6-operator/templates/deployment.yaml
+++ b/charts/k6-operator/templates/deployment.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         {{- if .Values.authProxy.enabled }}
         - name: kube-rbac-proxy
-          image: "{{ .Values.authProxy.image.name }}:{{ .Values.authProxy.image.tag }}"
+          image: "{{ .Values.global.image.registry | default .Values.authProxy.image.registry }}/{{ .Values.authProxy.image.repository }}:{{ .Values.authProxy.image.tag }}"
           imagePullPolicy: {{ .Values.authProxy.image.pullPolicy }}
           {{- if .Values.authProxy.resources }}
           resources:
@@ -50,7 +50,7 @@ spec:
               name: https
         {{- end }}
         - name: manager
-          image: "{{ .Values.manager.image.name }}:{{ .Values.manager.image.tag }}"
+          image: "{{ .Values.global.image.registry | default .Values.manager.image.registry }}/{{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag }}"
           imagePullPolicy: {{ .Values.manager.image.pullPolicy }}
           {{- if .Values.manager.livenessProbe }}
           livenessProbe:
@@ -75,7 +75,11 @@ spec:
             {{- if .Values.authProxy.enabled }}
             - --metrics-addr=127.0.0.1:8080
             {{- end }}
-      serviceAccount: {{ include "k6-operator.serviceAccountName" . }}
+      serviceAccountName: {{ include "k6-operator.serviceAccountName" . }}
+      {{- if .Values.global.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.global.image.pullSecrets | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/k6-operator/values.yaml
+++ b/charts/k6-operator/values.yaml
@@ -1,3 +1,10 @@
+global:
+  image:
+    # global.image.registry -- Global image registry to use if it needs to be overridden for some specific use cases (e.g local registries, custom images, ...)
+    registry: ""
+    # global.image.pullSecrets -- Optional set of global image pull secrets
+    pullSecrets: []
+
 # customAnnotations -- Custom Annotations to be applied on all resources
 customAnnotations: {}
 
@@ -31,8 +38,10 @@ authProxy:
   # authProxy.enabled -- enables the protection of /metrics endpoint. (https://github.com/brancz/kube-rbac-proxy)
   enabled: true
   image:
-    # authProxy.image.name -- rbac-proxy image name
-    name: gcr.io/kubebuilder/kube-rbac-proxy
+    # authProxy.image.registry
+    registry: gcr.io
+    # authProxy.image.repository -- rbac-proxy image repository
+    repository: kubebuilder/kube-rbac-proxy
     # authProxy.image.tag -- rbac-proxy image tag
     tag: v0.8.0
     # authProxy.image.pullPolicy -- pull policy for the image can be Always, Never, IfNotPresent (default: IfNotPresent)
@@ -53,12 +62,14 @@ manager:
     # manager.serviceAccount.create -- create the service account (default: true)
     create: true
   image:
-    # manager.image.name -- controller-manager image name
-    name: ghcr.io/grafana/k6-operator
+    # manager.image.registry
+    registry: ghcr.io
+    # manager.image.repository -- controller-manager image repository
+    repository: grafana/k6-operator
     # manager.image.tag -- controller-manager image tag
     tag: controller-v0.0.12
-    # manager.image.pullPolicy -- pull policy for the image possible values Always, Never, IfNotPresent (default: Always)
-    pullPolicy: Always
+    # manager.image.pullPolicy -- pull policy for the image possible values Always, Never, IfNotPresent (default: IfNotPresent)
+    pullPolicy: IfNotPresent
   # manager.livenessProbe -- Liveness probe in Probe format
   livenessProbe: {}
   # manager.readinessProbe -- Readiness probe in Probe format


### PR DESCRIPTION
I used the [grafana-agent](https://github.com/grafana/agent/tree/main/operations/helm/charts/grafana-agent) helm chart as a rough reference. Happy to tweak any of the value names or descriptions. Thank you!