### PR TITLE
Replace legacy testing services

### DIFF
--- a/config/samples/k6_v1alpha1_configmap.yaml
+++ b/config/samples/k6_v1alpha1_configmap.yaml
@@ -23,7 +23,7 @@ data:
     };
 
     export default function () {
-      const result = http.get('https://test-api.k6.io/public/crocodiles/');
+      const result = http.get('https://quickpizza.grafana.com');
       check(result, {
         'http response status code is 200': result.status === 200,
       });

--- a/e2e/test.js
+++ b/e2e/test.js
@@ -9,7 +9,7 @@ export let options = {
 };
 
 export default function () {
-  const result = http.get('https://test-api.k6.io/public/crocodiles/');
+  const result = http.get('https://quickpizza.grafana.com');
   check(result, {
     'http response status code is 200': result.status === 200,
   });


### PR DESCRIPTION
Replace legacy testing services with https://quickpizza.grafana.com/ instead.