### PR TITLE
Fixing values.yaml docs for schema generation, corrected values.schema.json

### DIFF
--- a/charts/k6-operator/templates/deployment.yaml
+++ b/charts/k6-operator/templates/deployment.yaml
@@ -43,7 +43,13 @@ spec:
           {{- if .Values.manager.env }}
           env:
             {{- with .Values.manager.env }}
-              {{- toYaml . | nindent 10 }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+          {{- if .Values.manager.envFrom }}
+          envFrom:
+            {{- with .Values.manager.envFrom }}
+              {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
          {{- if .Values.manager.containerSecurityContext }}

--- a/charts/k6-operator/values.schema.json
+++ b/charts/k6-operator/values.schema.json
@@ -2,7 +2,7 @@
   "additionalProperties": false,
   "properties": {
     "affinity": {
-      "additionalProperties": false,
+      "additionalProperties": true,
       "description": "affinity -- Affinity to be applied on all containers",
       "title": "affinity",
       "type": "object"
@@ -11,7 +11,7 @@
       "additionalProperties": false,
       "properties": {
         "containerSecurityContext": {
-          "additionalProperties": false,
+          "additionalProperties": true,
           "description": "authProxy.containerSecurityContext -- A security context defines privileges and access control settings for the container.",
           "title": "containerSecurityContext",
           "type": "object"
@@ -51,48 +51,38 @@
             }
           },
           "title": "image",
-          "type": "object",
-          "required": [
-            "registry",
-            "repository",
-            "tag",
-            "pullPolicy"
-          ]
+          "type": "object"
         },
         "livenessProbe": {
-          "additionalProperties": false,
+          "additionalProperties": true,
           "description": "authProxy.livenessProbe -- Liveness probe in Probe format",
           "title": "livenessProbe",
           "type": "object"
         },
         "readinessProbe": {
-          "additionalProperties": false,
+          "additionalProperties": true,
           "description": "authProxy.readinessProbe -- Readiness probe in Probe format",
           "title": "readinessProbe",
           "type": "object"
         },
         "resources": {
-          "additionalProperties": false,
+          "additionalProperties": true,
           "description": "authProxy.resources -- rbac-proxy resource limitation/request",
           "title": "resources",
           "type": "object"
         }
       },
       "title": "authProxy",
-      "type": "object",
-      "required": [
-        "enabled",
-        "image"
-      ]
+      "type": "object"
     },
     "customAnnotations": {
-      "additionalProperties": false,
+      "additionalProperties": true,
       "description": "customAnnotations -- Custom Annotations to be applied on all resources",
       "title": "customAnnotations",
       "type": "object"
     },
     "customLabels": {
-      "additionalProperties": false,
+      "additionalProperties": true,
       "description": "customLabels -- Custom Label to be applied on all resources",
       "title": "customLabels",
       "type": "object"
@@ -136,16 +126,22 @@
       "additionalProperties": false,
       "properties": {
         "containerSecurityContext": {
-          "additionalProperties": false,
+          "additionalProperties": true,
           "description": "manager.containerSecurityContext -- A security context defines privileges and access control settings for the container.",
           "title": "containerSecurityContext",
           "type": "object"
         },
         "env": {
-          "additionalProperties": false,
-          "description": "manager.env -- Environment variables to be applied on the controller",
+          "items": {},
+          "description": "manager.env -- List of environment variables to set in the controller",
           "title": "env",
-          "type": "object"
+          "type": "array"
+        },
+        "envFrom": {
+          "items": {},
+          "description": "manager.envFrom -- List of sources to populate environment variables in the controller",
+          "title": "envFrom",
+          "type": "array"
         },
         "image": {
           "additionalProperties": false,
@@ -169,29 +165,23 @@
               "type": "string"
             },
             "tag": {
-              "default": "controller-v0.0.15",
+              "default": "controller-v0.0.17",
               "description": "manager.image.tag -- controller-manager image tag",
               "title": "tag",
               "type": "string"
             }
           },
           "title": "image",
-          "type": "object",
-          "required": [
-            "registry",
-            "repository",
-            "tag",
-            "pullPolicy"
-          ]
+          "type": "object"
         },
         "livenessProbe": {
-          "additionalProperties": false,
+          "additionalProperties": true,
           "description": "manager.livenessProbe -- Liveness probe in Probe format",
           "title": "livenessProbe",
           "type": "object"
         },
         "readinessProbe": {
-          "additionalProperties": false,
+          "additionalProperties": true,
           "description": "manager.readinessProbe -- Readiness probe in Probe format",
           "title": "readinessProbe",
           "type": "object"
@@ -221,12 +211,9 @@
                   "type": "string"
                 }
               },
