### PR TITLE
Update controller-gen to v0.14.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,11 +120,7 @@ controller-gen:
 ifeq (, $(shell which controller-gen))
 	@{ \
 	set -e ;\
-	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
-	cd $$CONTROLLER_GEN_TMP_DIR ;\
-	go mod init tmp ;\
-	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.13.0 ;\
-	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
+	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.14.0 ;\
 	}
 CONTROLLER_GEN=$(GOBIN)/controller-gen
 else

--- a/config/crd/bases/k6.io_k6s.yaml
+++ b/config/crd/bases/k6.io_k6s.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: k6s.k6.io
 spec:
   group: k6.io

--- a/config/crd/bases/k6.io_privateloadzones.yaml
+++ b/config/crd/bases/k6.io_privateloadzones.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: privateloadzones.k6.io
 spec:
   group: k6.io

--- a/config/crd/bases/k6.io_testruns.yaml
+++ b/config/crd/bases/k6.io_testruns.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: testruns.k6.io
 spec:
   group: k6.io


### PR DESCRIPTION
This PR updates `controller-gen` to `v0.14.0` in order to get rid of a bug impeding the `make manifest` and `make generate` commands

```
k6-operator $ make manifests
/my/local/path/controller-gen "crd:maxDescLen=0" rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xa0e4be]

goroutine 49 [running]:
go/types.(*Checker).handleBailout(0xc000db0600, 0xc000adbd40)
        /usr/lib/go/src/go/types/check.go:367 +0x88
panic({0xbc8860?, 0x12b48a0?})
        /usr/lib/go/src/runtime/panic.go:770 +0x132
go/types.(*StdSizes).Sizeof(0x0, {0xdc4c18, 0x12bd060})
        /usr/lib/go/src/go/types/sizes.go:228 +0x31e
go/types.(*Config).sizeof(...)
        /usr/lib/go/src/go/types/sizes.go:333
go/types.representableConst.func1({0xdc4c18?, 0x12bd060?})
        /usr/lib/go/src/go/types/const.go:76 +0x9e
go/types.representableConst({0xdcaff0, 0x1287f90}, 0xc000db0600, 0x12bd060, 0x0)
        /usr/lib/go/src/go/types/const.go:92 +0x192
go/types.(*Checker).arrayLength(0xc000db0600, {0xdc92a0, 0xc0001b9aa0?})
        /usr/lib/go/src/go/types/typexpr.go:510 +0x2d3
go/types.(*Checker).typInternal(0xc000db0600, {0xdc78c0, 0xc000322b40}, 0xc00032ec30)
        /usr/lib/go/src/go/types/typexpr.go:299 +0x49d
go/types.(*Checker).definedType(0xc000db0600, {0xdc78c0, 0xc000322b40}, 0x10?)
        /usr/lib/go/src/go/types/typexpr.go:180 +0x37
go/types.(*Checker).typeDecl(0xc000db0600, 0xc00032ec30, 0xc000d11640, 0x0)
        /usr/lib/go/src/go/types/decl.go:615 +0x44d
go/types.(*Checker).objDecl(0xc000db0600, {0xdd04b8, 0xc00032ec30}, 0x0)
        /usr/lib/go/src/go/types/decl.go:197 +0xa7f
go/types.(*Checker).packageObjects(0xc000db0600)
        /usr/lib/go/src/go/types/resolver.go:681 +0x425
go/types.(*Checker).checkFiles(0xc000db0600, {0xc000080f30, 0x1, 0x1})
        /usr/lib/go/src/go/types/check.go:408 +0x1a5
go/types.(*Checker).Files(...)
        /usr/lib/go/src/go/types/check.go:372
sigs.k8s.io/controller-tools/pkg/loader.(*loader).typeCheck(0xc000227440, 0xc000254080)
        /my/local/path/pkg/mod/sigs.k8s.io/controller-tools@v0.13.0/pkg/loader/loader.go:286 +0x36a
sigs.k8s.io/controller-tools/pkg/loader.(*Package).NeedTypesInfo(0xc000254080)
        /my/local/path/pkg/mod/sigs.k8s.io/controller-tools@v0.13.0/pkg/loader/loader.go:99 +0x39
sigs.k8s.io/controller-tools/pkg/loader.(*TypeChecker).check(0xc000e390b0, 0xc000254080)
        /my/local/path/pkg/mod/sigs.k8s.io/controller-tools@v0.13.0/pkg/loader/refs.go:268 +0x2b7
sigs.k8s.io/controller-tools/pkg/loader.(*TypeChecker).check.func1(0x39?)
        /my/local/path/pkg/mod/sigs.k8s.io/controller-tools@v0.13.0/pkg/loader/refs.go:262 +0x53
created by sigs.k8s.io/controller-tools/pkg/loader.(*TypeChecker).check in goroutine 37
        /my/local/path/pkg/mod/sigs.k8s.io/controller-tools@v0.13.0/pkg/loader/refs.go:260 +0x1c5
make: *** [Makefile:91: manifests] Error 2
```


It also simplifies the installation process for `controller-gen`