### PR TITLE
Bind metrics server on all interfaces by default, not just loopback

### DIFF
--- a/charts/k6-operator/templates/deployment.yaml
+++ b/charts/k6-operator/templates/deployment.yaml
@@ -63,7 +63,7 @@ spec:
             {{- if gt (int .Values.manager.replicas) 1 }}
             - --leader-elect
             {{- end }}
-            - --metrics-bind-address=127.0.0.1:8080
+            - --metrics-bind-address=:8080
       serviceAccountName: {{ include "k6-operator.serviceAccountName" . }}
       {{- if .Values.global.image.pullSecrets }}
       imagePullSecrets:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -61,7 +61,7 @@ spec:
         - command:
             - /manager
           args:
-            - --metrics-bind-address=127.0.0.1:8080
+            - --metrics-bind-address=:8080
             - --leader-elect
             - --health-probe-bind-address=:8081
           image: controller:latest


### PR DESCRIPTION
Only binding the metrics server to the IPv4 loopback adapter makes it impossible to scrape these metrics from outside of the controller pod.