### PR TITLE
feat: allow service without authproxy

### DIFF
--- a/charts/k6-operator/templates/service.yaml
+++ b/charts/k6-operator/templates/service.yaml
@@ -9,12 +9,12 @@ metadata:
     app.kubernetes.io/component: controller
     {{- include "k6-operator.labels" . | nindent 4 }}
     {{- include "k6-operator.customLabels" . | default "" | nindent 4 }}
-    {{- with .Values.metrics.service.annotations }}
+    {{- with .Values.service.annotations }}
     {{ toYaml . | nindent 4 }}
     {{- end }}
   annotations:
     {{- include "k6-operator.customAnnotations" . | default "" | nindent 4 }}
-    {{- with .Values.metrics.service.annotations }}
+    {{- with .Values.service.annotations }}
     {{ toYaml . | nindent 4 }}
     {{- end }}
 spec:

--- a/charts/k6-operator/templates/service.yaml
+++ b/charts/k6-operator/templates/service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.authProxy.enabled }}
+{{- if or .Values.authProxy.enabled .Values.service.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -9,8 +9,14 @@ metadata:
     app.kubernetes.io/component: controller
     {{- include "k6-operator.labels" . | nindent 4 }}
     {{- include "k6-operator.customLabels" . | default "" | nindent 4 }}
+    {{- with .Values.metrics.service.annotations }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
   annotations:
     {{- include "k6-operator.customAnnotations" . | default "" | nindent 4 }}
+    {{- with .Values.metrics.service.annotations }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   ports:
   - name: https

--- a/charts/k6-operator/values.schema.json
+++ b/charts/k6-operator/values.schema.json
@@ -7,6 +7,27 @@
       "title": "affinity",
       "type": "object"
     },
+    "service": {
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "default": false,
+          "description": "service.enabled -- enables the service",
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "labels": {
+          "additionalProperties": true,
+          "description": "service.labels -- service custom labels",
+          "title": "labels",
+          "type": "object"
+        },
+        "annotations": {
+          "additionalProperties": true,
+          "description": "service.annotations -- service custom annotations",
+          "title": "labels",
+          "type": "object"
+        },
     "authProxy": {
       "additionalProperties": false,
       "properties": {

--- a/charts/k6-operator/values.schema.json
+++ b/charts/k6-operator/values.schema.json
@@ -27,7 +27,11 @@
           "description": "service.annotations -- service custom annotations",
           "title": "labels",
           "type": "object"
-        },
+        }
+      },
+      "title": "service",
+      "type": "object"
+    },
     "authProxy": {
       "additionalProperties": false,
       "properties": {

--- a/charts/k6-operator/values.yaml
+++ b/charts/k6-operator/values.yaml
@@ -115,6 +115,32 @@ prometheus:
 # required: false
 # type: object
 # @schema
+service:
+  # @schema
+  # required: false
+  # type: boolean
+  # @schema
+  # service.enabled -- enables the k6 service (default: false)
+  enabled: false
+  # @schema
+  # additionalProperties: true
+  # required: false
+  # type: object
+  # @schema
+  # service.labels -- service custom labels
+  labels: {}
+  # @schema
+  # additionalProperties: true
+  # required: false
+  # type: object
+  # @schema
+  # service.annotations -- service custom annotations
+  annotations: {}
+
+# @schema
+# required: false
+# type: object
+# @schema
 authProxy:
   # @schema
   # required: false

--- a/charts/k6-operator/values.yaml
+++ b/charts/k6-operator/values.yaml
@@ -120,8 +120,8 @@ service:
   # required: false
   # type: boolean
   # @schema
-  # service.enabled -- enables the k6 service (default: false)
-  enabled: false
+  # service.enabled -- enables the k6-operator service (default: false)
+  enabled: true
   # @schema
   # additionalProperties: true
   # required: false


### PR DESCRIPTION
I want to be able to access the service without using the authproxy.
Moreover I added the way to put some custom labels and annotations on it