### PR TITLE
Release Helm chart 4.1.1 

### DIFF
--- a/charts/k6-operator/Chart.yaml
+++ b/charts/k6-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.1.0"
 description: A Helm chart to install the k6-operator
 name: k6-operator
-version: 4.1.0
+version: 4.1.1
 kubeVersion: ">=1.16.0-0"
 home: https://k6.io
 sources:

--- a/charts/k6-operator/README.md
+++ b/charts/k6-operator/README.md
@@ -1,6 +1,6 @@
 # k6-operator
 
-![Version: 4.1.0](https://img.shields.io/badge/Version-4.1.0-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
+![Version: 4.1.1](https://img.shields.io/badge/Version-4.1.1-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
 
 A Helm chart to install the k6-operator
 


### PR DESCRIPTION
To include fix for missing CRDs: https://github.com/grafana/k6-operator/issues/672