### PR TITLE
CI: remove permissions from the call to helm-charts

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -47,8 +47,8 @@ jobs:
   call-update-helm-repo:
     needs:
       - generate-chart-schema
-    permissions:
-      contents: write
+    # permissions:
+    #   contents: write
     uses: grafana/helm-charts/.github/workflows/update-helm-repo.yaml@main
     with:
       charts_dir: charts


### PR DESCRIPTION
Release workflow gets the startup failure:

```
Invalid workflow file: .github/workflows/helm-release.yaml#L47
The workflow is not valid. .github/workflows/helm-release.yaml (Line: 47, Col: 3): Error calling workflow 'grafana/helm-charts/.github/workflows/update-helm-repo.yaml@main'. The nested job 'release' is requesting 'packages: write', but is only allowed 'packages: none'.
```
Failed build: https://github.com/grafana/k6-operator/actions/runs/11628556424

Permissions are being set in the helm-charts workflow:
https://github.com/grafana/helm-charts/blob/main/.github/workflows/update-helm-repo.yaml#L96

Not certain if there could there be a conflict between the two, but it doesn't make sense to set them from the calling workflow.