### PR TITLE
CI: bump python version for helm workflows

### DIFF
--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.13.1
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.6.1

--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.13.1
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.6.1


### PR DESCRIPTION
Default ubuntu-latest runner is being bumped to 24.04:
https://github.com/actions/runner-images/issues/10636

And apparently Python should be recent enough to be installed there:
https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json

CI error:
![image](https://github.com/user-attachments/assets/758516cc-27a1-42af-91f9-601a0645c2b0)
