### PR TITLE
Fix PLZ printer columns to have `age`

### DIFF
--- a/api/v1alpha1/privateloadzone_types.go
+++ b/api/v1alpha1/privateloadzone_types.go
@@ -49,6 +49,7 @@ type PrivateLoadZoneStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 //+kubebuilder:printcolumn:name="Registered",type="string",JSONPath=".status.conditions[0].status",description="The status of registration"
 
 // PrivateLoadZone is the Schema for the privateloadzones API

--- a/charts/k6-operator/templates/crds/plz.yaml
+++ b/charts/k6-operator/templates/crds/plz.yaml
@@ -20,6 +20,9 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     - description: The status of registration
       jsonPath: .status.conditions[0].status
       name: Registered

--- a/config/crd/bases/k6.io_privateloadzones.yaml
+++ b/config/crd/bases/k6.io_privateloadzones.yaml
@@ -15,6 +15,9 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     - description: The status of registration
       jsonPath: .status.conditions[0].status
       name: Registered


### PR DESCRIPTION
For some reason, the default `age` column disappeared with the changes in https://github.com/grafana/k6-operator/pull/558 so it's not so "default". Adding it back manually.

Issue: https://github.com/grafana/k6-operator/issues/524