### PR TITLE
Add `portName` option to Helm chart

### DIFF
--- a/charts/k6-operator/README.md
+++ b/charts/k6-operator/README.md
@@ -71,6 +71,7 @@ Kubernetes: `>=1.16.0-0`
 | nodeSelector | object | `{}` | Node Selector to be applied on all containers |
 | podAnnotations | object | `{}` | Custom Annotations to be applied on all pods |
 | podLabels | object | `{}` | Custom Label to be applied on all pods |
+| portName | string | `"https"` | Name for controller-manager HTTP port |
 | rbac | object | `{"namespaced":false}` | RBAC configuration |
 | rbac.namespaced | bool | `false` | If true, does not install cluster RBAC resources |
 | service.annotations | object | `{}` | service custom annotations |

--- a/charts/k6-operator/README.md
+++ b/charts/k6-operator/README.md
@@ -71,11 +71,11 @@ Kubernetes: `>=1.16.0-0`
 | nodeSelector | object | `{}` | Node Selector to be applied on all containers |
 | podAnnotations | object | `{}` | Custom Annotations to be applied on all pods |
 | podLabels | object | `{}` | Custom Label to be applied on all pods |
-| portName | string | `"https"` | Name for controller-manager HTTP port |
 | rbac | object | `{"namespaced":false}` | RBAC configuration |
 | rbac.namespaced | bool | `false` | If true, does not install cluster RBAC resources |
 | service.annotations | object | `{}` | service custom annotations |
 | service.enabled | bool | `true` | enables the k6-operator service (default: false) |
 | service.labels | object | `{}` | service custom labels |
+| service.portName | string | `"https"` | Name for controller-manager HTTP port |
 | tolerations | list | `[]` | Tolerations to be applied on all containers |
 

--- a/charts/k6-operator/templates/deployment.yaml
+++ b/charts/k6-operator/templates/deployment.yaml
@@ -66,7 +66,7 @@ spec:
             - --metrics-bind-address=:8443
           ports:
             - containerPort: 8443
-              name: {{ include "k6-operator.portName" . }}
+              name: {{ .Values.portName }}
       serviceAccountName: {{ include "k6-operator.serviceAccountName" . }}
       {{- if .Values.global.image.pullSecrets }}
       imagePullSecrets:

--- a/charts/k6-operator/templates/deployment.yaml
+++ b/charts/k6-operator/templates/deployment.yaml
@@ -66,7 +66,7 @@ spec:
             - --metrics-bind-address=:8443
           ports:
             - containerPort: 8443
-              name: https
+              name: {{ include "k6-operator.portName" . }}
       serviceAccountName: {{ include "k6-operator.serviceAccountName" . }}
       {{- if .Values.global.image.pullSecrets }}
       imagePullSecrets:

--- a/charts/k6-operator/templates/deployment.yaml
+++ b/charts/k6-operator/templates/deployment.yaml
@@ -66,7 +66,7 @@ spec:
             - --metrics-bind-address=:8443
           ports:
             - containerPort: 8443
-              name: {{ .Values.portName }}
+              name: {{ .Values.service.portName }}
       serviceAccountName: {{ include "k6-operator.serviceAccountName" . }}
       {{- if .Values.global.image.pullSecrets }}
       imagePullSecrets:

--- a/charts/k6-operator/templates/service.yaml
+++ b/charts/k6-operator/templates/service.yaml
@@ -19,10 +19,10 @@ metadata:
     {{- end }}
 spec:
   ports:
-  - name: {{ .Values.portName }}
+  - name: {{ .Values.service.portName }}
     port: 8443
     protocol: TCP
-    targetPort: {{ .Values.portName }}
+    targetPort: {{ .Values.service.portName }}
   selector:
     control-plane: "controller-manager"
 {{- end }}

--- a/charts/k6-operator/templates/service.yaml
+++ b/charts/k6-operator/templates/service.yaml
@@ -19,10 +19,10 @@ metadata:
     {{- end }}
 spec:
   ports:
-  - name: https
+  - name: {{ include "k6-operator.portName" . }}
     port: 8443
     protocol: TCP
-    targetPort: https
+    targetPort: {{ include "k6-operator.portName" . }}
   selector:
     control-plane: "controller-manager"
 {{- end }}

--- a/charts/k6-operator/templates/service.yaml
+++ b/charts/k6-operator/templates/service.yaml
@@ -19,10 +19,10 @@ metadata:
     {{- end }}
 spec:
   ports:
-  - name: {{ include "k6-operator.portName" . }}
+  - name: {{ .Values.portName }}
     port: 8443
     protocol: TCP
-    targetPort: {{ include "k6-operator.portName" . }}
+    targetPort: {{ .Values.portName }}
   selector:
     control-plane: "controller-manager"
 {{- end }}

--- a/charts/k6-operator/values.schema.json
+++ b/charts/k6-operator/values.schema.json
@@ -397,6 +397,12 @@
       "title": "podLabels",
       "type": "object"
     },
+    "portName": {
+      "default": "https",
+      "description": "portName -- Name for controller-manager HTTP port",
+      "title": "portName",
+      "type": "string"
+    },
     "rbac": {
       "additionalProperties": false,
       "properties": {

--- a/charts/k6-operator/values.schema.json
+++ b/charts/k6-operator/values.schema.json
@@ -397,12 +397,6 @@
       "title": "podLabels",
       "type": "object"
     },
-    "portName": {
-      "default": "https",
-      "description": "portName -- Name for controller-manager HTTP port",
-      "title": "portName",
-      "type": "string"
-    },
     "rbac": {
       "additionalProperties": false,
       "properties": {
@@ -437,6 +431,12 @@
           "description": "service.labels -- service custom labels",
           "title": "labels",
           "type": "object"
+        },
+        "portName": {
+          "default": "https",
+          "description": "service.portName -- Name for controller-manager HTTP port",
+          "title": "portName",
+          "type": "string"
         }
       },
       "title": "service",

--- a/charts/k6-operator/values.yaml
+++ b/charts/k6-operator/values.yaml
@@ -11,13 +11,6 @@ nameOverride: ""
 fullnameOverride: ""
 
 # @schema
-# required: false
-# type: string
-# @schema
-# portName -- Name for controller-manager HTTP port
-portName: "https"
-
-# @schema
 # additionalProperties: true
 # required: false
 # type: object
@@ -240,6 +233,12 @@ service:
   # @schema
   # service.annotations -- service custom annotations
   annotations: {}
+  # @schema
+  # required: false
+  # type: string
+  # @schema
+  # service.portName -- Name for controller-manager HTTP port
+  portName: "https"
 
 # @schema
 # required: false

--- a/charts/k6-operator/values.yaml
+++ b/charts/k6-operator/values.yaml
@@ -11,6 +11,13 @@ nameOverride: ""
 fullnameOverride: ""
 
 # @schema
+# required: false
+# type: string
+# @schema
+# portName -- Name for controller-manager HTTP port
+portName: "https"
+
+# @schema
 # additionalProperties: true
 # required: false
 # type: object


### PR DESCRIPTION
Adds a `portName` option to the Helm chart so that the Deployment and Service port name can be configured externally.