### PR TITLE
fix: reduce curl container log output to single line status

### DIFF
--- a/pkg/resources/containers/curl_start.go
+++ b/pkg/resources/containers/curl_start.go
@@ -25,7 +25,7 @@ func NewStartContainer(hostnames []string, image string, imagePullPolicy corev1.
 
 	var parts []string
 	for _, hostname := range hostnames {
-		parts = append(parts, fmt.Sprintf("curl --retry 3 -X PATCH -H 'Content-Type: application/json' http://%s/v1/status -d '%s'", net.JoinHostPort(hostname, "6565"), req))
+		parts = append(parts, fmt.Sprintf("curl --retry 3 -X PATCH -H 'Content-Type: application/json' http://%s/v1/status -d '%s' -o /dev/null -s -w '{http_code=\"%%{http_code}\"}\n'", net.JoinHostPort(hostname, "6565"), req))
 	}
 
 	return corev1.Container{

--- a/pkg/resources/containers/curl_stop.go
+++ b/pkg/resources/containers/curl_stop.go
@@ -25,7 +25,7 @@ func NewStopContainer(hostnames []string, image string, imagePullPolicy corev1.P
 
 	var parts []string
 	for _, hostname := range hostnames {
-		parts = append(parts, fmt.Sprintf("curl --retry 3 -X PATCH -H 'Content-Type: application/json' http://%s/v1/status -d '%s'", net.JoinHostPort(hostname, "6565"), req))
+		parts = append(parts, fmt.Sprintf("curl --retry 3 -X PATCH -H 'Content-Type: application/json' http://%s/v1/status -d '%s' -o /dev/null -s -w '{http_code=\"%%{http_code}\"}\n'", net.JoinHostPort(hostname, "6565"), req))
 	}
 
 	return corev1.Container{


### PR DESCRIPTION
## Summary
Reduces curl container log output from verbose multi-line format to a clean single-line status format as requested in issue #653.

## Changes
Modified curl commands in `curl_start.go` and `curl_stop.go` to include `-o /dev/null -s -w '{http_code="%{http_code}"}\n'` flags

## Before
```
❯ kubectl logs k6-curl-test-starter-bxwx6  
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   237  100   150  100    87  36443  21137 --:--:-- --:--:-- --:--:-- 79000
{"data":{"type":"status","id":"default","attributes":{"status":4,"paused":false,"vus":0,"vus-max":1,"stopped":false,"running":false,"tainted":false}}}%
```

## After
```
❯ kubectl logs k6-curl-test-starter-9j6lr  
{http_code="200"}
```

## Testing
- Verified the change works as expected with k6 curl test containers
- Log output is now concise and easier to parse while maintaining essential status information

Fixes #653