### PR TITLE
feat: differentiate between Runner and Initializer initContainers

### DIFF
--- a/config/samples/k6_v1alpha1_k6_with_initContainers.yaml
+++ b/config/samples/k6_v1alpha1_k6_with_initContainers.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: k6.io/v1alpha1
+kind: K6
+metadata:
+  name: k6-sample
+spec:
+  parallelism: 4
+  script:
+    configMap:
+      name: k6-test
+      file: test.js
+  initializer: 
+    initContainers:
+      - image: busybox:latest
+        command: [ "sh", "-c", "echo 'is part of initializer pod'" ]
+  runner:
+    initContainers:
+      - image: busybox:latest
+        command: [ "sh", "-c", "echo 'is part of all 4 testrun pods'" ]

--- a/config/samples/k6_v1alpha1_k6_with_initContainers.yaml
+++ b/config/samples/k6_v1alpha1_k6_with_initContainers.yaml
@@ -12,8 +12,8 @@ spec:
   initializer: 
     initContainers:
       - image: busybox:latest
-        command: [ "sh", "-c", "echo 'is part of initializer pod'" ]
+        command: ["sh", "-c", "echo 'is part of initializer pod'"]
   runner:
     initContainers:
       - image: busybox:latest
-        command: [ "sh", "-c", "echo 'is part of all 4 testrun pods'" ]
+        command: ["sh", "-c", "echo 'is part of all 4 testrun pods'"]

--- a/pkg/resources/jobs/helpers.go
+++ b/pkg/resources/jobs/helpers.go
@@ -117,10 +117,10 @@ func newIstioEnvVar(istio v1alpha1.K6Scuttle, istioEnabled bool) []corev1.EnvVar
 }
 
 // TODO: Envoy variables are not passed to init containers
-func getInitContainers(k6Spec *v1alpha1.TestRunSpec, script *types.Script) []corev1.Container {
+func getInitContainers(pod *v1alpha1.Pod, script *types.Script) []corev1.Container {
 	var initContainers []corev1.Container
 
-	for i, k6InitContainer := range k6Spec.Runner.InitContainers {
+	for i, k6InitContainer := range pod.InitContainers {
 
 		name := fmt.Sprintf("k6-init-%d", i)
 		if k6InitContainer.Name != "" {
@@ -138,8 +138,8 @@ func getInitContainers(k6Spec *v1alpha1.TestRunSpec, script *types.Script) []cor
 			EnvFrom:         k6InitContainer.EnvFrom,
 			Env:             k6InitContainer.Env,
 			VolumeMounts:    volumeMounts,
-			ImagePullPolicy: k6Spec.Runner.ImagePullPolicy,
-			SecurityContext: &k6Spec.Runner.ContainerSecurityContext,
+			ImagePullPolicy: pod.ImagePullPolicy,
+			SecurityContext: &pod.ContainerSecurityContext,
 		}
 		initContainers = append(initContainers, initContainer)
 	}

--- a/pkg/resources/jobs/initializer.go
+++ b/pkg/resources/jobs/initializer.go
@@ -113,7 +113,7 @@ func NewInitializerJob(k6 v1alpha1.TestRunI, argLine string) (*batchv1.Job, erro
 					SecurityContext:              &k6.GetSpec().Initializer.SecurityContext,
 					RestartPolicy:                corev1.RestartPolicyNever,
 					ImagePullSecrets:             k6.GetSpec().Initializer.ImagePullSecrets,
-					InitContainers:               getInitContainers(k6.GetSpec(), script),
+					InitContainers:               getInitContainers(k6.GetSpec().Initializer, script),
 					Containers: []corev1.Container{
 						{
 							Image:           image,

--- a/pkg/resources/jobs/runner.go
+++ b/pkg/resources/jobs/runner.go
@@ -174,7 +174,7 @@ func NewRunnerJob(k6 v1alpha1.TestRunI, index int, token string) (*batchv1.Job, 
 					TopologySpreadConstraints:    k6.GetSpec().Runner.TopologySpreadConstraints,
 					SecurityContext:              &k6.GetSpec().Runner.SecurityContext,
 					ImagePullSecrets:             k6.GetSpec().Runner.ImagePullSecrets,
-					InitContainers:               getInitContainers(k6.GetSpec(), script),
+					InitContainers:               getInitContainers(&k6.GetSpec().Runner, script),
 					Containers: []corev1.Container{{
 						Image:           image,
 						ImagePullPolicy: k6.GetSpec().Runner.ImagePullPolicy,

--- a/pkg/resources/jobs/runner.go
+++ b/pkg/resources/jobs/runner.go
@@ -174,7 +174,7 @@ func NewRunnerJob(k6 v1alpha1.TestRunI, index int, token string) (*batchv1.Job, 
 					TopologySpreadConstraints:    k6.GetSpec().Runner.TopologySpreadConstraints,
 					SecurityContext:              &k6.GetSpec().Runner.SecurityContext,
 					ImagePullSecrets:             k6.GetSpec().Runner.ImagePullSecrets,
-					InitContainers:               getInitContainers(k6.GetSpec().Runner, script),
+					InitContainers:               getInitContainers(&k6.GetSpec().Runner, script),
 					Containers: []corev1.Container{{
 						Image:           image,
 						ImagePullPolicy: k6.GetSpec().Runner.ImagePullPolicy,

--- a/pkg/resources/jobs/runner.go
+++ b/pkg/resources/jobs/runner.go
@@ -174,7 +174,7 @@ func NewRunnerJob(k6 v1alpha1.TestRunI, index int, token string) (*batchv1.Job, 
 					TopologySpreadConstraints:    k6.GetSpec().Runner.TopologySpreadConstraints,
 					SecurityContext:              &k6.GetSpec().Runner.SecurityContext,
 					ImagePullSecrets:             k6.GetSpec().Runner.ImagePullSecrets,
-					InitContainers:               getInitContainers(&k6.GetSpec().Runner, script),
+					InitContainers:               getInitContainers(k6.GetSpec().Runner, script),
 					Containers: []corev1.Container{{
 						Image:           image,
 						ImagePullPolicy: k6.GetSpec().Runner.ImagePullPolicy,


### PR DESCRIPTION
Fixes [296](https://github.com/grafana/k6-operator/issues/296)

Enables you to have separate initContainers for the initializer and runner pod. 

Was tested successfully in own K8 environment (only the initializer pod was configured to have initContainers):
![image](https://github.com/grafana/k6-operator/assets/93530403/6f83b9e3-be1d-4fc3-8289-2d712223cc53)

Config looks like this:
```yaml
initializer:
    ...
    {{- if .Values.executor.script.volumeClaim }}
    initContainers:
      - image: {{ tpl $.Values.docker.registry $ }}/{{ tpl $.Values.image.name $ }}:{{ tpl $.Values.image.tag $ }}
        {{- if .Values.image.command }}
        command: [ "sh", "-c", {{ .Values.image.command }} ]
        {{- else }}
          {{- with (index .Values.mount.pvcs 0) }}
        command: [ "sh", "-c", "cp -r /home/* {{ .path }};" ]
          {{- end }}
        {{- end }}
    {{- end }}
```

