### PR TITLE
Docs: add missing details

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Passing additional configuration can be done with `values.yaml` (example can be 
 helm install k6-operator grafana/k6-operator -f values.yaml
 ```
 
+Complete list of options available for Helm can be found [here](https://github.com/grafana/k6-operator/blob/main/charts/k6-operator/README.md).
+
 #### Makefile deployment
 
 In order to install the operator with Makefile, the following additional tooling must be installed:
@@ -488,6 +490,28 @@ spec:
             - name: k6-yaml
               configMap:
                 name: <test-name>-config
+```
+
+### Namespaced deployment
+
+By default, k6-operator watches `TestRun` and `PriaveLoadZone` custom resources in all namespaces. But it is possible to configure k6-operator to watch only a specific namespace by setting a `WATCH_NAMESPACE` environment variable for the operator's deployment:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: k6-operator-controller-manager
+  namespace: k6-operator-system
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          image: ghcr.io/grafana/k6-operator:controller-v0.0.14
+          env:
+            - name: WATCH_NAMESPACE
+              value: "some-ns"
+# ...
 ```
 
 ## Uninstallation

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -14,7 +14,14 @@ export const options = {
 };
 ```
 
-There are several ways this `test.js` can be configured by k6-operator. Let's look into some of them.
+Firstly, it is a recommended practice to set the default value of environment variable definition as here:
+```js
+const VUS = __ENV.TEST_VUS || 10000;
+```
+
+This way, the script won't break even if there are changes in the setup.
+
+Within k6-operator context, there are several ways the `TEST_VUS` can be configured for `test.js`. Let's look into some of them.
 
 ## ConfigMap with `test.js`
 


### PR DESCRIPTION
Adding some clarifications in docs for: 
- `WATCH_NAMESPACE` env var
- Helm documentation
- highlighting recommended practice for env vars in k6 scripts