### PR TITLE
CI: fix `ct install` in helm-test

### DIFF
--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -48,4 +48,4 @@ jobs:
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'
         run: |
-            ct install --charts ./charts/
+            ct install --charts ./charts/k6-operator


### PR DESCRIPTION
Related issue: https://github.com/grafana/k6-operator/issues/419