### PR TITLE
generate helm values schema

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -10,7 +10,38 @@ on:
       - 'charts/k6-operator/Chart.yaml'
 
 jobs:
+  generate-chart-schema:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Make changes to the file
+        run: |
+          make helm-schema
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Commit and push changes
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          git add charts/k6-operator/values.schema.json
+          
+          if git diff-index --quiet HEAD; then
+            echo "No updates to helm values schema"
+          else
+            git commit -m "gen schema json"
+            git push origin HEAD:helm-schema
+          fi
+
   call-update-helm-repo:
+    needs:
+      - generate-chart-schema
     permissions:
       contents: write
     uses: grafana/helm-charts/.github/workflows/update-helm-repo.yaml@main

--- a/Makefile
+++ b/Makefile
@@ -170,6 +170,10 @@ deploy-helm: manifests helm
 helm-template: manifests helm
 	$(HELM) template k6-operator ./charts/k6-operator -f ./charts/k6-operator/values.yaml --set manager.image.name=$(IMG_NAME) --set manager.image.tag=$(IMG_TAG)
 
+helm-schema:
+	go install github.com/dadav/helm-schema/cmd/helm-schema@0.12.0
+	$(shell go env GOPATH)/bin/helm-schema --chart-search-root ./charts/k6-operator
+
 # Delete operator from a cluster
 delete-helm: manifests helm
 	$(HELM) uninstall k6-operator

