### PR TITLE
Fix of logic for error on duplicate job

### DIFF
--- a/api/v1alpha1/k6conditions.go
+++ b/api/v1alpha1/k6conditions.go
@@ -88,7 +88,6 @@ func Initialize(k6 TestRunI) {
 
 	// PLZ test run case
 	if len(k6.GetSpec().TestRunID) > 0 {
-		UpdateCondition(k6, CloudTestRun, metav1.ConditionTrue)
 		UpdateCondition(k6, CloudPLZTestRun, metav1.ConditionTrue)
 		UpdateCondition(k6, CloudTestRunCreated, metav1.ConditionTrue)
 		UpdateCondition(k6, CloudTestRunFinalized, metav1.ConditionFalse)

--- a/controllers/k6_create.go
+++ b/controllers/k6_create.go
@@ -88,9 +88,11 @@ func createJobSpecs(ctx context.Context, log logr.Logger, k6 v1alpha1.TestRunI, 
 		log.Info(err.Error())
 
 		// is it possible to implement this delay with resourceVersion of the job?
+
 		t, condUpdated := v1alpha1.LastUpdate(k6, v1alpha1.CloudTestRun)
-		// if condition has not been updated yet or has been updated very recently
-		if !condUpdated || time.Since(t).Seconds() <= 30 {
+		// If condition is unknown then resource hasn't been updated with `k6 inspect` results.
+		// If it has been updated but very recently, wait a bit before throwing an error.
+		if v1alpha1.IsUnknown(k6, v1alpha1.CloudTestRun) || !condUpdated || time.Since(t).Seconds() <= 30 {
 			// try again before returning an error
 			return ctrl.Result{RequeueAfter: time.Second * 10}, true, nil
 		}


### PR DESCRIPTION
Ensure that error handling logic will be the same for all types of test runs.