+              "description": "manager.resources.limits -- controller-manager Resources limits",
               "title": "limits",
-              "type": "object",
-              "required": [
-                "cpu",
-                "memory"
-              ]
+              "type": "object"
             },
             "requests": {
               "additionalProperties": false,
@@ -244,21 +231,14 @@
                   "type": "string"
                 }
               },
+              "description": "manager.resources.requests -- controller-manager Resources requests",
               "title": "requests",
-              "type": "object",
-              "required": [
-                "cpu",
-                "memory"
-              ]
+              "type": "object"
             }
           },
           "description": "manager.resources -- controller-manager Resources definition",
           "title": "resources",
-          "type": "object",
-          "required": [
-            "limits",
-            "requests"
-          ]
+          "type": "object"
         },
         "serviceAccount": {
           "additionalProperties": false,
@@ -277,20 +257,13 @@
             }
           },
           "title": "serviceAccount",
-          "type": "object",
-          "required": [
-            "name",
-            "create"
-          ]
+          "type": "object"
         }
       },
       "title": "manager",
       "type": "object",
       "required": [
-        "replicas",
-        "serviceAccount",
-        "image",
-        "resources"
+        "image"
       ]
     },
     "namespace": {
@@ -303,26 +276,24 @@
           "type": "boolean"
         }
       },
+      "description": "namespace -- Namespace creation",
       "title": "namespace",
-      "type": "object",
-      "required": [
-        "create"
-      ]
+      "type": "object"
     },
     "nodeSelector": {
-      "additionalProperties": false,
+      "additionalProperties": true,
       "description": "nodeSelector -- Node Selector to be applied on all containers",
       "title": "nodeSelector",
       "type": "object"
     },
     "podAnnotations": {
-      "additionalProperties": false,
+      "additionalProperties": true,
       "description": "podAnnotations -- Custom Annotations to be applied on all pods",
       "title": "podAnnotations",
       "type": "object"
     },
     "podLabels": {
-      "additionalProperties": false,
+      "additionalProperties": true,
       "description": "podLabels -- Custom Label to be applied on all pods",
       "title": "podLabels",
       "type": "object"
@@ -338,13 +309,10 @@
         }
       },
       "title": "prometheus",
-      "type": "object",
-      "required": [
-        "enabled"
-      ]
+      "type": "object"
     },
     "tolerations": {
-      "additionalProperties": false,
+      "additionalProperties": true,
       "description": "tolerations -- Tolerations to be applied on all containers",
       "title": "tolerations",
       "type": "object"
@@ -354,10 +322,7 @@
   "type": "object",
   "required": [
     "global",
-    "installCRDs",
-    "namespace",
     "prometheus",
-    "authProxy",
     "manager"
   ]
 }

--- a/charts/k6-operator/values.schema.json
+++ b/charts/k6-operator/values.schema.json
@@ -106,15 +106,13 @@
               "type": "string"
             }
           },
+          "description": "global.image -- Global image configuration",
           "title": "image",
           "type": "object"
         }
       },
       "title": "global",
-      "type": "object",
-      "required": [
-        "image"
-      ]
+      "type": "object"
     },
     "installCRDs": {
       "default": true,
@@ -171,6 +169,7 @@
               "type": "string"
             }
           },
+          "description": "manager.image -- controller-manager image configuration",
           "title": "image",
           "type": "object"
         },
@@ -260,11 +259,9 @@
           "type": "object"
         }
       },
+      "description": "manager -- controller-manager configuration",
       "title": "manager",
-      "type": "object",
-      "required": [
-        "image"
-      ]
+      "type": "object"
     },
     "namespace": {
       "additionalProperties": false,
@@ -319,10 +316,5 @@
     }
   },
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "type": "object",
-  "required": [
-    "global",
-    "prometheus",
-    "manager"
-  ]
+  "type": "object"
 }

