### PR TITLE
`VolumeClaim` with relative path should be mounted as default `/test`

### DIFF
--- a/api/v1alpha1/testrun_types.go
+++ b/api/v1alpha1/testrun_types.go
@@ -222,8 +222,14 @@ func (k6 TestRunSpec) ParseScript() (*types.Script, error) {
 		s.Name = spec.VolumeClaim.Name
 		if spec.VolumeClaim.File != "" {
 			s.Path, s.Filename = filepath.Split(spec.VolumeClaim.File)
+			if !filepath.IsAbs(s.Path) {
+				// if the path is not absolute, treat this as a default case
+				s.Filename = spec.VolumeClaim.File
+				s.Path = ""
+			}
 			s.ReadOnly = spec.VolumeClaim.ReadOnly
 		}
+
 		if s.Path == "" {
 			s.Path = "/test/"
 		}

--- a/api/v1alpha1/testrun_types_test.go
+++ b/api/v1alpha1/testrun_types_test.go
@@ -1,0 +1,134 @@
+package v1alpha1
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/grafana/k6-operator/pkg/types"
+)
+
+func Test_ParseScript(t *testing.T) {
+	testCases := []struct {
+		name        string
+		expectedErr bool
+		expected    *types.Script
+		tr          *TestRunSpec
+	}{
+		{
+			"Empty script",
+			true,
+			nil,
+			&TestRunSpec{},
+		},
+		{
+			"ConfigMap",
+			false,
+			&types.Script{
+				Name:     "Test",
+				Path:     "/test/",
+				Filename: "thing.js",
+				Type:     "ConfigMap",
+			},
+
+			&TestRunSpec{
+				Script: K6Script{
+					ConfigMap: K6Configmap{
+						Name: "Test",
+						File: "thing.js",
+					},
+				},
+			},
+		},
+		{
+			"LocalFile",
+			false,
+			&types.Script{
+				Name:     "LocalFile",
+				Path:     "/custom/",
+				Filename: "my_test.js",
+				Type:     "LocalFile",
+			},
+
+			&TestRunSpec{
+				Script: K6Script{
+					LocalFile: "/custom/my_test.js",
+				},
+			},
+		},
+		{
+			"VolumeClaim default case /test/test.js",
+			false,
+			&types.Script{
+				Name:     "Test",
+				Path:     "/test/",
+				Filename: "thing.js",
+				Type:     "VolumeClaim",
+			},
+
+			&TestRunSpec{
+				Script: K6Script{
+					VolumeClaim: K6VolumeClaim{
+						Name: "Test",
+						File: "thing.js",
+					},
+				},
+			},
+		},
+		{
+			"VolumeClaim custom path /foo/test.js",
+			false,
+			&types.Script{
+				Name:     "Test",
+				Path:     "/foo/",
+				Filename: "test.js",
+				Type:     "VolumeClaim",
+			},
+
+			&TestRunSpec{
+				Script: K6Script{
+					VolumeClaim: K6VolumeClaim{
+						Name: "Test",
+						File: "/foo/test.js",
+					},
+				},
+			},
+		},
+		{
+			"VolumeClaim default case with subfolders /test/foo/test.js",
+			false,
+			&types.Script{
+				Name:     "Test",
+				Path:     "/test/",
+				Filename: "foo/test.js",
+				Type:     "VolumeClaim",
+			},
+
+			&TestRunSpec{
+				Script: K6Script{
+					VolumeClaim: K6VolumeClaim{
+						Name: "Test",
+						File: "foo/test.js",
+					},
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			script, err := testCase.tr.ParseScript()
+			if testCase.expectedErr && err == nil {
+				t.Errorf("ParseScript should have returned an error.")
+			}
+			if !testCase.expectedErr && err != nil {
+				t.Errorf("ParseScript returned unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(script, testCase.expected) {
+				t.Errorf("ParseScript failed to return expected output, got: %v, expected: %v", script, testCase.expected)
+			}
+		})
+	}
+}

--- a/pkg/resources/jobs/runner_test.go
+++ b/pkg/resources/jobs/runner_test.go
@@ -1,7 +1,6 @@
 package jobs
 
 import (
-	"errors"
 	"reflect"
 	"testing"
 
@@ -34,91 +33,6 @@ var aggregationEnvVars = []corev1.EnvVar{
 		Name:  "K6_CLOUD_METRIC_PUSH_CONCURRENCY",
 		Value: "10",
 	},
-}
-
-func TestNewScriptVolumeClaim(t *testing.T) {
-	expectedOutcome := &types.Script{
-		Name:     "Test",
-		Path:     "/test/",
-		Filename: "thing.js",
-		Type:     "VolumeClaim",
-	}
-
-	k6 := v1alpha1.TestRunSpec{
-		Script: v1alpha1.K6Script{
-			VolumeClaim: v1alpha1.K6VolumeClaim{
-				Name: "Test",
-				File: "thing.js",
-			},
-		},
-	}
-
-	script, err := k6.ParseScript()
-	if err != nil {
-		t.Errorf("NewScript with ConfigMap errored, got: %v, want: %v", err, expectedOutcome)
-	}
-	if !reflect.DeepEqual(script, expectedOutcome) {
-		t.Errorf("NewScript with VolumeClaim failed to return expected output, got: %v, expected: %v", script, expectedOutcome)
-	}
-}
-
-func TestNewScriptConfigMap(t *testing.T) {
-	expectedOutcome := &types.Script{
-		Name:     "Test",
-		Path:     "/test/",
-		Filename: "thing.js",
-		Type:     "ConfigMap",
-	}
-
-	k6 := v1alpha1.TestRunSpec{
-		Script: v1alpha1.K6Script{
-			ConfigMap: v1alpha1.K6Configmap{
-				Name: "Test",
-				File: "thing.js",
-			},
-		},
-	}
-
-	script, err := k6.ParseScript()
-	if err != nil {
-		t.Errorf("NewScript with ConfigMap errored, got: %v, want: %v", err, expectedOutcome)
-	}
-	if !reflect.DeepEqual(script, expectedOutcome) {
-		t.Errorf("NewScript with ConfigMap failed to return expected output, got: %v, expected: %v", script, expectedOutcome)
-	}
-}
-
-func TestNewScriptLocalFile(t *testing.T) {
-
-	expectedOutcome := &types.Script{
-		Name:     "LocalFile",
-		Path:     "/custom/",
-		Filename: "my_test.js",
-		Type:     "LocalFile",
-	}
-
-	k6 := v1alpha1.TestRunSpec{
-		Script: v1alpha1.K6Script{
-			LocalFile: "/custom/my_test.js",
-		},
-	}
-
-	script, err := k6.ParseScript()
-	if err != nil {
-		t.Errorf("NewScript with LocalFile errored, got: %v, want: %v", err, expectedOutcome)
-	}
-	if !reflect.DeepEqual(script, expectedOutcome) {
-		t.Errorf("NewScript with LocalFile failed to return expected output, got: %v, expected: %v", script, expectedOutcome)
-	}
-}
-
-func TestNewScriptNoScript(t *testing.T) {
-	k6 := v1alpha1.TestRunSpec{}
-
-	script, err := k6.ParseScript()
-	if err == nil && script != nil {
-		t.Errorf("Expected Error from NewScript, got: %v, want: %v", err, errors.New("configMap, VolumeClaim or LocalFile not provided in script definition"))
-	}
 }
 
 func TestNewVolumeSpecVolumeClaim(t *testing.T) {


### PR DESCRIPTION
Fixes: https://github.com/grafana/k6-operator/issues/686