--- a/charts/k6-operator/values.schema.json
+++ b/charts/k6-operator/values.schema.json
@@ -1,0 +1,366 @@
+{
+  "additionalProperties": false,
+  "properties": {
+    "affinity": {
+      "additionalProperties": false,
+      "description": "affinity -- Affinity to be applied on all containers",
+      "title": "affinity",
+      "type": "object"
+    },
+    "authProxy": {
+      "additionalProperties": false,
+      "properties": {
+        "containerSecurityContext": {
+          "additionalProperties": false,
+          "description": "authProxy.containerSecurityContext -- A security context defines privileges and access control settings for the container.",
+          "title": "containerSecurityContext",
+          "type": "object"
+        },
+        "enabled": {
+          "default": true,
+          "description": "authProxy.enabled -- enables the protection of /metrics endpoint. (https://github.com/brancz/kube-rbac-proxy)",
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "image": {
+          "additionalProperties": false,
+          "properties": {
+            "pullPolicy": {
+              "default": "IfNotPresent",
+              "description": "authProxy.image.pullPolicy -- pull policy for the image can be Always, Never, IfNotPresent (default: IfNotPresent)",
+              "title": "pullPolicy",
+              "type": "string"
+            },
+            "registry": {
+              "default": "gcr.io",
+              "description": "authProxy.image.registry",
+              "title": "registry",
+              "type": "string"
+            },
+            "repository": {
+              "default": "kubebuilder/kube-rbac-proxy",
+              "description": "authProxy.image.repository -- rbac-proxy image repository",
+              "title": "repository",
+              "type": "string"
+            },
+            "tag": {
+              "default": "v0.15.0",
+              "description": "authProxy.image.tag -- rbac-proxy image tag",
+              "title": "tag",
+              "type": "string"
+            }
+          },
+          "title": "image",
+          "type": "object",
+          "required": [
+            "registry",
+            "repository",
+            "tag",
+            "pullPolicy"
+          ]
+        },
+        "livenessProbe": {
+          "additionalProperties": false,
+          "description": "authProxy.livenessProbe -- Liveness probe in Probe format",
+          "title": "livenessProbe",
+          "type": "object"
+        },
+        "readinessProbe": {
+          "additionalProperties": false,
+          "description": "authProxy.readinessProbe -- Readiness probe in Probe format",
+          "title": "readinessProbe",
+          "type": "object"
+        },
+        "resources": {
+          "additionalProperties": false,
+          "description": "authProxy.resources -- rbac-proxy resource limitation/request",
+          "title": "resources",
+          "type": "object"
+        }
+      },
+      "title": "authProxy",
+      "type": "object",
+      "required": [
+        "enabled",
+        "image"
+      ]
+    },
+    "customAnnotations": {
+      "additionalProperties": false,
+      "description": "customAnnotations -- Custom Annotations to be applied on all resources",
+      "title": "customAnnotations",
+      "type": "object"
+    },
+    "customLabels": {
+      "additionalProperties": false,
+      "description": "customLabels -- Custom Label to be applied on all resources",
+      "title": "customLabels",
+      "type": "object"
+    },
+    "global": {
+      "additionalProperties": false,
+      "properties": {
+        "image": {
+          "additionalProperties": false,
+          "properties": {
+            "pullSecrets": {
+              "items": {},
+              "description": "global.image.pullSecrets -- Optional set of global image pull secrets",
+              "title": "pullSecrets",
+              "type": "array"
+            },
+            "registry": {
+              "default": "",
+              "description": "global.image.registry -- Global image registry to use if it needs to be overridden for some specific use cases (e.g local registries, custom images, ...)",
+              "title": "registry",
+              "type": "string"
+            }
+          },
+          "title": "image",
+          "type": "object",
+          "required": [
+            "pullSecrets"
+          ]
+        }
+      },
+      "title": "global",
+      "type": "object",
+      "required": [
+        "image"
+      ]
+    },
+    "installCRDs": {
+      "default": true,
+      "description": "installCRDs -- Installs CRDs as part of the release",
+      "title": "installCRDs",
+      "type": "boolean"
+    },
+    "manager": {
+      "additionalProperties": false,
+      "properties": {
+        "containerSecurityContext": {
+          "additionalProperties": false,
+          "description": "manager.containerSecurityContext -- A security context defines privileges and access control settings for the container.",
+          "title": "containerSecurityContext",
+          "type": "object"
+        },
+        "env": {
+          "additionalProperties": false,
+          "description": "manager.env -- Environment variables to be applied on the controller",
+          "title": "env",
+          "type": "object"
+        },
+        "image": {
+          "additionalProperties": false,
+          "properties": {
+            "pullPolicy": {
+              "default": "IfNotPresent",
+              "description": "manager.image.pullPolicy -- pull policy for the image possible values Always, Never, IfNotPresent (default: IfNotPresent)",
+              "title": "pullPolicy",
+              "type": "string"
+            },
+            "registry": {
+              "default": "ghcr.io",
+              "description": "manager.image.registry",
+              "title": "registry",
+              "type": "string"
+            },
+            "repository": {
+              "default": "grafana/k6-operator",
+              "description": "manager.image.repository -- controller-manager image repository",
+              "title": "repository",
+              "type": "string"
+            },
+            "tag": {
+              "default": "controller-v0.0.15",
+              "description": "manager.image.tag -- controller-manager image tag",
+              "title": "tag",
+              "type": "string"
+            }
+          },
+          "title": "image",
+          "type": "object",
+          "required": [
+            "registry",
+            "repository",
+            "tag",
+            "pullPolicy"
+          ]
+        },
+        "livenessProbe": {
+          "additionalProperties": false,
+          "description": "manager.livenessProbe -- Liveness probe in Probe format",
+          "title": "livenessProbe",
+          "type": "object"
+        },
+        "readinessProbe": {
+          "additionalProperties": false,
+          "description": "manager.readinessProbe -- Readiness probe in Probe format",
+          "title": "readinessProbe",
+          "type": "object"
+        },
+        "replicas": {
+          "default": 1,
+          "description": "manager.replicas -- number of controller-manager replicas (default: 1)",
+          "title": "replicas",
+          "type": "integer"
+        },
+        "resources": {
+          "additionalProperties": false,
+          "properties": {
+            "limits": {
+              "additionalProperties": false,
+              "properties": {
+                "cpu": {
+                  "default": "100m",
+                  "description": "manager.resources.limits.cpu -- controller-manager CPU limit (Max)",
+                  "title": "cpu",
+                  "type": "string"
+                },
+                "memory": {
+                  "default": "100Mi",
+                  "description": "manager.resources.limits.memory -- controller-manager Memory limit (Max)",
+                  "title": "memory",
+                  "type": "string"
+                }
+              },
+              "title": "limits",
+              "type": "object",
+              "required": [
+                "cpu",
+                "memory"
+              ]
+            },
+            "requests": {
+              "additionalProperties": false,
+              "properties": {
+                "cpu": {
+                  "default": "100m",
+                  "description": "manager.resources.requests.cpu -- controller-manager CPU request (Min)",
+                  "title": "cpu",
+                  "type": "string"
+                },
+                "memory": {
+                  "default": "50Mi",
+                  "description": "manager.resources.requests.memory -- controller-manager Memory request (Min)",
+                  "title": "memory",
+                  "type": "string"
+                }
+              },
+              "title": "requests",
+              "type": "object",
+              "required": [
+                "cpu",
+                "memory"
+              ]
+            }
+          },
+          "description": "manager.resources -- controller-manager Resources definition",
+          "title": "resources",
+          "type": "object",
+          "required": [
+            "limits",
+            "requests"
+          ]
+        },
+        "serviceAccount": {
+          "additionalProperties": false,
+          "properties": {
+            "create": {
+              "default": true,
+              "description": "manager.serviceAccount.create -- create the service account (default: true)",
+              "title": "create",
+              "type": "boolean"
+            },
+            "name": {
+              "default": "k6-operator-controller",
+              "description": "manager.serviceAccount.name -- kubernetes service account for the k6 manager",
+              "title": "name",
+              "type": "string"
+            }
+          },
+          "title": "serviceAccount",
+          "type": "object",
+          "required": [
+            "name",
+            "create"
+          ]
+        }
+      },
+      "title": "manager",
+      "type": "object",
+      "required": [
+        "replicas",
+        "serviceAccount",
+        "image",
+        "resources"
+      ]
+    },
+    "namespace": {
+      "additionalProperties": false,
+      "properties": {
+        "create": {
+          "default": true,
+          "description": "namespace.create -- create the namespace (default: true)",
+          "title": "create",
+          "type": "boolean"
+        }
+      },
+      "title": "namespace",
+      "type": "object",
+      "required": [
+        "create"
+      ]
+    },
+    "nodeSelector": {
+      "additionalProperties": false,
+      "description": "nodeSelector -- Node Selector to be applied on all containers",
+      "title": "nodeSelector",
+      "type": "object"
+    },
+    "podAnnotations": {
+      "additionalProperties": false,
+      "description": "podAnnotations -- Custom Annotations to be applied on all pods",
+      "title": "podAnnotations",
+      "type": "object"
+    },
+    "podLabels": {
+      "additionalProperties": false,
+      "description": "podLabels -- Custom Label to be applied on all pods",
+      "title": "podLabels",
+      "type": "object"
+    },
+    "prometheus": {
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "default": false,
+          "description": "prometheus.enabled -- enables the prometheus metrics scraping (default: false)",
+          "title": "enabled",
+          "type": "boolean"
+        }
+      },
+      "title": "prometheus",
+      "type": "object",
+      "required": [
+        "enabled"
+      ]
+    },
+    "tolerations": {
+      "additionalProperties": false,
+      "description": "tolerations -- Tolerations to be applied on all containers",
+      "title": "tolerations",
+      "type": "object"
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [
+    "global",
+    "installCRDs",
+    "namespace",
+    "prometheus",
+    "authProxy",
+    "manager"
+  ]
+}

--- a/charts/k6-operator/values.schema.json
+++ b/charts/k6-operator/values.schema.json
@@ -117,10 +117,7 @@
             }
           },
           "title": "image",
