### PR TITLE
Add CEL validation rule for `resources.limits` in PLZ

### DIFF
--- a/api/v1alpha1/privateloadzone_types.go
+++ b/api/v1alpha1/privateloadzone_types.go
@@ -36,6 +36,7 @@ type PrivateLoadZoneSpec struct {
 	// +kubebuilder:validation:Type=string
 	Token string `json:"token"`
 
+	// +kubebuilder:validation:XValidation:rule="has(self.limits.cpu) && has(self.limits.memory)",message="resources.limits is mandatory to register with Grafana Cloud k6"
 	Resources corev1.ResourceRequirements `json:"resources"`
 
 	// Service account name which should be associated with all created Pods.

--- a/charts/k6-operator/templates/crds/plz.yaml
+++ b/charts/k6-operator/templates/crds/plz.yaml
@@ -113,6 +113,10 @@ spec:
                       x-kubernetes-int-or-string: true
                     type: object
                 type: object
+                x-kubernetes-validations:
+                - message: resources.limits is mandatory to register with Grafana
+                    Cloud k6
+                  rule: has(self.limits.cpu) && has(self.limits.memory)
               serviceAccountName:
                 type: string
               token:

--- a/config/crd/bases/k6.io_privateloadzones.yaml
+++ b/config/crd/bases/k6.io_privateloadzones.yaml
@@ -108,6 +108,10 @@ spec:
                       x-kubernetes-int-or-string: true
                     type: object
                 type: object
+                x-kubernetes-validations:
+                - message: resources.limits is mandatory to register with Grafana
+                    Cloud k6
+                  rule: has(self.limits.cpu) && has(self.limits.memory)
               serviceAccountName:
                 type: string
               token:


### PR DESCRIPTION
Fixes: https://github.com/grafana/k6-operator/issues/661

This rule should work in any Kubernetes version, according to the [docs](https://kubernetes.io/docs/reference/using-api/cel/#cel-options-language-features-and-libraries).

Now, when one tries to create a PLZ without `resources.limits`, they'll get the following:
```sh
$ kubectl -f plz.yaml apply
The PrivateLoadZone "noticas" is invalid: spec.resources: Invalid value: "object": no such key: limits evaluating rule: resources.limits is mandatory to register with Grafana Cloud k6
```