--- a/charts/k6-operator/values.yaml
+++ b/charts/k6-operator/values.yaml
@@ -15,6 +15,7 @@ global:
     pullSecrets: []
 
 # @schema
+# additionalProperties: true
 # required: false
 # type: object
 # @schema
@@ -22,6 +23,7 @@ global:
 customAnnotations: {}
 
 # @schema
+# additionalProperties: true
 # required: false
 # type: object
 # @schema
@@ -29,6 +31,7 @@ customAnnotations: {}
 podAnnotations: {}
 
 # @schema
+# additionalProperties: true
 # required: false
 # type: object
 # @schema
@@ -36,6 +39,7 @@ podAnnotations: {}
 customLabels: {}
 
 # @schema
+# additionalProperties: true
 # required: false
 # type: object
 # @schema
@@ -43,6 +47,7 @@ customLabels: {}
 podLabels: {}
 
 # @schema
+# additionalProperties: true
 # required: false
 # type: object
 # @schema
@@ -50,6 +55,7 @@ podLabels: {}
 nodeSelector: {}
 
 # @schema
+# additionalProperties: true
 # required: false
 # type: object
 # @schema
@@ -57,37 +63,84 @@ nodeSelector: {}
 affinity: {}
 
 # @schema
+# additionalProperties: true
 # required: false
 # type: object
 # @schema
 # tolerations -- Tolerations to be applied on all containers
 tolerations: {}
 
+# @schema
+# required: false
+# type: boolean
+# @schema
 # installCRDs -- Installs CRDs as part of the release
 installCRDs: true
 
+# @schema
+# required: false
+# type: object
+# @schema
+# namespace -- Namespace creation
 namespace:
+  # @schema
+  # required: false
+  # type: boolean
+  # @schema
   # namespace.create -- create the namespace (default: true)
   create: true
 
 prometheus:
+  # @schema
+  # required: false
+  # type: boolean
+  # @schema
   # prometheus.enabled -- enables the prometheus metrics scraping (default: false)
   enabled: false
 
+# @schema
+# required: false
+# type: object
+# @schema
 authProxy:
+  # @schema
+  # required: false
+  # type: boolean
+  # @schema
   # authProxy.enabled -- enables the protection of /metrics endpoint. (https://github.com/brancz/kube-rbac-proxy)
   enabled: true
+  # @schema
+  # required: false
+  # type: object
+  # @schema
   image:
+    # @schema
+    # required: false
+    # type: string
+    # @schema
     # authProxy.image.registry
     registry: gcr.io
+    # @schema
+    # required: false
+    # type: string
+    # @schema
     # authProxy.image.repository -- rbac-proxy image repository
     repository: kubebuilder/kube-rbac-proxy
+    # @schema
+    # required: false
+    # type: string
+    # @schema
     # authProxy.image.tag -- rbac-proxy image tag
     tag: v0.15.0
+    # @schema
+    # required: false
+    # type: string
+    # @schema
     # authProxy.image.pullPolicy -- pull policy for the image can be Always, Never, IfNotPresent (default: IfNotPresent)
     pullPolicy: IfNotPresent
 
   # @schema
+  # additionalProperties: true
   # required: false
   # type: object
   # @schema
@@ -95,6 +148,7 @@ authProxy:
   resources: {}
 
   # @schema
+  # additionalProperties: true
   # required: false
   # type: object
   # @schema
@@ -102,6 +156,7 @@ authProxy:
   livenessProbe: {}
 
   # @schema
+  # additionalProperties: true
   # required: false
   # type: object
   # @schema
@@ -109,6 +164,7 @@ authProxy:
   readinessProbe: {}
 
   # @schema
+  # additionalProperties: true
   # required: false
   # type: object
   # @schema
@@ -116,24 +172,57 @@ authProxy:
   containerSecurityContext: {}
 
 manager:
+  # @schema
+  # required: false
+  # type: integer
+  # @schema
   # manager.replicas -- number of controller-manager replicas (default: 1)
   replicas: 1
+  # @schema
+  # required: false
+  # type: object
+  # @schema
   serviceAccount:
+    # @schema
+    # required: false
+    # type: string
+    # @schema
     # manager.serviceAccount.name -- kubernetes service account for the k6 manager
     name: k6-operator-controller
