### PR TITLE
Treat failed initializer as error (PR 291 continued)

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"time"
@@ -54,7 +55,12 @@ func inspectTestRun(ctx context.Context, log logr.Logger, k6 v1alpha1.TestRunI, 
 	}
 
 	// there should be only 1 initializer pod
-	if podList.Items[0].Status.Phase != corev1.PodSucceeded && podList.Items[0].Status.Phase != corev1.PodFailed {
+	if podList.Items[0].Status.Phase == corev1.PodFailed {
+		returnErr = errors.New("init job has failed")
+		log.Error(returnErr, "error:")
+		return
+	}
+	if podList.Items[0].Status.Phase != corev1.PodSucceeded {
 		log.Info("Waiting for initializing pod to finish")
 		return
 	}

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -56,7 +56,7 @@ func inspectTestRun(ctx context.Context, log logr.Logger, k6 v1alpha1.TestRunI, 
 
 	// there should be only 1 initializer pod
 	if podList.Items[0].Status.Phase == corev1.PodFailed {
-		returnErr = errors.New("init job has failed")
+		returnErr = errors.New("initalizer job has failed")
 		log.Error(returnErr, "error:")
 		return
 	}

--- a/controllers/k6_initialize.go
+++ b/controllers/k6_initialize.go
@@ -62,6 +62,14 @@ func RunValidations(ctx context.Context, log logr.Logger, k6 v1alpha1.TestRunI, 
 				WithDetail(fmt.Sprintf("Failed to inspect the test script: %v", err)).
 				WithAbort()
 			cloud.SendTestRunEvents(r.k6CloudClient, v1alpha1.TestRunID(k6), log, events)
+		} else {
+			// if there is any error, we have to reflect it on the K6 manifest
+			k6.GetStatus().Stage = "error"
+			if _, err := r.UpdateStatus(ctx, k6, log); err != nil {
+				return ctrl.Result{}, ready, err
+			}
+
+			return ctrl.Result{}, ready, nil
 		}
 
 		// inspectTestRun made a log message already so just return without requeue


### PR DESCRIPTION
PullRequest 291 has been out of date, and I believe that more time has passed and merging has become more difficult, so I have reworked the PR.
The changes are basically the same as in PullRequest 291, with a few modifications based on comments.

https://github.com/grafana/k6-operator/pull/291

Thanks to JorTurFer and yorugac.