### PR TITLE
CI: add token to bypass bug in kustomize GA

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -41,6 +41,7 @@ jobs:
           kustomize_build_dir: "config/default"
           kustomize_output_file: "rendered.yaml"
           kustomize_build_options: "--load_restrictor none"
+          token: ${{ github.token }} # ref: https://github.com/karancode/kustomize-github-action/issues/46
         # TODO: setup-kind seems to be not well maintained so check for alternatives
       - uses: engineerd/setup-kind@v0.5.0
         with:


### PR DESCRIPTION
E2E workflow has been broken for the last few weeks.
Why: https://github.com/karancode/kustomize-github-action/issues/46
Adding token as a workaround, found by nice folk in the above issue.

~~If~~ When there's a proper fix for kustomize GA, token here should be removed.