### PR TITLE
Add cloud logs configuration to PLZ test runs by default 

### DIFF
--- a/controllers/plz_controller.go
+++ b/controllers/plz_controller.go
@@ -55,6 +55,7 @@ type PrivateLoadZoneReconciler struct {
 	// poller should be made PLZ specific;
 	// e.g. with a map: PLZ name -> poller.
 	poller *cloud.TestRunPoller
+	token  string // needed for cloud logs
 }
 
 //+kubebuilder:rbac:groups=k6.io,resources=privateloadzones,verbs=get;list;watch;create;update;patch;delete
@@ -88,6 +89,7 @@ func (r *PrivateLoadZoneReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		}
 
 		r.poller = cloud.NewTestRunPoller(cloud.ApiURL(k6CloudHost()), token, plz.Name, logger)
+		r.token = token
 	}
 
 	if plz.DeletionTimestamp.IsZero() && (plz.IsUnknown(v1alpha1.PLZRegistered) || plz.IsFalse(v1alpha1.PLZRegistered)) {

--- a/controllers/plz_factory.go
+++ b/controllers/plz_factory.go
@@ -41,7 +41,7 @@ func (r *PrivateLoadZoneReconciler) startFactory(plz *v1alpha1.PrivateLoadZone, 
 				continue
 			}
 
-			k6 = testrun.NewPLZTestRun(plz, trData, k6CloudHost())
+			k6 = testrun.NewPLZTestRun(plz, r.token, trData, k6CloudHost())
 
 			logger.Info(fmt.Sprintf("PLZ test run has been prepared with image `%s` and `%d` instances",
 				k6.Spec.Runner.Image, k6.Spec.Parallelism), "testRunId", testRunId)

--- a/pkg/testrun/plz.go
+++ b/pkg/testrun/plz.go
@@ -16,7 +16,7 @@ func TestName(testRunId string) string {
 }
 
 // ingestURL is a temp hack
-func NewPLZTestRun(plz *v1alpha1.PrivateLoadZone, trData *cloud.TestRunData, ingestUrl string) *v1alpha1.TestRun {
+func NewPLZTestRun(plz *v1alpha1.PrivateLoadZone, token string, trData *cloud.TestRunData, ingestUrl string) *v1alpha1.TestRun {
 	volume := corev1.Volume{
 		Name: "archive-volume",
 		VolumeSource: corev1.VolumeSource{
@@ -72,8 +72,11 @@ func NewPLZTestRun(plz *v1alpha1.PrivateLoadZone, trData *cloud.TestRunData, ing
 			},
 			Parallelism: int32(trData.InstanceCount),
 			Separate:    false,
-			Arguments:   "--out cloud --no-thresholds",
-			Cleanup:     v1alpha1.Cleanup("post"),
+			Arguments: fmt.Sprintf(`--out cloud --no-thresholds --log-output=loki=https://cloudlogs.k6.io/api/v1/push,label.lz=%s,label.test_run_id=%s,header.Authorization="Token %s"`,
+				plz.Name,
+				trData.TestRunID(),
+				token),
+			Cleanup: v1alpha1.Cleanup("post"),
 
 			TestRunID: trData.TestRunID(),
 			Token:     plz.Spec.Token,


### PR DESCRIPTION
This is likely a temporary solution that will be removed once k6 supports cloud logs for local execution natively, reference issue:
https://github.com/grafana/k6/issues/3282