### PR TITLE
Fix for zizmor unsound-condition rule

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -116,7 +116,7 @@ jobs:
           git diff --cached | tee diff.file
           echo "BUNDLE_DIFF=$(wc -c < diff.file)" >> "$GITHUB_OUTPUT"
       - name: "Make PR"
-        if: ${{ steps.branch.BUNDLE_DIFF }} > 0
+        if: steps.branch.BUNDLE_DIFF > 0
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
It appears that zizmor workflow has been updated to a newer version and there is now a failing `unsound-condition` audit rule. Example in this PR:
https://github.com/grafana/k6-operator/pull/654
https://github.com/grafana/k6-operator/actions/runs/18561726897/job/53593337077?pr=654
<img width="1090" height="520" alt="image" src="https://github.com/user-attachments/assets/f0eee388-de92-4655-95cc-2f49666d4c4c" />


Fixing this here.