### PR TITLE
Gate creation of ServiceAccount resource on .Values.manager.serviceAccount.create

### DIFF
--- a/charts/k6-operator/templates/serviceAccount.yaml
+++ b/charts/k6-operator/templates/serviceAccount.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.manager.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -9,3 +10,4 @@ metadata:
     {{- include "k6-operator.customLabels" . | default "" | nindent 4 }}
   annotations:
     {{- include "k6-operator.customAnnotations" . | default "" | nindent 4 }}
+{{- end }}


### PR DESCRIPTION
Fixes #665

Before (created even when `manager.serviceAccount.create=false`:

```shell
➜  k6-operator git:(main) ✗ helm template . --set manager.serviceAccount.create=false -s templates/serviceAccount.yaml
---
# Source: k6-operator/templates/serviceAccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: k6-operator-controller
  namespace: release-name-system
  labels:
    app.kubernetes.io/component: controller
    helm.sh/chart: k6-operator-4.0.0
    app.kubernetes.io/name: k6-operator
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "1.0.0"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: k6-operator
    
  annotations:
➜  k6-operator git:(main) ✗ helm template . --set manager.serviceAccount.create=true -s templates/serviceAccount.yaml 
---
# Source: k6-operator/templates/serviceAccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: k6-operator-controller
  namespace: release-name-system
  labels:
    app.kubernetes.io/component: controller
    helm.sh/chart: k6-operator-4.0.0
    app.kubernetes.io/name: k6-operator
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "1.0.0"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: k6-operator
    
  annotations:
```

After (not created when `manager.serviceAccount.create=false`):

```shell
➜  k6-operator git:(main) ✗ helm template . --set manager.serviceAccount.create=false -s templates/serviceAccount.yaml
Error: could not find template templates/serviceAccount.yaml in chart
➜  k6-operator git:(main) ✗ helm template . --set manager.serviceAccount.create=true -s templates/serviceAccount.yaml
---
# Source: k6-operator/templates/serviceAccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: k6-operator-controller
  namespace: release-name-system
  labels:
    app.kubernetes.io/component: controller
    helm.sh/chart: k6-operator-4.0.0
    app.kubernetes.io/name: k6-operator
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "1.0.0"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: k6-operator
    
  annotations:
```