### PR TITLE
CI: use correct syntax for output vars release workflow

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -110,13 +110,14 @@ jobs:
         run: |
           cd config/default && kustomize edit set image ghcr.io/grafana/k6-operator=*:controller-${{env.IMAGETAG}} && kustomize build . > ../../bundle.yaml
       - name: "Branch"
+        id: branch
         run: |
           git checkout -b release-${{env.IMAGETAG}}/bundle-update
           git add bundle.yaml
           git diff --cached | tee diff.file
           echo "BUNDLE_DIFF=$(wc -c < diff.file)" >> "$GITHUB_OUTPUT"
       - name: "Make PR"
-        if: steps.branch.BUNDLE_DIFF > 0
+        if: steps.branch.outputs.BUNDLE_DIFF > 0
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
Hopefully, will fix this issue: https://github.com/grafana/k6-operator/issues/691