### PR TITLE
fix: set BackoffLimit to zero for starter job to prevent excessive pod creation

### DIFF
--- a/pkg/resources/jobs/starter.go
+++ b/pkg/resources/jobs/starter.go
@@ -62,6 +62,8 @@ func NewStarterJob(k6 *v1alpha1.TestRun, hostname []string) *batchv1.Job {
 		resourceRequirements = k6.GetSpec().Starter.Resources
 	}
 
+	var zero32 int32
+
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        fmt.Sprintf("%s-starter", k6.NamespacedName().Name),
@@ -70,6 +72,7 @@ func NewStarterJob(k6 *v1alpha1.TestRun, hostname []string) *batchv1.Job {
 			Annotations: starterAnnotations,
 		},
 		Spec: batchv1.JobSpec{
+			BackoffLimit: &zero32,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      starterLabels,


### PR DESCRIPTION
## Summary
Fixes #658 

Sets `BackoffLimit` to `0` for the starter job to prevent excessive pod creation on failures, aligning its behavior with the initializer and runner jobs.

## Problem
The starter job was missing a `BackoffLimit` configuration, causing it to use Kubernetes' default value of 6. This led to:
- **Excessive pod creation**: Up to 6 pods created for the same failure
- **Resource waste**: Unnecessary compute resources consumed
- **Inconsistent behavior**: Initializer and runner jobs fail immediately with `BackoffLimit: 0`, but starter retries 6 times
- **Delayed error detection**: Takes longer to identify actual issues
- **Redundant logging**: Same failure logged 6 times

Since the starter job's curl command already has `--retry 3` built-in, the job-level retries were redundant and resulted in up to 18 total attempts (6 pods × 3 curl retries) for the same failure.

## Changes
- Added `BackoffLimit: &zero32` to the starter job specification in `pkg/resources/jobs/starter.go`
- This makes the starter job behavior consistent with initializer and runner jobs, both of which already use `BackoffLimit: 0`

## Testing
- Verified that starter job now fails immediately after curl's internal retries complete
- Confirmed only one starter pod is created on failure, matching initializer/runner behavior
- No behavioral changes for successful test runs

## Impact
- **Breaking Change**: No
- **Performance**: Improved - reduces unnecessary pod creation and faster failure detection
- **Consistency**: All three job types (starter, initializer, runner) now have the same BackoffLimit policy