### PR TITLE
Helm 3.14.2: 8443 port as a default for manager metrics

### DIFF
--- a/charts/k6-operator/Chart.yaml
+++ b/charts/k6-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.0.22"
 description: A Helm chart to install the k6-operator
 name: k6-operator
-version: 3.14.1
+version: 3.14.2
 kubeVersion: ">=1.16.0-0"
 home: https://k6.io
 sources:

--- a/charts/k6-operator/README.md
+++ b/charts/k6-operator/README.md
@@ -1,6 +1,6 @@
 # k6-operator
 
-![Version: 3.14.1](https://img.shields.io/badge/Version-3.14.1-informational?style=flat-square) ![AppVersion: 0.0.22](https://img.shields.io/badge/AppVersion-0.0.22-informational?style=flat-square)
+![Version: 3.14.2](https://img.shields.io/badge/Version-3.14.2-informational?style=flat-square) ![AppVersion: 0.0.22](https://img.shields.io/badge/AppVersion-0.0.22-informational?style=flat-square)
 
 A Helm chart to install the k6-operator
 

--- a/charts/k6-operator/templates/deployment.yaml
+++ b/charts/k6-operator/templates/deployment.yaml
@@ -63,7 +63,7 @@ spec:
             {{- if gt (int .Values.manager.replicas) 1 }}
             - --leader-elect
             {{- end }}
-            - --metrics-bind-address=:8080
+            - --metrics-bind-address=:8443
       serviceAccountName: {{ include "k6-operator.serviceAccountName" . }}
       {{- if .Values.global.image.pullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
Fixes: https://github.com/grafana/k6-operator/issues/596