+    # @schema
+    # required: false
+    # type: boolean
+    # @schema
     # manager.serviceAccount.create -- create the service account (default: true)
     create: true
   image:
+    # @schema
+    # required: false
+    # type: string
+    # @schema
     # manager.image.registry
     registry: ghcr.io
+    # @schema
+    # required: false
+    # type: string
+    # @schema
     # manager.image.repository -- controller-manager image repository
     repository: grafana/k6-operator
+    # @schema
+    # required: false
+    # type: string
+    # @schema
     # manager.image.tag -- controller-manager image tag
     tag: controller-v0.0.17
+    # @schema
+    # required: false
+    # type: string
+    # @schema
     # manager.image.pullPolicy -- pull policy for the image possible values Always, Never, IfNotPresent (default: IfNotPresent)
     pullPolicy: IfNotPresent
 
   # @schema
+  # additionalProperties: true
   # required: false
   # type: object
   # @schema
@@ -141,6 +230,7 @@ manager:
   livenessProbe: {}
 
   # @schema
+  # additionalProperties: true
   # required: false
   # type: object
   # @schema
@@ -149,24 +239,63 @@ manager:
 
   # @schema
   # required: false
+  # type: array
+  # @schema
+  # manager.env -- List of environment variables to set in the controller
+  env: []
+
+  # @schema
+  # required: false
+  # type: array
+  # @schema
+  # manager.envFrom -- List of sources to populate environment variables in the controller
+  envFrom: []
+
+  # @schema
+  # required: false
   # type: object
   # @schema
-  # manager.env -- Environment variables to be applied on the controller
-  env: {}
   # manager.resources -- controller-manager Resources definition
   resources:
+    # @schema
+    # required: false
+    # type: object
+    # @schema
+    # manager.resources.limits -- controller-manager Resources limits
     limits:
+      # @schema
+      # required: false
+      # type: string
+      # @schema
       # manager.resources.limits.cpu -- controller-manager CPU limit (Max)
       cpu: 100m
+      # @schema
+      # required: false
+      # type: string
+      # @schema
       # manager.resources.limits.memory -- controller-manager Memory limit (Max)
       memory: 100Mi
+    # @schema
+    # required: false
+    # type: object
+    # @schema
+    # manager.resources.requests -- controller-manager Resources requests
     requests:
+      # @schema
+      # required: false
+      # type: string
+      # @schema
       # manager.resources.requests.cpu -- controller-manager CPU request (Min)
       cpu: 100m
+      # @schema
+      # required: false
+      # type: string
+      # @schema
       # manager.resources.requests.memory -- controller-manager Memory request (Min)
       memory: 50Mi
 
   # @schema
+  # additionalProperties: true
   # required: false
   # type: object
   # @schema

--- a/charts/k6-operator/values.yaml
+++ b/charts/k6-operator/values.yaml
@@ -1,4 +1,13 @@
+# @schema
+# required: false
+# type: object
+# @schema
 global:
+  # @schema
+  # required: false
+  # type: object
+  # @schema
+  # global.image -- Global image configuration
   image:
     # @schema
     # required: false
@@ -90,6 +99,10 @@ namespace:
   # namespace.create -- create the namespace (default: true)
   create: true
 
+# @schema
+# required: false
+# type: object
+# @schema
 prometheus:
   # @schema
   # required: false
@@ -171,6 +184,11 @@ authProxy:
   # authProxy.containerSecurityContext -- A security context defines privileges and access control settings for the container.
   containerSecurityContext: {}
 
+# @schema
+# required: false
+# type: object
+# @schema
+# manager -- controller-manager configuration
 manager:
   # @schema
   # required: false
@@ -195,6 +213,11 @@ manager:
     # @schema
     # manager.serviceAccount.create -- create the service account (default: true)
     create: true
+  # @schema
+  # required: false
+  # type: object
+  # @schema
+  # manager.image -- controller-manager image configuration
   image:
     # @schema
     # required: false


### PR DESCRIPTION
With 3.9.0, the `values.schema.json` is created incorrectly from the `values.yaml`, therefore not allowing any extra env values from `manager.env` to be placed in there since it's requiring an object, but `env` is supposed to be an array of objects.

Should fix https://github.com/grafana/k6-operator/issues/471