### PR TITLE
Revert "CI: allow bundle generation for manual dispatch"

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -69,7 +69,7 @@ jobs:
 
   bundle:
     name: "Generate bundle"
-    if: startsWith(github.ref_name, 'v') || github.event_name == "workflow_dispatch"
+    if: startsWith(github.ref_name, 'v')
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
This reverts commit b8e6e3438701d4c7b280fd10b6d5fcb01aa3038e.