### PR TITLE
Fix envtest runs in CI

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.19'
+          go-version: '1.20'
           cache: false
       - name: lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -7,7 +7,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.19.x]
+        go-version: [1.20.x]
         k8s_version: [1.19.2, 1.24.1, 1.27.1]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ endif
 all: manager
 
 # Run tests
+ENVTEST_VERSION ?= release-0.17
 ENVTEST_ASSETS_DIR = $(shell pwd)/testbin
 ENVTEST_K8S_VERSION ?= 1.24.1
 GOOS=$(shell go env GOOS)
@@ -44,13 +45,13 @@ test-setup:
 	curl -L -O "https://storage.googleapis.com/kubebuilder-tools/kubebuilder-tools-$(ENVTEST_K8S_VERSION)-$(GOOS)-$(GOARCH).tar.gz"
 	tar -zxvf kubebuilder-tools-$(ENVTEST_K8S_VERSION)-$(GOOS)-$(GOARCH).tar.gz
 	mv kubebuilder $(KUBEBUILDER_ASSETS_ROOT)
-	export KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS); go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	export KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS); go install sigs.k8s.io/controller-runtime/tools/setup-envtest@$(ENVTEST_VERSION)
 
 test-setup-ci:
 	curl -L -O "https://storage.googleapis.com/kubebuilder-tools/kubebuilder-tools-$(ENVTEST_K8S_VERSION)-$(GOOS)-$(GOARCH).tar.gz"
 	tar -xvf kubebuilder-tools-$(ENVTEST_K8S_VERSION)-$(GOOS)-$(GOARCH).tar.gz
 	mv kubebuilder $(KUBEBUILDER_ASSETS_ROOT)
-	export KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS); go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	export KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS); go install sigs.k8s.io/controller-runtime/tools/setup-envtest@$(ENVTEST_VERSION)
 
 e2e: deploy
 	kubectl create configmap crocodile-stress-test --from-file e2e/test.js


### PR DESCRIPTION
Recent change in envtest is causing CI to break:
https://github.com/kubernetes-sigs/controller-runtime/issues/2720
So fixing envtest version for now.

+ Minor update of `go-version`.
