### PR TITLE
CI: add zizmor.yml to ignore cache-poisoning

### DIFF
--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,5 @@
+rules:
+  cache-poisoning:
+    ignore:
+      - e2e-test.yaml:30
+      - push.yaml:56


### PR DESCRIPTION
Related: PR #559 

New automated workflow for zizmor is here: https://github.com/grafana/security-github-actions/blob/main/.github/workflows/self-zizmor.yaml