### PR TITLE
CI: allow setting custom chart values in Helm test workflow

### DIFF
--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -11,6 +11,11 @@ on:
   pull_request:
     branches-ignore:
       - 'release-**/bundle-update'
+  workflow_dispatch:
+    inputs:
+      helm_extra_args:
+        description: "Helm chart values that should be overriden, e.g. `--set=key=value`."
+        required: false
 
 jobs:
   test:
@@ -53,4 +58,4 @@ jobs:
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'
         run: |
-            ct install --config ./charts/ct.yaml --helm-extra-set-args "--set=namespace.create=false"
+            ct install --config ./charts/ct.yaml --helm-extra-set-args "--set=namespace.create=false ${{ github.event.inputs.helm_extra_args }}"


### PR DESCRIPTION
When there is a change both in manifests and in the code at the same time, it is possible that the chart can be tested only with a custom (not released yet) k6-operator image. In that case, it makes sense to be able to pass custom value for the image to the chart, in order for Helm test workflow to run successfully.

This PR adds manual dispatch of Helm test workflow, with an option to pass `helm_extra_args` containing a required custom value.

Case where this problem came up: https://github.com/grafana/k6-operator/pull/592