### PR TITLE
CI: update helm release to use vault

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -58,6 +58,8 @@ jobs:
   call-update-helm-repo:
     permissions:
       packages: write
+      id-token: write
+      contents: write
     needs:
       - generate-chart-schema
     uses: grafana/helm-charts/.github/workflows/update-helm-repo.yaml@main
@@ -67,5 +69,4 @@ jobs:
       ct_configfile: charts/ct.yaml
       helm_tag_prefix: helm
     secrets:
-      github_app_id: ${{ secrets.K6_OPERATOR_HELM_RELEASE_APP_ID }}
-      github_app_pem: ${{ secrets.K6_OPERATOR_HELM_RELEASE_PEM_KEY }}
+      vault_repo_secret_name: github-app


### PR DESCRIPTION
Following the guide:
https://github.com/grafana/shared-workflows/tree/main/actions/get-vault-secrets