### PR TITLE
Helm Chart - Enable Leader Election only if replica count greater than one

### DIFF
--- a/charts/k6-operator/templates/deployment.yaml
+++ b/charts/k6-operator/templates/deployment.yaml
@@ -53,7 +53,9 @@ spec:
           command:
             - /manager
           args:
+            {{- if gt .Values.manager.replicas 1 }}
             - --enable-leader-election
+            {{- end }}
             {{- if .Values.authProxy.enabled }}
             - --metrics-addr=127.0.0.1:8080
             {{- end }}


### PR DESCRIPTION
Addresses Issue #462 

This will enable Leader election only when the K6 Operator deployment count is greater than one.  This turns off a check that is not needed and keeps the operator logs clean.