### PR TITLE
Add validation to confirm that parallelism is positive

### DIFF
--- a/internal/controller/testrun_controller.go
+++ b/internal/controller/testrun_controller.go
@@ -81,6 +81,12 @@ func (r *TestRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{Requeue: true}, err
 	}
 
+	if k6.Spec.Parallelism < 1 {
+		err = fmt.Errorf("Parallelism of TestRun cannot be less than 1; provided value is %d.", k6.Spec.Parallelism)
+		log.Error(err, "Stopping reconciliation.")
+		return ctrl.Result{}, err
+	}
+
 	return r.reconcile(ctx, req, log, k6)
 }
 


### PR DESCRIPTION
For `TestRun` CRD, non-positive value of `.spec.parallelism` does not make any sense and can be seen as a bug. Specifically: 
- In case of zero value, `TestRun` completes successfully but without creating any runner pod, just wasting resources on initializer and starter.
- In case of negative value, `TestRun` gets stuck, because `-1 != 0` is always true.


So this fix rejects reconciliation upon non-positive value of parallelism and returns an error. It's up to a user to fix the problem in the spec.