### PR TITLE
Release Chart 3.10.1

### DIFF
--- a/charts/k6-operator/Chart.yaml
+++ b/charts/k6-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.0.18"
 description: A Helm chart to install the k6-operator
 name: k6-operator
-version: 3.10.0
+version: 3.10.1
 kubeVersion: ">=1.16.0-0"
 home: https://k6.io
 sources:

--- a/charts/k6-operator/README.md
+++ b/charts/k6-operator/README.md
@@ -1,6 +1,6 @@
 # k6-operator
 
-![Version: 3.10.0](https://img.shields.io/badge/Version-3.10.0-informational?style=flat-square) ![AppVersion: 0.0.18](https://img.shields.io/badge/AppVersion-0.0.18-informational?style=flat-square)
+![Version: 3.10.1](https://img.shields.io/badge/Version-3.10.1-informational?style=flat-square) ![AppVersion: 0.0.18](https://img.shields.io/badge/AppVersion-0.0.18-informational?style=flat-square)
 
 A Helm chart to install the k6-operator
 


### PR DESCRIPTION
We were having issues with the release as a consequence of trying to fix OCI changes in helm-charts. For ref.:
https://github.com/grafana/helm-charts/pull/3424

Bumping a chart as a test.