### PR TITLE
Add rbac.namespaced value as an option to disable creation of cluster roles and role bindings

### DIFF
--- a/charts/k6-operator/templates/clusterRole.yaml
+++ b/charts/k6-operator/templates/clusterRole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.installClusterRBAC }}
+{{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/charts/k6-operator/templates/clusterRole.yaml
+++ b/charts/k6-operator/templates/clusterRole.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.installClusterRBAC }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -227,3 +228,4 @@ rules:
   - privateloadzones/status
   verbs:
   - get
+{{- end }}

--- a/charts/k6-operator/templates/clusterRole.yaml
+++ b/charts/k6-operator/templates/clusterRole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create }}
+{{- if not .Values.rbac.namespaced }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/charts/k6-operator/templates/clusterRoleBinding.yaml
+++ b/charts/k6-operator/templates/clusterRoleBinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.installClusterRBAC }}
+{{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/charts/k6-operator/templates/clusterRoleBinding.yaml
+++ b/charts/k6-operator/templates/clusterRoleBinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create }}
+{{- if not .Values.rbac.namespaced }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/charts/k6-operator/templates/clusterRoleBinding.yaml
+++ b/charts/k6-operator/templates/clusterRoleBinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.installClusterRBAC }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -34,4 +35,5 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "k6-operator.serviceAccountName" . }}
     namespace: {{- include "k6-operator.namespace" . -}}
+{{- end }}
 {{- end }}

--- a/charts/k6-operator/values.schema.json
+++ b/charts/k6-operator/values.schema.json
@@ -125,6 +125,12 @@
       "title": "installCRDs",
       "type": "boolean"
     },
+    "installClusterRBAC": {
+      "default": true,
+      "description": "installClusterRBAC -- Installs cluster roles and role bindings as part of the release",
+      "title": "installClusterRBAC",
+      "type": "boolean"
+    },
     "manager": {
       "additionalProperties": false,
       "properties": {

--- a/charts/k6-operator/values.schema.json
+++ b/charts/k6-operator/values.schema.json
@@ -125,11 +125,18 @@
       "title": "installCRDs",
       "type": "boolean"
     },
-    "installClusterRBAC": {
-      "default": true,
-      "description": "installClusterRBAC -- Installs cluster roles and role bindings as part of the release",
-      "title": "installClusterRBAC",
-      "type": "boolean"
+    "rbac": {
+      "additionalProperties": false,
+      "properties": {
+        "namespaced": {
+          "default": false,
+          "description": "rbac.namespaced -- If true, does not install cluster RBAC resources",
+          "title": "namespaced",
+          "type": "boolean"
+        }
+      },
+      "title": "rbac",
+      "type": "object"
     },
     "manager": {
       "additionalProperties": false,

--- a/charts/k6-operator/values.yaml
+++ b/charts/k6-operator/values.yaml
@@ -101,6 +101,13 @@ installCRDs: true
 
 # @schema
 # required: false
+# type: boolean
+# @schema
+# installClusterRBAC -- Installs cluster roles and role bindings as part of the release
+installClusterRBAC: true
+
+# @schema
+# required: false
 # type: object
 # @schema
 # namespace -- Namespace creation

--- a/charts/k6-operator/values.yaml
+++ b/charts/k6-operator/values.yaml
@@ -101,10 +101,16 @@ installCRDs: true
 
 # @schema
 # required: false
-# type: boolean
+# type: object
 # @schema
-# installClusterRBAC -- Installs cluster roles and role bindings as part of the release
-installClusterRBAC: true
+# rbac -- RBAC configuration
+rbac:
+  # @schema
+  # required: false
+  # type: boolean
+  # @schema
+  # rbac.namespaced -- If true, does not install cluster RBAC resources
+  namespaced: false
 
 # @schema
 # required: false


### PR DESCRIPTION
This change provides a value for guarding the creation of cluster roles and role bindings. For shared clusters with multiple namespaces, it may not be possible for someone to create cluster-level roles. More details in https://github.com/grafana/k6-operator/issues/574.

In such a case, in their Helm chart, they would set ...
```
"installClusterRBAC": false
```
and then manage the roles and role bindings themselves.

The alternative is to allow creating these cluster RBACs and namespaced RBACs instead.