### PR TITLE
Docs: update samples to use TestRun instead of K6

### DIFF
--- a/config/samples/k6_v1alpha1_k6.yaml
+++ b/config/samples/k6_v1alpha1_k6.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: k6.io/v1alpha1
-kind: K6
+kind: TestRun
 metadata:
   name: k6-sample
 spec:

--- a/config/samples/k6_v1alpha1_k6_with_initContainers.yaml
+++ b/config/samples/k6_v1alpha1_k6_with_initContainers.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: k6.io/v1alpha1
-kind: K6
+kind: TestRun
 metadata:
   name: k6-sample
 spec:


### PR DESCRIPTION
As noticed in community forum, we have some outdated samples still.
Ref.: https://community.grafana.com/t/k6-custom-resource-kind-testrun-vs-k6/123965