### PR TITLE
Add ReadOnly option to volumeMount in Pods

### DIFF
--- a/api/v1alpha1/k6_types.go
+++ b/api/v1alpha1/k6_types.go
@@ -100,8 +100,9 @@ type K6Script struct {
 
 // K6VolumeClaim describes the volume claim script location
 type K6VolumeClaim struct {
-	Name string `json:"name"`
-	File string `json:"file,omitempty"`
+	Name     string `json:"name"`
+	File     string `json:"file,omitempty"`
+	ReadOnly bool   `json:"readOnly,omitempty"`
 }
 
 // K6Configmap describes the config map script location

--- a/api/v1alpha1/testrun_types.go
+++ b/api/v1alpha1/testrun_types.go
@@ -65,6 +65,7 @@ func (k6 TestRunSpec) ParseScript() (*types.Script, error) {
 		s.Name = spec.VolumeClaim.Name
 		if spec.VolumeClaim.File != "" {
 			s.Filename = spec.VolumeClaim.File
+			s.ReadOnly = spec.VolumeClaim.ReadOnly
 		}
 
 		s.Type = "VolumeClaim"

--- a/config/crd/bases/k6.io_k6s.yaml
+++ b/config/crd/bases/k6.io_k6s.yaml
@@ -3537,6 +3537,8 @@ spec:
                         type: string
                       name:
                         type: string
+                      readOnly:
+                        type: boolean
                     required:
                     - name
                     type: object

--- a/config/crd/bases/k6.io_testruns.yaml
+++ b/config/crd/bases/k6.io_testruns.yaml
@@ -3535,6 +3535,8 @@ spec:
                         type: string
                       name:
                         type: string
+                      readOnly:
+                        type: boolean
                     required:
                     - name
                     type: object

--- a/config/samples/k6_v1alpha1_k6_with_readOnlyVolumeClaim.yaml
+++ b/config/samples/k6_v1alpha1_k6_with_readOnlyVolumeClaim.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: k6.io/v1alpha1
+kind: TestRun
+metadata:
+  name: k6-sample
+  namespace: load-test
+spec:
+  parallelism: 4
+  script:
+    volumeClaim:
+      name: stress-test-volumeClaim
+      file: test.js
+      # If ReadOnly is set to true, PVCs are mounted in Pods on a ReadOnly basis.
+      readOnly: true

--- a/pkg/types/script.go
+++ b/pkg/types/script.go
@@ -10,6 +10,7 @@ import (
 // Internal type created to support Spec.script options
 type Script struct {
 	Name     string // Name of ConfigMap or VolumeClaim or "LocalFile"
+	ReadOnly bool
 	Filename string
 	Path     string
 	Type     string // ConfigMap | VolumeClaim | LocalFile
@@ -29,6 +30,7 @@ func (s *Script) Volume() []corev1.Volume {
 				VolumeSource: corev1.VolumeSource{
 					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 						ClaimName: s.Name,
+						ReadOnly:  s.ReadOnly,
 					},
 				},
 			},

--- a/pkg/types/script.go
+++ b/pkg/types/script.go
@@ -10,7 +10,7 @@ import (
 // Internal type created to support Spec.script options
 type Script struct {
 	Name     string // Name of ConfigMap or VolumeClaim or "LocalFile"
-	ReadOnly bool
+	ReadOnly bool // VolumeClaim only
 	Filename string
 	Path     string
 	Type     string // ConfigMap | VolumeClaim | LocalFile


### PR DESCRIPTION
Added ReadOnly to the volumeMount option in Pods to support mounting of ReadOnlyMany(ROX) PVC.
https://github.com/grafana/k6-operator/issues/279

The default is ReadOnly: false.
The reason was to avoid destructive changes, considering the possibility that some users may already be writing to the volume in the init container.


Here are the results of a simple test.
[files.zip](https://github.com/user-attachments/files/15799552/files.zip)

Test Contents
- kubectl apply -f pvc.yaml to create pods to add pods and scenarios
- kubectl exec -it vp -- /bin/bash to add main.js to /mnt/vp in pods
- Create TestRun with kubectl apply -f main.yaml

result
describe-log.txt and get-log.txt are the execution results.
You can confirm that ReadOnly for k6-test-volume is true.