### PR TITLE
feat: Add configurable path option for ConfigMap and VolumeClaim script sources

### DIFF
--- a/api/v1alpha1/testrun_types.go
+++ b/api/v1alpha1/testrun_types.go
@@ -17,6 +17,7 @@ package v1alpha1
 import (
 	"errors"
 	"path/filepath"
+	"strings"
 
 	"github.com/grafana/k6-operator/pkg/types"
 	corev1 "k8s.io/api/core/v1"
@@ -144,6 +145,9 @@ type K6VolumeClaim struct {
 	Name string `json:"name"`
 	// Name of the file to execute (.js or .tar), stored on the Volume.
 	File string `json:"file,omitempty"`
+	// Path specifies the directory path where the script file is located.
+	// If not specified, defaults to "/test/".
+	Path string `json:"path,omitempty"`
 	// ReadOnly shows whether the volume should be mounted as `readOnly`.
 	ReadOnly bool `json:"readOnly,omitempty"`
 }
@@ -154,6 +158,9 @@ type K6Configmap struct {
 	Name string `json:"name"`
 	// Name of the file to execute (.js or .tar), stored as a key in the ConfigMap.
 	File string `json:"file,omitempty"`
+	// Path specifies the directory path where the script file is located.
+	// If not specified, defaults to "/test/".
+	Path string `json:"path,omitempty"`
 }
 
 //TODO: cleanup pre-execution?
@@ -218,6 +225,13 @@ func (k6 TestRunSpec) ParseScript() (*types.Script, error) {
 			s.ReadOnly = spec.VolumeClaim.ReadOnly
 		}
 
+		if spec.VolumeClaim.Path != "" {
+			s.Path = spec.VolumeClaim.Path
+			if !strings.HasSuffix(s.Path, "/") {
+				s.Path += "/"
+			}
+		}
+
 		s.Type = "VolumeClaim"
 		return s, nil
 	}
@@ -227,6 +241,13 @@ func (k6 TestRunSpec) ParseScript() (*types.Script, error) {
 
 		if spec.ConfigMap.File != "" {
 			s.Filename = spec.ConfigMap.File
+		}
+
+		if spec.ConfigMap.Path != "" {
+			s.Path = spec.ConfigMap.Path
+			if !strings.HasSuffix(s.Path, "/") {
+				s.Path += "/"
+			}
 		}
 
 		s.Type = "ConfigMap"

--- a/config/crd/bases/k6.io_testruns.yaml
+++ b/config/crd/bases/k6.io_testruns.yaml
@@ -3916,6 +3916,8 @@ spec:
                         type: string
                       name:
                         type: string
+                      path:
+                        type: string
                     required:
                     - name
                     type: object
@@ -3926,6 +3928,8 @@ spec:
                       file:
                         type: string
                       name:
+                        type: string
+                      path:
                         type: string
                       readOnly:
                         type: boolean

--- a/docs/crd-generated.md
+++ b/docs/crd-generated.md
@@ -782,6 +782,14 @@ K6Configmap describes the location of the script in the ConfigMap.
           Name of the file to execute (.js or .tar), stored as a key in the ConfigMap.<br/>
         </td>
         <td>false</td>
+      </tr><tr>
+        <td><b>path</b></td>
+        <td>string</td>
+        <td>
+          Path specifies the directory path where the script file is located.
+If not specified, defaults to "/test/".<br/>
+        </td>
+        <td>false</td>
       </tr></tbody>
 </table>
 
@@ -815,6 +823,14 @@ It is mounted as a `/test` folder to all k6 Pods.<br/>
         <td>string</td>
         <td>
           Name of the file to execute (.js or .tar), stored on the Volume.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>path</b></td>
+        <td>string</td>
+        <td>
+          Path specifies the directory path where the script file is located.
+If not specified, defaults to "/test/".<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/pkg/types/script.go
+++ b/pkg/types/script.go
@@ -57,13 +57,18 @@ func (s *Script) Volume() []corev1.Volume {
 // VolumeMount creates a VolumeMount spec for the script
 func (s *Script) VolumeMount() []corev1.VolumeMount {
 
+	mountPath := s.Path
+	if mountPath == "" {
+		mountPath = "/test/"
+	}
+
 	switch s.Type {
 
 	case "VolumeClaim":
 		return []corev1.VolumeMount{
 			corev1.VolumeMount{
 				Name:      "k6-test-volume",
-				MountPath: "/test",
+				MountPath: mountPath,
 				ReadOnly:  s.ReadOnly,
 			},
 		}
@@ -72,7 +77,7 @@ func (s *Script) VolumeMount() []corev1.VolumeMount {
 		return []corev1.VolumeMount{
 			corev1.VolumeMount{
 				Name:      "k6-test-volume",
-				MountPath: "/test",
+				MountPath: mountPath,
 				ReadOnly:  true,
 			},
 		}


### PR DESCRIPTION
## Summary

This PR adds support for configurable script paths in `ConfigMap` and `VolumeClaim` script sources, addressing the limitation where these options were hardcoded to use the `/test/` directory.

## Changes

- **Added `path` field** to `K6Configmap` and `K6VolumeClaim` structs
- **Updated CRD schema** to include the new optional `path` parameter
- **Enhanced documentation** to reflect the new configuration option
- **Implemented path normalization** to ensure paths always end with `/`
- **Maintained backward compatibility** by defaulting to `/test/` when path is not specified

## Motivation

Previously, `ConfigMap` and `VolumeClaim` script sources were hardcoded to mount scripts in the `/test/` directory, which:
- Didn't match the flexible behavior of `LocalFile` option
- Caused issues when users needed custom mount paths
- Limited organizational flexibility for test scripts

## Implementation Details

- The `path` field is optional and defaults to `/test/` for backward compatibility
- Path normalization ensures consistent behavior by appending `/` if missing
- Updated both parsing logic and volume mount generation
- CRD schema and generated documentation updated accordingly

## Testing

✅ **Local testing completed** with the following scenarios:

### Test Case 1: Custom Path
```yaml
apiVersion: k6.io/v1alpha1
kind: TestRun
metadata:
  name: custom-path-test
spec:
  script:
    configMap:
      name: test-scripts
      file: load-test.js
      path: /custom/scripts  # Custom path specified
```

### Test Case 2: Default Path (Backward Compatibility)
```yaml
apiVersion: k6.io/v1alpha1
kind: TestRun
metadata:
  name: default-path-test
spec:
  script:
    configMap:
      name: test-scripts
      file: load-test.js
      # No path specified - should default to /test/
```

Both test cases completed successfully, confirming:
- Custom paths work as expected
- Backward compatibility is maintained
- No breaking changes for existing configurations

## Breaking Changes

None. This is a backward-compatible enhancement.

## Related Issues

Fixes: [Issue reference if available]

## Checklist

- [x] Code follows project conventions
- [x] CRD schema updated
- [x] Documentation updated
- [x] Backward compatibility maintained
- [x] Local testing completed
- [ ] Unit tests added/updated (if applicable)