### PR TITLE
ci(helm): add schema validation check for PRs

### DIFF
--- a/.github/workflows/helm-schema.yaml
+++ b/.github/workflows/helm-schema.yaml
@@ -1,0 +1,44 @@
+---
+name: Helm Schema
+
+permissions: {}
+
+on:
+  push:
+    branches:
+      - "**"
+    paths:
+      - "charts/**"
+  pull_request:
+    branches-ignore:
+      - "release-**/bundle-update"
+    paths:
+      - "charts/**"
+
+jobs:
+  schema:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25.x"
+          cache: false
+
+      - name: Generate Helm values schema
+        run: make helm-schema
+
+      - name: Verify schema is up to date
+        run: |
+          if ! git diff --exit-code -- charts/k6-operator/values.schema.json; then
+            echo "::error::values.schema.json is not up to date. Run 'make helm-schema' and commit the result."
+            echo "---- diff ----"
+            git diff -- charts/k6-operator/values.schema.json
+            exit 1
+          fi


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                              
  - Add a CI workflow that runs `make helm-schema` and fails if `values.schema.json` has uncommitted changes                                                                                              
  - Prevents manually edited or outdated schema files from being merged
  - On failure, the diff is printed so contributors can see exactly what needs updating

  Closes #699

  ## Test plan
Tested in my fork - workflow runs successfully:
  - [x] Push a PR with a manually edited `values.schema.json` and confirm CI fails with a helpful error message
  - [x] Push a PR with a correctly generated `values.schema.json` and confirm CI passes
  - [x] Push a PR that changes `charts/` files but not `values.yaml` and confirm CI passes