-          "type": "object",
-          "required": [
-            "pullSecrets"
-          ]
+          "type": "object"
         }
       },
       "title": "global",

--- a/charts/k6-operator/values.yaml
+++ b/charts/k6-operator/values.yaml
@@ -1,28 +1,61 @@
 global:
   image:
+    # @schema
+    # required: false
+    # type: string
+    # @schema
     # global.image.registry -- Global image registry to use if it needs to be overridden for some specific use cases (e.g local registries, custom images, ...)
     registry: ""
+
     # global.image.pullSecrets -- Optional set of global image pull secrets
     pullSecrets: []
 
+# @schema
+# required: false
+# type: object
+# @schema
 # customAnnotations -- Custom Annotations to be applied on all resources
 customAnnotations: {}
 
+# @schema
+# required: false
+# type: object
+# @schema
 # podAnnotations -- Custom Annotations to be applied on all pods
 podAnnotations: {}
 
+# @schema
+# required: false
+# type: object
+# @schema
 # customLabels -- Custom Label to be applied on all resources
 customLabels: {}
 
+# @schema
+# required: false
+# type: object
+# @schema
 # podLabels -- Custom Label to be applied on all pods
 podLabels: {}
 
+# @schema
+# required: false
+# type: object
+# @schema
 # nodeSelector -- Node Selector to be applied on all containers
 nodeSelector: {}
 
