### PR TITLE
CI: run Helm lint and test on PRs

### DIFF
--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -7,6 +7,9 @@ on:
   push:
     branches:
       - '**'
+  pull_request:
+    branches-ignore:
+      - 'release-**/bundle-update'
 
 jobs:
   lint:
@@ -30,4 +33,11 @@ jobs:
         uses: helm/chart-testing-action@v2.2.0
 
       - name: Run chart-testing (lint)
-        run: ct lint --target-branch ${{ github.ref_name }} --config ./charts/ct.yaml
+        run: |
+          # is there a better way to get the right name for branch?
+          # for ref.: https://github.com/helm/chart-testing/issues/186#issuecomment-585595379
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            ct lint --target-branch ${{ github.head_ref }} --config ./charts/ct.yaml
+          else
+            ct lint --target-branch ${{ github.ref_name }} --config ./charts/ct.yaml
+          fi

--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -5,6 +5,9 @@ on:
     # run only on branches and not tags
     branches:
       - '**'
+  pull_request:
+    branches-ignore:
+      - 'release-**/bundle-update'
 
 jobs:
   test:
@@ -30,7 +33,12 @@ jobs:
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$(ct list-changed --config ./charts/ct.yaml --target-branch ${{ github.ref_name }})
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            changed=$(ct list-changed --config ./charts/ct.yaml --target-branch ${{ github.head_ref }})
+          else
+            changed=$(ct list-changed --config ./charts/ct.yaml --target-branch ${{ github.ref_name }})
+          fi
+
           if [[ -n "$changed" ]]; then
             echo "changed=true" >> $GITHUB_OUTPUT
           fi
@@ -41,4 +49,9 @@ jobs:
 
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct install --target-branch ${{ github.ref_name }} --charts ./charts/
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            ct install --target-branch ${{ github.head_ref }} --charts ./charts/
+          else
+            ct install --target-branch ${{ github.ref_name }} --charts ./charts/
+          fi


### PR DESCRIPTION
Enable Helm lint and test workflow on PRs, except for automated bundle update.