### PR TITLE
Update Helm chart according to the latest kubebuilder changes

### DIFF
--- a/charts/k6-operator/README.md
+++ b/charts/k6-operator/README.md
@@ -25,15 +25,6 @@ Kubernetes: `>=1.16.0-0`
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity to be applied on all containers |
-| authProxy.containerSecurityContext | object | `{}` | A security context defines privileges and access control settings for the container. |
-| authProxy.enabled | bool | `true` | enables the protection of /metrics endpoint. (https://github.com/brancz/kube-rbac-proxy) |
-| authProxy.image.pullPolicy | string | `"IfNotPresent"` | pull policy for the image can be Always, Never, IfNotPresent (default: IfNotPresent) |
-| authProxy.image.registry | string | `"quay.io"` |  |
-| authProxy.image.repository | string | `"brancz/kube-rbac-proxy"` | rbac-proxy image repository |
-| authProxy.image.tag | string | `"v0.18.2"` | rbac-proxy image tag |
-| authProxy.livenessProbe | object | `{}` | Liveness probe in Probe format |
-| authProxy.readinessProbe | object | `{}` | Readiness probe in Probe format |
-| authProxy.resources | object | `{}` | rbac-proxy resource limitation/request |
 | customAnnotations | object | `{}` | Custom Annotations to be applied on all resources |
 | customLabels | object | `{}` | Custom Label to be applied on all resources |
 | fullnameOverride | string | `""` |  |
@@ -41,7 +32,7 @@ Kubernetes: `>=1.16.0-0`
 | global.image.pullSecrets | list | `[]` | Optional set of global image pull secrets |
 | global.image.registry | string | `""` | Global image registry to use if it needs to be overridden for some specific use cases (e.g local registries, custom images, ...) |
 | installCRDs | bool | `true` | Installs CRDs as part of the release |
-| manager | object | `{"containerSecurityContext":{},"env":[],"envFrom":[],"image":{"pullPolicy":"IfNotPresent","registry":"ghcr.io","repository":"grafana/k6-operator","tag":"controller-v0.0.21"},"livenessProbe":{},"podSecurityContext":{},"readinessProbe":{},"replicas":1,"resources":{"limits":{"cpu":"100m","memory":"100Mi"},"requests":{"cpu":"100m","memory":"50Mi"}},"serviceAccount":{"create":true,"name":"k6-operator-controller"}}` | controller-manager configuration |
+| manager | object | `{"containerSecurityContext":{},"env":[],"envFrom":[],"image":{"pullPolicy":"IfNotPresent","registry":"ghcr.io","repository":"grafana/k6-operator","tag":"controller-v0.0.21"},"livenessProbe":{"httpGet":{"path":"/healthz","port":8081},"initialDelaySeconds":15,"periodSeconds":20},"podSecurityContext":{},"readinessProbe":{"httpGet":{"path":"/healthz","port":8081},"initialDelaySeconds":5,"periodSeconds":10},"replicas":1,"resources":{"limits":{"cpu":"100m","memory":"100Mi"},"requests":{"cpu":"100m","memory":"50Mi"}},"serviceAccount":{"create":true,"name":"k6-operator-controller"}}` | controller-manager configuration |
 | manager.containerSecurityContext | object | `{}` | A security context defines privileges and access control settings for the container. |
 | manager.env | list | `[]` | List of environment variables to set in the controller |
 | manager.envFrom | list | `[]` | List of sources to populate environment variables in the controller |
@@ -49,9 +40,11 @@ Kubernetes: `>=1.16.0-0`
 | manager.image.pullPolicy | string | `"IfNotPresent"` | pull policy for the image possible values Always, Never, IfNotPresent (default: IfNotPresent) |
 | manager.image.repository | string | `"grafana/k6-operator"` | controller-manager image repository |
 | manager.image.tag | string | `"controller-v0.0.21"` | controller-manager image tag |
-| manager.livenessProbe | object | `{}` | Liveness probe in Probe format |
+| manager.livenessProbe | object | `{"httpGet":{"path":"/healthz","port":8081},"initialDelaySeconds":15,"periodSeconds":20}` | Liveness probe in Probe format |
+| manager.livenessProbe.httpGet | object | `{"path":"/healthz","port":8081}` | HTTP liveness probe |
 | manager.podSecurityContext | object | `{}` | A security context defines privileges and access control settings for a pod. |
-| manager.readinessProbe | object | `{}` | Readiness probe in Probe format |
+| manager.readinessProbe | object | `{"httpGet":{"path":"/healthz","port":8081},"initialDelaySeconds":5,"periodSeconds":10}` | Readiness probe in Probe format |
+| manager.readinessProbe.httpGet | object | `{"path":"/healthz","port":8081}` | HTTP readiness probe |
 | manager.replicas | int | `1` | number of controller-manager replicas (default: 1) |
 | manager.resources | object | `{"limits":{"cpu":"100m","memory":"100Mi"},"requests":{"cpu":"100m","memory":"50Mi"}}` | controller-manager Resources definition |
 | manager.resources.limits | object | `{"cpu":"100m","memory":"100Mi"}` | controller-manager Resources limits |
@@ -78,6 +71,8 @@ Kubernetes: `>=1.16.0-0`
 | nodeSelector | object | `{}` | Node Selector to be applied on all containers |
 | podAnnotations | object | `{}` | Custom Annotations to be applied on all pods |
 | podLabels | object | `{}` | Custom Label to be applied on all pods |
+| rbac | object | `{"namespaced":false}` | RBAC configuration |
+| rbac.namespaced | bool | `false` | If true, does not install cluster RBAC resources |
 | service.annotations | object | `{}` | service custom annotations |
 | service.enabled | bool | `true` | enables the k6-operator service (default: false) |
 | service.labels | object | `{}` | service custom labels |

--- a/charts/k6-operator/samples/customAnnotationsAndLabels.yaml
+++ b/charts/k6-operator/samples/customAnnotationsAndLabels.yaml
@@ -38,15 +38,6 @@ tolerations:
     operator: "Exists"
     effect: "NoSchedule"
 
-authProxy:
-  resources:
-    limits:
-      cpu: 100m
-      memory: 100Mi
-    requests:
-      cpu: 100m
-      memory: 50Mi
-
 manager:
   image:
     registry: ghcr.io

--- a/charts/k6-operator/templates/_helpers.tpl
+++ b/charts/k6-operator/templates/_helpers.tpl
@@ -103,18 +103,3 @@ Create the name of the service account to use
     {{- .Release.Namespace | indent 1 }}
   {{- end }}
 {{- end -}}
-
-
-{{- define "k6-operator.livenessProbe" -}}
-  {{- if .Values.authProxy.livenessProbe }}
-  livenessProbe:
-    {{- toYaml .Values.authProxy.livenessProbe | nindent 12 }}
-  {{- end }}
-{{- end -}}
-
-{{- define "k6-operator.readinessProbe" -}}
-  {{- if .Values.authProxy.readinessProbe }}
-  readinessProbe:
-    {{- toYaml .Values.authProxy.readinessProbe | nindent 12 }}
-  {{- end }}
-{{- end -}}

--- a/charts/k6-operator/templates/clusterRole.yaml
+++ b/charts/k6-operator/templates/clusterRole.yaml
@@ -142,27 +142,11 @@ rules:
   - get
   - patch
   - update
-{{- if .Values.authProxy.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "k6-operator.fullname" . }}-metrics-reader
-  labels:
-    {{- include "k6-operator.labels" . | nindent 4 }}
-    {{- include "k6-operator.customLabels" . | default "" | nindent 4 }}
-  annotations:
-    {{- include "k6-operator.customAnnotations" . | default "" | nindent 4 }}
-rules:
-- nonResourceURLs:
-  - /metrics
-  verbs:
-  - get
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: {{ include "k6-operator.fullname" . }}-proxy-role
+  name: {{ include "k6-operator.fullname" . }}-metrics-auth-role
   labels:
     {{- include "k6-operator.labels" . | nindent 4 }}
     {{- include "k6-operator.customLabels" . | default "" | nindent 4 }}
@@ -181,7 +165,21 @@ rules:
   - subjectaccessreviews
   verbs:
   - create
-{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "k6-operator.fullname" . }}-metrics-reader
+  labels:
+    {{- include "k6-operator.labels" . | nindent 4 }}
+    {{- include "k6-operator.customLabels" . | default "" | nindent 4 }}
+  annotations:
+    {{- include "k6-operator.customAnnotations" . | default "" | nindent 4 }}
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
 ---
 # permissions for end users to edit privateloadzones.
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/k6-operator/templates/clusterRoleBinding.yaml
+++ b/charts/k6-operator/templates/clusterRoleBinding.yaml
@@ -16,13 +16,12 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "k6-operator.serviceAccountName" . }}
-    namespace: {{- include "k6-operator.namespace" . -}}
-{{- if .Values.authProxy.enabled }}
+    namespace: {{- include "k6-operator.namespace" . }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "k6-operator.fullname" . }}-proxy-rolebinding
+  name: {{ include "k6-operator.fullname" . }}-metrics-auth-rolebinding
   labels:
     {{- include "k6-operator.customLabels" . | default "" | nindent 4 }}
   annotations:
