### PR TITLE
Remove default image from PLZ definition

### DIFF
--- a/api/v1alpha1/privateloadzone_types.go
+++ b/api/v1alpha1/privateloadzone_types.go
@@ -45,7 +45,7 @@ type PrivateLoadZoneSpec struct {
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 
 	// The Docker image of the k6 runners.
-	// +kubebuilder:default="grafana/k6:latest"
+	// Default is "grafana/k6:latest", set by Grafana Cloud k6.
 	Image string `json:"image,omitempty"`
 
 	// The imagePullSecrets which should be configured for all created Pods.

--- a/config/crd/bases/k6.io_privateloadzones.yaml
+++ b/config/crd/bases/k6.io_privateloadzones.yaml
@@ -61,7 +61,6 @@ spec:
                     type: array
                 type: object
               image:
-                default: grafana/k6:latest
                 type: string
               imagePullSecrets:
                 items:

--- a/docs/crd-generated.md
+++ b/docs/crd-generated.md
@@ -114,9 +114,8 @@ PrivateLoadZoneSpec defines the desired state of PrivateLoadZone
         <td><b>image</b></td>
         <td>string</td>
         <td>
-          The Docker image of the k6 runners.<br/>
-          <br/>
-            <i>Default</i>: grafana/k6:latest<br/>
+          The Docker image of the k6 runners.
+Default is "grafana/k6:latest", set by Grafana Cloud k6.<br/>
         </td>
         <td>false</td>
       </tr><tr>


### PR DESCRIPTION
This is a requirement for Grafana Cloud k6 [UI tests](https://grafana.com/docs/grafana-cloud/testing/k6/author-run/script-editor/).

The value of the default is still true, it's `grafana/k6:latest`, but the default image for PLZ tests must be set by GCk6 side; otherwise, UI test cannot be started. 