### PR TITLE
Update Go and golangci-lint versions

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -31,7 +31,7 @@ jobs:
           file: Dockerfile.controller
           push: true
           build-args: |
-            GO_BUILDER_IMG=golang:1.25
+            GO_BUILDER_IMG=golang:1.26
           tags: |
             ghcr.io/grafana/k6-operator:${{ github.sha }}
 

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -14,10 +14,10 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         with:
-          go-version: "1.25.x"
+          go-version: "1.26.x"
           cache: false
       - name: lint
         uses: golangci/golangci-lint-action@b207e52793e67a85c21e5e0e8f6b42f0c634489b
         with:
-          version: v2.4.0
+          version: v2.10.1
           args: --timeout=5m

--- a/.github/workflows/helm-schema.yaml
+++ b/.github/workflows/helm-schema.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         with:
-          go-version: "1.25.x"
+          go-version: "1.26.x"
           cache: false
 
       - name: Generate Helm values schema

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -56,7 +56,7 @@ jobs:
           push: true
           file: Dockerfile.controller
           build-args: |
-            GO_BUILDER_IMG=golang:1.25
+            GO_BUILDER_IMG=golang:1.26
           platforms: linux/amd64,linux/arm64
           tags: ghcr.io/grafana/k6-operator:latest,ghcr.io/grafana/k6-operator:controller-${{env.IMAGETAG}}
       - name: "Build:dockerimage"

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -8,7 +8,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.24.x, 1.25.x]
+        go-version: [1.25.x, 1.26.x]
         k8s_version: [1.27.1, 1.30.0, 1.34]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ SHELL = /usr/bin/env bash -o pipefail
 # Current Operator version
 VERSION ?= 1.3.1
 # Image to use for building Go
-GO_BUILDER_IMG ?= "golang:1.25"
+GO_BUILDER_IMG ?= "golang:1.26"
 # Image URL to use all building/pushing image targets
 IMG_NAME ?= ghcr.io/grafana/k6-operator
 IMG_TAG ?= latest
@@ -215,7 +215,7 @@ KUSTOMIZE_VERSION ?= v5.5.0
 CONTROLLER_TOOLS_VERSION ?= v0.19.0
 # ENVTEST_VERSION ?= latest # ref. https://github.com/kubernetes-sigs/controller-runtime/tree/main/tools/setup-envtest
 ENVTEST_VERSION ?= release-0.19
-GOLANGCI_LINT_VERSION ?= v2.4.0
+GOLANGCI_LINT_VERSION ?= v2.10.1
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.31.0
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/k6-operator
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
- Switch go.mod to Go 1.25
- GA and images to Go 1.26
- Update golangci-lint to 2.10.1