### PR TITLE
Small fixes for e2e test suite

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -57,6 +57,11 @@ echo -n '<MY ORG TOKEN HERE>' | base64
 export CLOUD_ORG_TOKEN=... # in base64!
 ```
 
+If the cloud environment variables are present in a `stack.env` file, they can be quickly exported before running the test suite with this command:
+```sh
+export $(cat stack.env | xargs)
+```
+
 ## How to add a test
 
 Firstly, the existing tests can be used as a basis for many additional experiments. Otherwise, the skeleton for the test looks like this:

--- a/e2e/run-tests.sh
+++ b/e2e/run-tests.sh
@@ -60,11 +60,6 @@ fi
 
 echo "Using k6-operator image:" $IMAGE
 
-if ! docker pull $IMAGE ; then 
-  echo "Cannot find this image: $IMAGE"
-  exit 1
-fi
-
 # Recreate kustomization.
 
 echo "Regenerate ./latest from the bundle"
@@ -140,6 +135,7 @@ tests=(
   "testrun-watch-namespaces"
   "testrun-cloud-output"
   "testrun-simultaneous-cloud-output"
+  # volume-claim
   # "kyverno"
   # "custom-domain"
   # "browser-1"


### PR DESCRIPTION
2 small changes:
- removing Docker image check from the script.
- adding shortcut command for quickly loading `.env` files to Readme.