+# @schema
+# required: false
+# type: object
+# @schema
 # affinity -- Affinity to be applied on all containers
 affinity: {}
 
+# @schema
+# required: false
+# type: object
+# @schema
 # tolerations -- Tolerations to be applied on all containers
 tolerations: {}
 
@@ -49,12 +82,32 @@ authProxy:
     tag: v0.15.0
     # authProxy.image.pullPolicy -- pull policy for the image can be Always, Never, IfNotPresent (default: IfNotPresent)
     pullPolicy: IfNotPresent
+
+  # @schema
+  # required: false
+  # type: object
+  # @schema
   # authProxy.resources -- rbac-proxy resource limitation/request
   resources: {}
+
+  # @schema
+  # required: false
+  # type: object
+  # @schema
   # authProxy.livenessProbe -- Liveness probe in Probe format
   livenessProbe: {}
+
+  # @schema
+  # required: false
+  # type: object
+  # @schema
   # authProxy.readinessProbe -- Readiness probe in Probe format
   readinessProbe: {}
+
+  # @schema
+  # required: false
+  # type: object
+  # @schema
   # authProxy.containerSecurityContext -- A security context defines privileges and access control settings for the container.
   containerSecurityContext: {}
 
@@ -75,10 +128,25 @@ manager:
     tag: controller-v0.0.15
     # manager.image.pullPolicy -- pull policy for the image possible values Always, Never, IfNotPresent (default: IfNotPresent)
     pullPolicy: IfNotPresent
+
+  # @schema
+  # required: false
+  # type: object
+  # @schema
   # manager.livenessProbe -- Liveness probe in Probe format
   livenessProbe: {}
+
+  # @schema
+  # required: false
+  # type: object
+  # @schema
   # manager.readinessProbe -- Readiness probe in Probe format
   readinessProbe: {}
+
+  # @schema
+  # required: false
+  # type: object
+  # @schema
   # manager.env -- Environment variables to be applied on the controller
   env: {}
   # manager.resources -- controller-manager Resources definition
@@ -93,5 +161,10 @@ manager:
       cpu: 100m
       # manager.resources.requests.memory -- controller-manager Memory request (Min)
       memory: 50Mi
+
+  # @schema
+  # required: false
+  # type: object
+  # @schema
   # manager.containerSecurityContext -- A security context defines privileges and access control settings for the container.
   containerSecurityContext: {}

--- a/charts/k6-operator/values.yaml
+++ b/charts/k6-operator/values.yaml
@@ -7,6 +7,10 @@ global:
     # global.image.registry -- Global image registry to use if it needs to be overridden for some specific use cases (e.g local registries, custom images, ...)
     registry: ""
 
+    # @schema
+    # required: false
+    # type: array
+    # @schema
     # global.image.pullSecrets -- Optional set of global image pull secrets
     pullSecrets: []
 


### PR DESCRIPTION
closes #431

Adds initial `schema.values.json` to the chart and extends `helm-release` with a step that generates and commits the schema.

Also, adds a new Makefile target to generate the schema using [github.com/dadav/helm-schema](github.com/dadav/helm-schema).