### PR TITLE
Bump Go to 1.23

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -24,6 +24,7 @@ body:
   - type: textarea
     attributes:
       label: TestRun / PrivateLoadZone YAML
+      placeholder: Paste your YAML ```with 3 backticks to include formatting```
     validations:
       required: true
   - type: input

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -25,7 +25,7 @@ jobs:
           file: Dockerfile.controller
           push: true
           build-args: |
-            GO_BUILDER_IMG=golang:1.22
+            GO_BUILDER_IMG=golang:1.23
           tags: |
             ghcr.io/grafana/k6-operator:${{ github.sha }}
 

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.23'
           cache: false
       - name: lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -47,7 +47,7 @@ jobs:
           push: true
           file: Dockerfile.controller
           build-args: |
-            GO_BUILDER_IMG=golang:1.22
+            GO_BUILDER_IMG=golang:1.23
           platforms: linux/amd64,linux/arm64
           tags: ghcr.io/grafana/k6-operator:latest,ghcr.io/grafana/k6-operator:controller-${{env.IMAGETAG}}
       - name: "Build:dockerimage"

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -7,7 +7,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.22.x]
+        go-version: [1.23.x]
         k8s_version: [1.24.1, 1.27.1, 1.30.0]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}

--- a/Dockerfile.controller
+++ b/Dockerfile.controller
@@ -1,6 +1,6 @@
 ARG GO_BUILDER_IMG
 # Build the manager binary
-FROM ${GO_BUILDER_IMG} as builder
+FROM ${GO_BUILDER_IMG} AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ CONTROLLER_GEN_VERSION=v0.16.1
 CONTROLLER_GEN=$(GOBIN)/controller-gen
 
 # Image to use for building Go
-GO_BUILDER_IMG ?= "golang:1.22"
+GO_BUILDER_IMG ?= "golang:1.23"
 # Image URL to use all building/pushing image targets
 IMG_NAME ?= ghcr.io/grafana/k6-operator
 IMG_TAG ?= latest

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/k6-operator
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/go-logr/logr v1.4.2


### PR DESCRIPTION
Required for deps update like this one:
https://github.com/grafana/k6-operator/pull/530