@@ -30,10 +29,9 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "k6-operator.fullname" . }}-proxy-role
+  name: {{ include "k6-operator.fullname" . }}-metrics-auth-role
 subjects:
   - kind: ServiceAccount
     name: {{ include "k6-operator.serviceAccountName" . }}
-    namespace: {{- include "k6-operator.namespace" . -}}
-{{- end }}
+    namespace: {{- include "k6-operator.namespace" . }}
 {{- end }}

--- a/charts/k6-operator/templates/crds/testrun.yaml
+++ b/charts/k6-operator/templates/crds/testrun.yaml
@@ -774,6 +774,8 @@ spec:
                           type: string
                         name:
                           type: string
+                        restartPolicy:
+                          type: string
                         volumeMounts:
                           items:
                             properties:
@@ -1034,6 +1036,8 @@ spec:
                       runAsUser:
                         format: int64
                         type: integer
+                      seLinuxChangePolicy:
+                        type: string
                       seLinuxOptions:
                         properties:
                           level:
@@ -2715,6 +2719,8 @@ spec:
                           type: string
                         name:
                           type: string
+                        restartPolicy:
+                          type: string
                         volumeMounts:
                           items:
                             properties:
@@ -2975,6 +2981,8 @@ spec:
                       runAsUser:
                         format: int64
                         type: integer
