### PR TITLE
docs: add schema generation as a step in release

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -13,9 +13,10 @@ Current release process is rather heavy on manual interventions:
 - Update CRDs in Helm chart if needed.
 - Update k6-operator's version in `values.yaml` and bump `Chart.yaml`
 - Run `make helm-docs` to update the auto-generated documentation for the Chart
+- Run `make helm-schema` to update the schema file.
 - Commit the changes:
     ```bash
-    git add charts/k6-operator/Chart.yaml charts/k6-operator/README.md charts/k6-operator/values.yaml docs/versioning.md Makefile
+    git add charts/k6-operator/Chart.yaml charts/k6-operator/README.md charts/k6-operator/values.yaml charts/k6-operator/values.schema.json docs/versioning.md Makefile
     git commit -m 'release: update for v0.0.x'
     ```
 5. "Helm release" workflow is triggered, publishing to Helm Grafana repo.


### PR DESCRIPTION
There is a preventive measure in CI for this which stops Helm release completely if schema was not updated. But it's better not to forget about this step during regular releases!