### PR TITLE
Fix IPv6 compatibility issue with starter pod

### DIFF
--- a/e2e/ipv6/kind-ipv6.yaml
+++ b/e2e/ipv6/kind-ipv6.yaml
@@ -1,0 +1,5 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  ipFamily: ipv6
+  apiServerAddress: 127.0.0.1

--- a/pkg/resources/containers/curl_start.go
+++ b/pkg/resources/containers/curl_start.go
@@ -3,6 +3,7 @@ package containers
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"strings"
 
 	"github.com/grafana/k6-operator/pkg/types"
@@ -26,7 +27,7 @@ func NewStartContainer(hostnames []string, image string, imagePullPolicy corev1.
 
 	var parts []string
 	for _, hostname := range hostnames {
-		parts = append(parts, fmt.Sprintf("curl --retry 3 -X PATCH -H 'Content-Type: application/json' http://%s:6565/v1/status -d '%s'", hostname, req))
+		parts = append(parts, fmt.Sprintf("curl --retry 3 -X PATCH -H 'Content-Type: application/json' http://%s/v1/status -d '%s'", net.JoinHostPort(hostname, "6565"), req))
 	}
 
 	return corev1.Container{

--- a/pkg/resources/containers/curl_stop.go
+++ b/pkg/resources/containers/curl_stop.go
@@ -3,6 +3,7 @@ package containers
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"strings"
 
 	"github.com/grafana/k6-operator/pkg/types"
@@ -26,7 +27,7 @@ func NewStopContainer(hostnames []string, image string, imagePullPolicy corev1.P
 
 	var parts []string
 	for _, hostname := range hostnames {
-		parts = append(parts, fmt.Sprintf("curl --retry 3 -X PATCH -H 'Content-Type: application/json' http://%s:6565/v1/status -d '%s'", hostname, req))
+		parts = append(parts, fmt.Sprintf("curl --retry 3 -X PATCH -H 'Content-Type: application/json' http://%s/v1/status -d '%s'", net.JoinHostPort(hostname, "6565"), req))
 	}
 
 	return corev1.Container{


### PR DESCRIPTION
**Summary**
Bug Fixed: [Starter doesn't work in an IPv6 cluster](https://github.com/grafana/k6-operator/issues/171)

This pull request addresses the IPv6 compatibility issue in the k6-operator as outlined in the referenced issue. Specifically, the changes ensure that the k6-curl container can correctly handle IPv6 addresses.

**Changes Made**
Introduced the net package to handle IPv6 addresses.
Hostname Wrapping: Utilized net.JoinHostPort to wrap the hostname in square brackets if it is a literal IPv6 address, ensuring proper formatting.

**Testing**
Verified that the k6-curl container now supports both IPv6 and IPv4 addresses.
Conducted tests on local k8s cluster via KIND to confirm the functionality of the k6 operator with the updated IPv6 support.

Snapshot of starter pod that deals with IPv6 address correctly:
![image](https://github.com/user-attachments/assets/6e70dc5c-edd0-418b-8278-d2be4f3bfda7)
Snapshot of starter pod that still works with IPv4 address:
![image](https://github.com/user-attachments/assets/4676ba22-3bb6-4265-a1a5-e0a7b3465284)

**Impact**
These changes enhance the compatibility and robustness of the k6-operator, allowing it to function correctly in environments utilizing IPv6 addresses.