### PR TITLE
cloud: mark abort events with "k6" origin

### DIFF
--- a/controllers/k6_create.go
+++ b/controllers/k6_create.go
@@ -54,7 +54,7 @@ func CreateJobs(ctx context.Context, log logr.Logger, k6 *v1alpha1.TestRun, r *T
 		if v1alpha1.IsTrue(k6, v1alpha1.CloudTestRun) {
 			events := cloud.ErrorEvent(cloud.K6OperatorStartError).
 				WithDetail(fmt.Sprintf("Failed to create runner jobs: %v", err)).
-				WithAbort()
+				WithAbort(cloud.OriginK6)
 			cloud.SendTestRunEvents(r.k6CloudClient, k6.TestRunID(), log, events)
 		}
 

--- a/controllers/k6_finish.go
+++ b/controllers/k6_finish.go
@@ -56,7 +56,7 @@ func FinishJobs(ctx context.Context, log logr.Logger, k6 *v1alpha1.TestRun, r *T
 	if v1alpha1.IsTrue(k6, v1alpha1.CloudTestRun) && failed > 0 {
 		events := cloud.ErrorEvent(cloud.K6OperatorRunnerError).
 			WithDetail(msg).
-			WithAbort()
+			WithAbort(cloud.OriginK6)
 		cloud.SendTestRunEvents(r.k6CloudClient, k6.TestRunID(), log, events)
 	}
 

--- a/controllers/k6_initialize.go
+++ b/controllers/k6_initialize.go
@@ -60,7 +60,7 @@ func RunValidations(ctx context.Context, log logr.Logger, k6 *v1alpha1.TestRun, 
 			// This error won't allow to start a test so let k6 Cloud know of it
 			events := cloud.ErrorEvent(cloud.K6OperatorStartError).
 				WithDetail(fmt.Sprintf("Failed to inspect the test script: %v", err)).
-				WithAbort()
+				WithAbort(cloud.OriginK6)
 			cloud.SendTestRunEvents(r.k6CloudClient, k6.TestRunID(), log, events)
 		} else {
 			// if there is any error, we have to reflect it on the K6 manifest

--- a/controllers/k6_start.go
+++ b/controllers/k6_start.go
@@ -69,7 +69,7 @@ func StartJobs(ctx context.Context, log logr.Logger, k6 *v1alpha1.TestRun, r *Te
 				if v1alpha1.IsTrue(k6, v1alpha1.CloudTestRun) {
 					events := cloud.ErrorEvent(cloud.K6OperatorStartError).
 						WithDetail(msg).
-						WithAbort()
+						WithAbort(cloud.OriginK6)
 					cloud.SendTestRunEvents(r.k6CloudClient, k6.TestRunID(), log, events)
 				}
 			}

--- a/controllers/testrun_controller.go
+++ b/controllers/testrun_controller.go
@@ -152,7 +152,7 @@ func (r *TestRunReconciler) reconcile(ctx context.Context, req ctrl.Request, log
 					if isCloudTestRun(k6) {
 						events := cloud.ErrorEvent(cloud.K6OperatorStartError).
 							WithDetail(msg).
-							WithAbort()
+							WithAbort(cloud.OriginK6)
 						cloud.SendTestRunEvents(r.k6CloudClient, k6.TestRunID(), log, events)
 					}
 				}

--- a/pkg/cloud/types.go
+++ b/pkg/cloud/types.go
@@ -190,13 +190,13 @@ func (e *Events) WithDetail(s string) *Events {
 }
 
 // WithAbort adds abortEvent to errorEvent if it already exists.
-func (e *Events) WithAbort() *Events {
+func (e *Events) WithAbort(o Origin) *Events {
 	if len(*e) == 0 {
 		return e
 	}
 
 	if (*e)[0].EventType == errorEvent {
-		*e = append(*e, AbortEvent(OriginUser))
+		*e = append(*e, AbortEvent(o))
 	}
 	return e
 }


### PR DESCRIPTION
Previously, all abort events were marked with "user" origin, to distinguish from pure "k6" origin. "k6" here is not ideal either, as it's not precise, but perhaps, somewhat less misleading.