### PR TITLE
 `e2e` suite: small fixes and improvements and update of the default manifests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ kubebuilder-tools-*
 .vscode
 
 testbin
+
+*.env

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -34,7 +34,7 @@ kind load docker-image k6operator:foo
 docker exec -it kind-control-plane crictl images | grep k6operator
 
 # Start a suite with the custom image:
-./e2e/run-tests.sh  -i docker.io/library/k6operator:foo
+./run-tests.sh  -i docker.io/library/k6operator:foo
 ```
 
 ### GCk6 tests

--- a/e2e/latest/ClusterRole-k6-operator-metrics-auth-role.yml
+++ b/e2e/latest/ClusterRole-k6-operator-metrics-auth-role.yml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: k6-operator-proxy-role
+  name: k6-operator-metrics-auth-role
 rules:
   - apiGroups:
       - authentication.k8s.io

--- a/e2e/latest/ClusterRoleBinding-k6-operator-manager-rolebinding.yml
+++ b/e2e/latest/ClusterRoleBinding-k6-operator-manager-rolebinding.yml
@@ -1,6 +1,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: k6-operator
   name: k6-operator-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/e2e/latest/ClusterRoleBinding-k6-operator-metrics-auth-rolebinding.yml
+++ b/e2e/latest/ClusterRoleBinding-k6-operator-metrics-auth-rolebinding.yml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: k6-operator-proxy-rolebinding
+  name: k6-operator-metrics-auth-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: k6-operator-proxy-role
+  name: k6-operator-metrics-auth-role
 subjects:
   - kind: ServiceAccount
     name: k6-operator-controller

--- a/e2e/latest/Deployment-k6-operator-controller-manager.yml
+++ b/e2e/latest/Deployment-k6-operator-controller-manager.yml
@@ -2,6 +2,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: k6-operator
     control-plane: controller-manager
   name: k6-operator-controller-manager
   namespace: k6-operator-system
@@ -17,12 +19,26 @@ spec:
     spec:
       containers:
         - args:
-            - --metrics-addr=127.0.0.1:8080
-            - --enable-leader-election
+            - --metrics-bind-address=:8443
+            - --metrics-bind-address=127.0.0.1:8080
+            - --leader-elect
+            - --health-probe-bind-address=:8081
           command:
             - /manager
-          image: ghcr.io/grafana/k6-operator:controller-v0.0.19
+          image: ghcr.io/grafana/k6-operator:controller-v0.0.22
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 20
           name: manager
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
           resources:
             limits:
               cpu: 100m
@@ -30,15 +46,12 @@ spec:
             requests:
               cpu: 100m
               memory: 50Mi
-        - args:
-            - --secure-listen-address=0.0.0.0:8443
-            - --upstream=http://127.0.0.1:8080/
-            - --logtostderr=true
-            - --v=10
-          image: quay.io/brancz/kube-rbac-proxy:v0.18.2
-          name: kube-rbac-proxy
-          ports:
-            - containerPort: 8443
-              name: https
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+      securityContext:
+        runAsNonRoot: true
       serviceAccountName: k6-operator-controller
       terminationGracePeriodSeconds: 10

--- a/e2e/latest/Namespace-k6-operator-system.yml
+++ b/e2e/latest/Namespace-k6-operator-system.yml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: k6-operator
     control-plane: controller-manager
   name: k6-operator-system

--- a/e2e/latest/Role-k6-operator-leader-election-role.yml
+++ b/e2e/latest/Role-k6-operator-leader-election-role.yml
@@ -1,6 +1,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: k6-operator
   name: k6-operator-leader-election-role
   namespace: k6-operator-system
 rules:

--- a/e2e/latest/RoleBinding-k6-operator-leader-election-rolebinding.yml
+++ b/e2e/latest/RoleBinding-k6-operator-leader-election-rolebinding.yml
@@ -1,6 +1,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: k6-operator
   name: k6-operator-leader-election-rolebinding
   namespace: k6-operator-system
 roleRef:

--- a/e2e/latest/Service-k6-operator-controller-manager-metrics-service.yml
+++ b/e2e/latest/Service-k6-operator-controller-manager-metrics-service.yml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: k6-operator
     control-plane: controller-manager
   name: k6-operator-controller-manager-metrics-service
   namespace: k6-operator-system
@@ -9,6 +11,7 @@ spec:
   ports:
     - name: https
       port: 8443
-      targetPort: https
+      protocol: TCP
+      targetPort: 8443
   selector:
     control-plane: controller-manager

--- a/e2e/latest/ServiceAccount-k6-operator-controller.yml
+++ b/e2e/latest/ServiceAccount-k6-operator-controller.yml
@@ -1,5 +1,8 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: k6-operator
   name: k6-operator-controller
   namespace: k6-operator-system

--- a/e2e/latest/kustomization.yaml
+++ b/e2e/latest/kustomization.yaml
@@ -2,10 +2,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ClusterRole-k6-operator-manager-role.yml
+- ClusterRole-k6-operator-metrics-auth-role.yml
 - ClusterRole-k6-operator-metrics-reader.yml
-- ClusterRole-k6-operator-proxy-role.yml
 - ClusterRoleBinding-k6-operator-manager-rolebinding.yml
-- ClusterRoleBinding-k6-operator-proxy-rolebinding.yml
+- ClusterRoleBinding-k6-operator-metrics-auth-rolebinding.yml
 - CustomResourceDefinition-privateloadzones.k6.io.yaml
 - CustomResourceDefinition-testruns.k6.io.yaml
 - Deployment-k6-operator-controller-manager.yml


### PR DESCRIPTION
- id of the user is looked up with `id` command (for docker execution)
- addition of `-u` flag to update the manifests in `latest` without running the tests
- typos in Readme
- update of manifests in `latest`
- early sanity check if the configured Docker image exists prior to running the tests