+                      seLinuxChangePolicy:
+                        type: string
                       seLinuxOptions:
                         properties:
                           level:
@@ -4679,6 +4687,8 @@ spec:
                           type: string
                         name:
                           type: string
+                        restartPolicy:
+                          type: string
                         volumeMounts:
                           items:
                             properties:
@@ -4939,6 +4949,8 @@ spec:
                       runAsUser:
                         format: int64
                         type: integer
+                      seLinuxChangePolicy:
+                        type: string
                       seLinuxOptions:
                         properties:
                           level:

--- a/charts/k6-operator/templates/deployment.yaml
+++ b/charts/k6-operator/templates/deployment.yaml
@@ -34,14 +34,10 @@ spec:
         - name: manager
           image: "{{ .Values.global.image.registry | default .Values.manager.image.registry }}/{{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag }}"
           imagePullPolicy: {{ .Values.manager.image.pullPolicy }}
-          {{- if .Values.manager.livenessProbe }}
           livenessProbe:
             {{- toYaml .Values.manager.livenessProbe | nindent 12 }}
-          {{- end }}
-          {{- if .Values.manager.readinessProbe }}
           readinessProbe:
             {{- toYaml .Values.manager.readinessProbe | nindent 12 }}
-          {{- end }}
           resources:
             {{- toYaml .Values.manager.resources | nindent 12 }}
           {{- if .Values.manager.env }}
@@ -63,42 +59,11 @@ spec:
           command:
             - /manager
           args:
+            - --health-probe-bind-address=:8081
             {{- if gt (int .Values.manager.replicas) 1 }}
-            - --enable-leader-election
+            - --leader-elect
             {{- end }}
