### PR TITLE
Add cloud host value to log labels

### DIFF
--- a/internal/controller/testrun_controller.go
+++ b/internal/controller/testrun_controller.go
@@ -432,15 +432,10 @@ func (r *TestRunReconciler) ShouldAbort(ctx context.Context, k6 *v1alpha1.TestRu
 
 	status, err := cloud.GetTestRunState(r.k6CloudClient, k6.TestRunID(), log)
 	if err != nil {
-		log.Error(err, "Failed to get test run state.")
 		return false
 	}
 
-	isAborted := status.Aborted()
-
-	log.Info(fmt.Sprintf("Received test run status %v", status))
-
-	return isAborted
+	return status.Aborted()
 }
 
 func (r *TestRunReconciler) createClient(ctx context.Context, k6 *v1alpha1.TestRun, log logr.Logger) (bool, error) {

--- a/pkg/cloud/cloud_output.go
+++ b/pkg/cloud/cloud_output.go
@@ -24,8 +24,10 @@ type TestRun struct {
 	Instances         int32               `json:"instances"`
 }
 
-func NewClient(log logr.Logger, token, host string) *cloudapi.Client {
-	logger := &logrus.Logger{
+// logger is currently unused, because of logrus dependency in cloudapi.
+// This will have a re-visit during or after https://github.com/grafana/k6-operator/issues/571
+func NewClient(logger logr.Logger, token, host string) *cloudapi.Client {
+	l := &logrus.Logger{
 		Out:       os.Stdout,
 		Formatter: new(logrus.TextFormatter),
 		Hooks:     make(logrus.LevelHooks),
@@ -38,15 +40,13 @@ func NewClient(log logr.Logger, token, host string) *cloudapi.Client {
 		host = cloudConfig.Host.String
 	}
 
+	logrusLogger := l.WithFields(logrus.Fields{"k6_cloud_host": host})
+
 	// TODO: how to get the version now?
-	return cloudapi.NewClient(logger, token, host, "1.2.3", time.Duration(time.Minute))
+	return cloudapi.NewClient(logrusLogger, token, host, "1.2.3", time.Duration(time.Minute))
 }
 
 func CreateTestRun(opts InspectOutput, instances int32, host, token string, log logr.Logger) (*cloudapi.CreateTestRunResponse, error) {
-	if client == nil {
-		client = NewClient(log, token, host)
-	}
-
 	cloudConfig := cloudapi.NewConfig()
 
 	if opts.ProjectID() > 0 {


### PR DESCRIPTION
Sometimes we run GCk6 tests in different environments and such tests can be hard to debug. So adding an additional `k6_cloud_host` label to track the calls made to GCk6.