### PR TITLE
e2e: create a map of tests, inject `PROJECT_ID`

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -16,6 +16,8 @@ It is assumed that there is a Kubernetes cluster to execute the tests in and `ku
 
 The [vcluster](https://www.vcluster.com/install) CLI should also be installed as it is currently a dependency of xk6-environment. See the [issue](https://github.com/grafana/xk6-environment/issues/1) for details.
 
+The list of all e2e tests is maintained in the machine-readable [tests.yaml](./tests.yaml).
+
 ## Under the hood
 
 `run-tests.sh` does not build any images but it can be customized with custom image and a tag for k6-operator image. At the same time the script uses the current k6-operator folder to get manifests. So for example, in order to test a certain branch, one has to switch to that branch locally first.
@@ -42,24 +44,18 @@ docker exec -it kind-control-plane crictl images | grep k6operator
 In order to execute Grafana Cloud k6 tests (cloud output or, in the future, PLZ), one is expected to create environment variables containing the tokens for authentication:
 
 ```sh
-# personal GCk6 token
+# Personal GCk6 token
 # Encode your token with base64:
 echo -n '<MY PERSONAL TOKEN HERE>' | base64
 
-# The output can contain an additional newline in terminal so remove it, then export it like this:
-export CLOUD_TOKEN=... # in base64!
-```
-
-A similar process will be needed for an organization token (required for PLZ):
-```sh
+# An organization token (required for PLZ):
 echo -n '<MY ORG TOKEN HERE>' | base64
-
-export CLOUD_ORG_TOKEN=... # in base64!
 ```
 
-If the cloud environment variables are present in a `stack.env` file, they can be quickly exported before running the test suite with this command:
+`run-tests.sh` reads an `e2e/.env` file containing these values. You can create it on your own or use a `sample.env` and populate it with values for your stack:
 ```sh
-export $(cat stack.env | xargs)
+cp e2e/sample.env e2e/.env
+nano e2e/.env
 ```
 
 #### Git ignore changes to `Secret.yaml`
@@ -72,7 +68,7 @@ git update-index --skip-worktree e2e/testrun-cloud-output/manifests/secret.yaml 
 
 ## How to add a test
 
-Firstly, the existing tests can be used as a basis for many additional experiments. Otherwise, the skeleton for the test looks like this:
+Firstly, the existing tests can be used as a basis for many additional experiments. The skeleton for the test looks like this:
 
 ```sh
 new-test

--- a/e2e/run-tests.sh
+++ b/e2e/run-tests.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# Source .env for CLOUD_TOKEN, PROJECT_ID, etc.
+if [ -f "$(dirname "$0")/.env" ]; then
+  set -a
+  source "$(dirname "$0")/.env"
+  set +a
+fi
+
 show_help() {
   echo "Usage: $(basename $0) [-h] [-t GHCR_IMAGE_TAG] [-i IMAGE] [-p TEST_NAME]"
   echo "Options:"
@@ -14,13 +21,15 @@ show_help() {
 exec_test() {
   echo "Executing test $TEST_NAME"
   cd $TEST_NAME/manifests
-  for f in *.yaml; do envsubst '$CLOUD_TOKEN' < $f > out && mv out $f; done
+  for f in *.yaml; do envsubst '$CLOUD_TOKEN $PROJECT_ID' < $f > out && mv out $f; done
   cd .. # back to $TEST_NAME
   if ! ../k6 run test.js ; then
     echo "Test $TEST_NAME failed"
+    git checkout -- manifests/
     cd .. # back to root
     exit 1
   fi
+  git checkout -- manifests/
   cd .. # back to root
 }
 
@@ -119,29 +128,7 @@ if [ ! -z "${TEST_NAME}" ]; then
   exit 0
 fi
 
-tests=(
-  "basic-testrun-1"
-  "basic-testrun-4"
-  "testrun-cleanup"
-  "testrun-archive"
-  "init-container-volume"
-  "multifile"
-  "error-stage"
-  "invalid-arguments"
-  "testrun-simultaneous"
-  "testrun-watch-namespace"
-  "testrun-watch-namespaces"
-  "testrun-cloud-output"
-  "testrun-simultaneous-cloud-output"
-  "initializer-disabled"
-  # volume-claim
-  # "kyverno"
-  # "custom-domain"
-  # "browser-1"
-  # cloud abort
-  # plz
-  # ipv6
-  )
+tests=($(grep '^  - name:' tests.yaml | awk '{print $3}'))
 
 for folder in "${tests[@]}"; do
     TEST_NAME=$folder

--- a/e2e/sample.env
+++ b/e2e/sample.env
@@ -1,0 +1,4 @@
+# my Grafana Cloud k6 stack
+CLOUD_TOKEN=<insert base64 value here>
+CLOUD_ORG_TOKEN=<insert base64 value here>
+PROJECT_ID=<insert the project you want to put your cloud tests in>

--- a/e2e/testrun-cloud-output/manifests/configmap.yaml
+++ b/e2e/testrun-cloud-output/manifests/configmap.yaml
@@ -19,7 +19,7 @@ data:
         { duration: '5s', target: 0 },
       ],
       cloud: {
-        projectID: 3756871,
+        projectID: $PROJECT_ID,
         name: 'k6-operator-e2e-cloud-output'
       }
     };