-            {{- if .Values.authProxy.enabled }}
-            - --metrics-addr=127.0.0.1:8080
-            {{- end }}
-        {{- if .Values.authProxy.enabled }}
-        - name: kube-rbac-proxy
-          image: "{{ .Values.global.image.registry | default .Values.authProxy.image.registry }}/{{ .Values.authProxy.image.repository }}:{{ .Values.authProxy.image.tag }}"
-          imagePullPolicy: {{ .Values.authProxy.image.pullPolicy }}
-          {{- if .Values.authProxy.resources }}
-          resources:
-            {{- toYaml .Values.authProxy.resources | nindent 12 }}
-          {{- end }}
-          {{- if .Values.authProxy.livenessProbe }}
-          livenessProbe:
-            {{- toYaml .Values.authProxy.livenessProbe | nindent 12 }}
-          {{- end }}
-          {{- if .Values.authProxy.readinessProbe }}
-          readinessProbe:
-            {{- toYaml .Values.authProxy.readinessProbe | nindent 12 }}
-          {{- end }}
-          args:
-            - --secure-listen-address=0.0.0.0:8443
-            - --upstream=http://127.0.0.1:8080/
-            - --logtostderr=true
-            - --v=10
-          {{- include "k6-operator.readinessProbe" . }}
-          ports:
-            - containerPort: 8443
-              name: https
-         {{- if .Values.authProxy.containerSecurityContext }}
-          securityContext:
-            {{- toYaml .Values.authProxy.containerSecurityContext | nindent 12 }}
-         {{- end }}
-        {{- end }}
+            - --metrics-bind-address=127.0.0.1:8080
       serviceAccountName: {{ include "k6-operator.serviceAccountName" . }}
       {{- if .Values.global.image.pullSecrets }}
       imagePullSecrets:

--- a/charts/k6-operator/templates/role.yaml
+++ b/charts/k6-operator/templates/role.yaml
@@ -11,17 +11,17 @@ metadata:
     {{- include "k6-operator.customAnnotations" . | default "" | nindent 4 }}
 rules:
 - apiGroups:
-  - ""
+    - ""
   resources:
-  - configmaps
+    - configmaps
   verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch
+    - delete
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -32,9 +32,9 @@ rules:
   - list
   - update
 - apiGroups:
-  - ""
+    - ""
   resources:
-  - events
+    - events
   verbs:
-  - create
-  - patch
+    - create
+    - patch

