### PR TITLE
Tolerations is an array and has been updated as such in the values.schema.json

### DIFF
--- a/charts/k6-operator/values.yaml
+++ b/charts/k6-operator/values.yaml
@@ -66,18 +66,18 @@ nodeSelector: {}
 # @schema
 # additionalProperties: true
 # required: false
-# type: object
+# type: array
 # @schema
-# affinity -- Affinity to be applied on all containers
-affinity: {}
+# affinity -- afinity rules to be applied on all containers
+affinity: []
 
 # @schema
 # additionalProperties: true
 # required: false
-# type: object
+# type: array
 # @schema
 # tolerations -- Tolerations to be applied on all containers
-tolerations: {}
+tolerations: []
 
 # @schema
 # required: false


### PR DESCRIPTION
Simple pull request to fix a typo.  Without this, you must use --skip-schema-validation to install the chart that uses tolerations as they're not object values; they're an array of objects.

The sample values in this project wouldn't pass validation.