--- a/e2e/testrun-simultaneous-cloud-output/manifests/configmap.yaml
+++ b/e2e/testrun-simultaneous-cloud-output/manifests/configmap.yaml
@@ -14,7 +14,7 @@ data:
         { target: 0, duration: '30s' },
       ],
       cloud: {
-        projectID: 3756871,
+        projectID: $PROJECT_ID,
         name: 'k6-operator-e2e-simultaneous-cloud-output'
       }
     };

--- a/e2e/tests.yaml
+++ b/e2e/tests.yaml
@@ -1,0 +1,113 @@
+# Source of truth for active e2e tests and their source dependencies.
+# Used by run-tests.sh (test list) and the select-e2e-tests agent (mapping).
+
+global_triggers:
+  # Changes to these paths trigger ALL tests.
+  - "api/v1alpha1/testrun_types.go"
+  - "internal/controller/testrun_controller.go"
+  - "internal/controller/common.go"
+  - "config/crd/"
+  - "config/default/"
+  - "config/manager/"
+  - "config/rbac/"
+  - "e2e/run-tests.sh"
+  - "e2e/latest/"
+
+skip_patterns:
+  # Changes ONLY to these paths trigger no tests.
+  - "*.md"
+  - "LICENSE"
+  - ".github/"
+  - ".claude/"
+  - "charts/"
+
+tests:
+  - name: basic-testrun-1
+    source_patterns:
+      - "internal/controller/k6_initialize.go"
+      - "pkg/resources/jobs/initializer.go"
+      - "pkg/types/script.go"
+
+  - name: basic-testrun-4
+    source_patterns:
+      - "internal/controller/k6_initialize.go"
+      - "internal/controller/k6_create.go"
+      - "internal/controller/k6_start.go"
+      - "pkg/resources/jobs/runner.go"
+      - "pkg/resources/jobs/starter.go"
+      - "pkg/resources/jobs/helpers.go"
+      - "pkg/resources/containers/curl_start.go"
+      - "pkg/segmentation/"
+      - "pkg/types/script.go"
+
+  - name: testrun-cleanup
+    source_patterns:
+      - "internal/controller/k6_finish.go"
+      - "internal/controller/k6_stop.go"
+      - "internal/controller/k6_stopped_jobs.go"
+      - "pkg/resources/jobs/stopper.go"
+      - "pkg/resources/containers/curl_stop.go"
+
+  - name: testrun-archive
+    source_patterns:
+      - "pkg/resources/jobs/initializer.go"
+
+  - name: init-container-volume
+    source_patterns:
+      - "internal/controller/k6_create.go"
+      - "pkg/resources/jobs/runner.go"
+      - "pkg/resources/jobs/helpers.go"
+      - "pkg/types/script.go"
+
+  - name: multifile
+    source_patterns:
+      - "internal/controller/k6_create.go"
+      - "pkg/segmentation/"
+      - "pkg/types/script.go"
+
+  - name: error-stage
+    source_patterns:
+      - "internal/controller/k6_initialize.go"
+      - "internal/controller/k6_finish.go"
+
+  - name: invalid-arguments
+    source_patterns:
+      - "pkg/types/k6cli.go"
+
+  - name: testrun-simultaneous
+    source_patterns:
+      - "internal/controller/k6_start.go"
+      - "pkg/resources/containers/curl_start.go"
+
+  - name: testrun-watch-namespace
+    source_patterns:
+      - "internal/controller/"
+
+  - name: testrun-watch-namespaces
+    source_patterns:
+      - "internal/controller/"
+
+  - name: testrun-cloud-output
+    source_patterns:
+      - "pkg/cloud/"
+      - "pkg/types/k6cli.go"
+      - "pkg/resources/jobs/runner.go"
+    requires_env: [CLOUD_TOKEN, PROJECT_ID]
+
+  - name: testrun-simultaneous-cloud-output
+    source_patterns:
+      - "pkg/cloud/"
+    requires_env: [CLOUD_TOKEN, PROJECT_ID]
+
+  - name: initializer-disabled
+    source_patterns:
+      - "internal/controller/k6_initialize.go"
+      - "pkg/resources/jobs/initializer.go"
+
+  # - name: volume-claim
+  # - name: kyverno
+  # - name: custom-domain
+  # - name: browser-1
+  # - name: cloud-abort
+  # - name: plz
+  # - name: ipv6


### PR DESCRIPTION
Changes:
- Adding a machine-readable map of e2e tests. 
- `run-tests.sh` reading `e2e/.env` on its own.
- `PROJECT_ID` as part of `.env`