### PR TITLE
ci(helm): add schema validation workflow

### DIFF
--- a/.github/workflows/helm-schema.yaml
+++ b/.github/workflows/helm-schema.yaml
@@ -1,0 +1,39 @@
+---
+name: Helm Schema Check
+permissions: {}
+on:
+  push:
+    branches:
+      - '**'
+    paths:
+      - 'charts/**'
+  pull_request:
+    branches-ignore:
+      - 'release-**/bundle-update'
+    paths:
+      - 'charts/**'
+
+jobs:
+  schema-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Generate Helm schema
+        run: make helm-schema
+
+      - name: Check for diff
+        run: |
+          if ! git diff --exit-code charts/k6-operator/values.schema.json; then
+            echo "::error::values.schema.json is out of date. Please run 'make helm-schema' and commit the changes."
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
Add CI check that runs `make helm-schema` and fails if values.schema.json has uncommitted changes. This prevents PRs with manual edits to the JSON schema that should be auto-generated.

## Changes
- New workflow `.github/workflows/helm-schema.yaml`
- Triggers on PRs modifying `charts/**`
- Runs `make helm-schema` and checks for diff

## Testing
Tested in my fork - workflow runs successfully:
See: https://github.com/AryanBagade/k6-operator/actions (Helm Schema Check 1st)

Closes #699