### PR TITLE
Release Helm v3.14.1

### DIFF
--- a/charts/k6-operator/Chart.yaml
+++ b/charts/k6-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.0.22"
 description: A Helm chart to install the k6-operator
 name: k6-operator
-version: 3.14.0
+version: 3.14.1
 kubeVersion: ">=1.16.0-0"
 home: https://k6.io
 sources:

--- a/charts/k6-operator/README.md
+++ b/charts/k6-operator/README.md
@@ -1,6 +1,6 @@
 # k6-operator
 
-![Version: 3.14.0](https://img.shields.io/badge/Version-3.14.0-informational?style=flat-square) ![AppVersion: 0.0.22](https://img.shields.io/badge/AppVersion-0.0.22-informational?style=flat-square)
+![Version: 3.14.1](https://img.shields.io/badge/Version-3.14.1-informational?style=flat-square) ![AppVersion: 0.0.22](https://img.shields.io/badge/AppVersion-0.0.22-informational?style=flat-square)
 
 A Helm chart to install the k6-operator
 


### PR DESCRIPTION
This is a bug fix release for metrics endpoint:
https://github.com/grafana/k6-operator/pull/599