### PR TITLE
feat: Fix Service labels binding error

### DIFF
--- a/charts/k6-operator/templates/service.yaml
+++ b/charts/k6-operator/templates/service.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/component: controller
     {{- include "k6-operator.labels" . | nindent 4 }}
     {{- include "k6-operator.customLabels" . | default "" | nindent 4 }}
-    {{- with .Values.service.annotations }}
+    {{- with .Values.service.labels }}
     {{ toYaml . | nindent 4 }}
     {{- end }}
   annotations:


### PR DESCRIPTION
Fixes the error binding `.Values.service.annotations` in `.metadata.labels` of `Service`.