--- a/charts/k6-operator/templates/service.yaml
+++ b/charts/k6-operator/templates/service.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.authProxy.enabled .Values.service.enabled }}
+{{- if .Values.service.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -21,6 +21,7 @@ spec:
   ports:
   - name: https
     port: 8443
+    protocol: TCP
     targetPort: https
   selector:
     control-plane: "controller-manager"

--- a/charts/k6-operator/values.schema.json
+++ b/charts/k6-operator/values.schema.json
@@ -7,74 +7,6 @@
       "title": "affinity",
       "type": "object"
     },
-    "authProxy": {
-      "additionalProperties": false,
-      "properties": {
-        "containerSecurityContext": {
-          "additionalProperties": true,
-          "description": "authProxy.containerSecurityContext -- A security context defines privileges and access control settings for the container.",
-          "title": "containerSecurityContext",
-          "type": "object"
-        },
-        "enabled": {
-          "default": true,
-          "description": "authProxy.enabled -- enables the protection of /metrics endpoint. (https://github.com/brancz/kube-rbac-proxy)",
-          "title": "enabled",
-          "type": "boolean"
-        },
-        "image": {
-          "additionalProperties": false,
-          "properties": {
-            "pullPolicy": {
-              "default": "IfNotPresent",
-              "description": "authProxy.image.pullPolicy -- pull policy for the image can be Always, Never, IfNotPresent (default: IfNotPresent)",
-              "title": "pullPolicy",
-              "type": "string"
-            },
-            "registry": {
-              "default": "quay.io",
-              "description": "authProxy.image.registry",
-              "title": "registry",
-              "type": "string"
-            },
-            "repository": {
-              "default": "brancz/kube-rbac-proxy",
-              "description": "authProxy.image.repository -- rbac-proxy image repository",
-              "title": "repository",
-              "type": "string"
-            },
-            "tag": {
-              "default": "v0.18.2",
-              "description": "authProxy.image.tag -- rbac-proxy image tag",
-              "title": "tag",
-              "type": "string"
-            }
-          },
-          "title": "image",
-          "type": "object"
-        },
-        "livenessProbe": {
-          "additionalProperties": true,
-          "description": "authProxy.livenessProbe -- Liveness probe in Probe format",
-          "title": "livenessProbe",
-          "type": "object"
-        },
-        "readinessProbe": {
-          "additionalProperties": true,
-          "description": "authProxy.readinessProbe -- Readiness probe in Probe format",
-          "title": "readinessProbe",
-          "type": "object"
-        },
-        "resources": {
-          "additionalProperties": true,
-          "description": "authProxy.resources -- rbac-proxy resource limitation/request",
-          "title": "resources",
-          "type": "object"
-        }
-      },
-      "title": "authProxy",
-      "type": "object"
-    },
     "customAnnotations": {
       "additionalProperties": true,
       "description": "customAnnotations -- Custom Annotations to be applied on all resources",
@@ -124,19 +56,6 @@
       "description": "installCRDs -- Installs CRDs as part of the release",
       "title": "installCRDs",
       "type": "boolean"
-    },
-    "rbac": {
-      "additionalProperties": false,
-      "properties": {
-        "namespaced": {
-          "default": false,
-          "description": "rbac.namespaced -- If true, does not install cluster RBAC resources",
-          "title": "namespaced",
-          "type": "boolean"
-        }
-      },
-      "title": "rbac",
-      "type": "object"
     },
     "manager": {
       "additionalProperties": false,
@@ -193,9 +112,47 @@
         },
         "livenessProbe": {
           "additionalProperties": true,
+          "properties": {
+            "httpGet": {
+              "additionalProperties": true,
+              "properties": {
+                "path": {
+                  "default": "/healthz",
+                  "title": "path",
+                  "type": "string"
+                },
+                "port": {
+                  "default": 8081,
+                  "title": "port",
+                  "type": "integer"
+                }
+              },
+              "description": "manager.livenessProbe.httpGet -- HTTP liveness probe",
+              "title": "httpGet",
+              "type": "object",
+              "required": [
+                "path",
+                "port"
+              ]
+            },
+            "initialDelaySeconds": {
+              "default": 15,
+              "title": "initialDelaySeconds",
+              "type": "integer"
+            },
+            "periodSeconds": {
+              "default": 20,
+              "title": "periodSeconds",
+              "type": "integer"
+            }
+          },
           "description": "manager.livenessProbe -- Liveness probe in Probe format",
           "title": "livenessProbe",
-          "type": "object"
+          "type": "object",
+          "required": [
+            "initialDelaySeconds",
+            "periodSeconds"
+          ]
         },
         "podSecurityContext": {
           "additionalProperties": true,
@@ -205,9 +162,47 @@
         },
         "readinessProbe": {
           "additionalProperties": true,
+          "properties": {
+            "httpGet": {
+              "additionalProperties": true,
+              "properties": {
+                "path": {
+                  "default": "/healthz",
+                  "title": "path",
+                  "type": "string"
+                },
+                "port": {
+                  "default": 8081,
+                  "title": "port",
+                  "type": "integer"
+                }
+              },
+              "description": "manager.readinessProbe.httpGet -- HTTP readiness probe",
+              "title": "httpGet",
+              "type": "object",
+              "required": [
+                "path",
+                "port"
+              ]
+            },
+            "initialDelaySeconds": {
+              "default": 5,
+              "title": "initialDelaySeconds",
+              "type": "integer"
+            },
+            "periodSeconds": {
+              "default": 10,
+              "title": "periodSeconds",
+              "type": "integer"
+            }
+          },
           "description": "manager.readinessProbe -- Readiness probe in Probe format",
           "title": "readinessProbe",
-          "type": "object"
+          "type": "object",
+          "required": [
+            "initialDelaySeconds",
+            "periodSeconds"
+          ]
         },
         "replicas": {
           "default": 1,
@@ -400,6 +395,20 @@
       "additionalProperties": true,
       "description": "podLabels -- Custom Label to be applied on all pods",
       "title": "podLabels",
+      "type": "object"
+    },
+    "rbac": {
+      "additionalProperties": false,
+      "properties": {
+        "namespaced": {
+          "default": false,
+          "description": "rbac.namespaced -- If true, does not install cluster RBAC resources",
+          "title": "namespaced",
+          "type": "boolean"
+        }
+      },
+      "description": "rbac -- RBAC configuration",
+      "title": "rbac",
       "type": "object"
     },
     "service": {

--- a/charts/k6-operator/values.yaml
+++ b/charts/k6-operator/values.yaml
@@ -238,79 +238,6 @@ service:
 # required: false
 # type: object
 # @schema
-authProxy:
-  # @schema
-  # required: false
-  # type: boolean
-  # @schema
-  # authProxy.enabled -- enables the protection of /metrics endpoint. (https://github.com/brancz/kube-rbac-proxy)
-  enabled: true
-  # @schema
-  # required: false
-  # type: object
-  # @schema
-  image:
-    # @schema
-    # required: false
-    # type: string
-    # @schema
-    # authProxy.image.registry
-    registry: quay.io
-    # @schema
-    # required: false
-    # type: string
-    # @schema
-    # authProxy.image.repository -- rbac-proxy image repository
-    repository: brancz/kube-rbac-proxy
-    # @schema
-    # required: false
-    # type: string
-    # @schema
-    # authProxy.image.tag -- rbac-proxy image tag
-    tag: v0.18.2
-    # @schema
-    # required: false
-    # type: string
-    # @schema
-    # authProxy.image.pullPolicy -- pull policy for the image can be Always, Never, IfNotPresent (default: IfNotPresent)
-    pullPolicy: IfNotPresent
-
-  # @schema
-  # additionalProperties: true
-  # required: false
-  # type: object
-  # @schema
-  # authProxy.resources -- rbac-proxy resource limitation/request
-  resources: {}
-
-  # @schema
-  # additionalProperties: true
-  # required: false
-  # type: object
-  # @schema
-  # authProxy.livenessProbe -- Liveness probe in Probe format
-  livenessProbe: {}
-
-  # @schema
-  # additionalProperties: true
-  # required: false
-  # type: object
-  # @schema
-  # authProxy.readinessProbe -- Readiness probe in Probe format
-  readinessProbe: {}
-
-  # @schema
-  # additionalProperties: true
-  # required: false
-  # type: object
-  # @schema
-  # authProxy.containerSecurityContext -- A security context defines privileges and access control settings for the container.
-  containerSecurityContext: {}
-
-# @schema
-# required: false
-# type: object
-# @schema
 # manager -- controller-manager configuration
 manager:
   # @schema
@@ -368,20 +295,42 @@ manager:
     pullPolicy: IfNotPresent
 
   # @schema
-  # additionalProperties: true
   # required: false
   # type: object
+  # additionalProperties: true
   # @schema
   # manager.livenessProbe -- Liveness probe in Probe format
-  livenessProbe: {}
+  livenessProbe:
+    # @schema
+    # required: false
+    # type: object
+    # additionalProperties: true
+    # @schema
+    # manager.livenessProbe.httpGet -- HTTP liveness probe
+    httpGet:
+      path: /healthz
+      port: 8081
+    initialDelaySeconds: 15
+    periodSeconds: 20
 
   # @schema
-  # additionalProperties: true
   # required: false
   # type: object
+  # additionalProperties: true
   # @schema
   # manager.readinessProbe -- Readiness probe in Probe format
-  readinessProbe: {}
+  readinessProbe:
+  # @schema
+    # required: false
+    # type: object
+    # additionalProperties: true
+    # @schema
+    # manager.readinessProbe.httpGet -- HTTP readiness probe
+    httpGet:
+      path: /healthz
+      port: 8081
+    initialDelaySeconds: 5
+    periodSeconds: 10
 
   # @schema
   # required: false


### PR DESCRIPTION
Issue: https://github.com/grafana/k6-operator/issues/235

This is a follow-up on PR https://github.com/grafana/k6-operator/pull/512, to ensure that Helm chart is fully up-to-date with those changes and can be upgraded successfully.
