### PR TITLE
feat: add priorityClassName to the deployment template

### DIFF
--- a/charts/k6-operator/README.md
+++ b/charts/k6-operator/README.md
@@ -73,6 +73,7 @@ Kubernetes: `>=1.16.0-0`
 | nodeSelector | object | `{}` | Node Selector to be applied on all containers |
 | podAnnotations | object | `{}` | Custom Annotations to be applied on all pods |
 | podLabels | object | `{}` | Custom Label to be applied on all pods |
+| priorityClassName | string | `""` |  |
 | rbac | object | `{"namespaced":false}` | RBAC configuration |
 | rbac.namespaced | bool | `false` | If true, does not install cluster RBAC resources |
 | service.annotations | object | `{}` | service custom annotations |

--- a/charts/k6-operator/templates/deployment.yaml
+++ b/charts/k6-operator/templates/deployment.yaml
@@ -68,6 +68,9 @@ spec:
           ports:
             - containerPort: 8443
               name: {{ .Values.service.portName }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       serviceAccountName: {{ include "k6-operator.serviceAccountName" . }}
       {{- if .Values.global.image.pullSecrets }}
       imagePullSecrets:

--- a/charts/k6-operator/values.schema.json
+++ b/charts/k6-operator/values.schema.json
@@ -411,6 +411,11 @@
       "title": "podLabels",
       "type": "object"
     },
+    "priorityClassName": {
+      "default": "",
+      "title": "priorityClassName",
+      "type": "string"
+    },
     "rbac": {
       "additionalProperties": false,
       "properties": {

--- a/charts/k6-operator/values.yaml
+++ b/charts/k6-operator/values.yaml
@@ -69,6 +69,12 @@ customLabels: {}
 podLabels: {}
 
 # @schema
+# required: false
+# type: string
+# @schema
+priorityClassName: ""
+
+# @schema
 # additionalProperties: true
 # required: false
 # type: object


### PR DESCRIPTION
Adding priorityClassName field to a Helm chart will allow to define Pod deployment priority.
See: https://github.com/grafana/k6-operator/issues/695