### PR TITLE
Improve unit tests

### DIFF
--- a/api/v1alpha1/testrun_types.go
+++ b/api/v1alpha1/testrun_types.go
@@ -32,6 +32,9 @@ type PodMetadata struct {
 }
 
 type Pod struct {
+	// Disabled is supported only for initializer pod, and it allows to skip initializer execution.
+	// Use it when absolutely certain k6 script is valid and set up correctly in Kubernetes.
+	// It is ignored by cloud output test runs, as they depend on initializer.
 	// +optional
 	// +kubebuilder:default=false
 	Disabled                     bool                              `json:"disabled,omitempty"`

--- a/api/v1alpha1/testrun_types_test.go
+++ b/api/v1alpha1/testrun_types_test.go
@@ -40,28 +40,29 @@ func Test_ParseScript(t *testing.T) {
 			},
 		},
 		{
-			"LocalFile",
-			false,
-			&types.Script{
-				Name:     "LocalFile",
-				Path:     "/custom/",
-				Filename: "my_test.js",
-				Type:     "LocalFile",
-			},
-
-			&TestRunSpec{
-				Script: K6Script{
-					LocalFile: "/custom/my_test.js",
-				},
-			},
-		},
-		{
-			"VolumeClaim default case /test/test.js",
+			"ConfigMap with no file defaults to test.js",
 			false,
 			&types.Script{
 				Name:     "Test",
 				Path:     "/test/",
-				Filename: "thing.js",
+				Filename: "test.js",
+				Type:     "ConfigMap",
+			},
+			&TestRunSpec{
+				Script: K6Script{
+					ConfigMap: K6Configmap{
+						Name: "Test",
+					},
+				},
+			},
+		},
+		{
+			"VolumeClaim: default case /test/script.js",
+			false,
+			&types.Script{
+				Name:     "Test",
+				Path:     "/test/",
+				Filename: "script.js",
 				Type:     "VolumeClaim",
 			},
 
@@ -69,13 +70,13 @@ func Test_ParseScript(t *testing.T) {
 				Script: K6Script{
 					VolumeClaim: K6VolumeClaim{
 						Name: "Test",
-						File: "thing.js",
+						File: "script.js",
 					},
 				},
 			},
 		},
 		{
-			"VolumeClaim custom path /foo/test.js",
+			"VolumeClaim: custom absolute path",
 			false,
 			&types.Script{
 				Name:     "Test",
@@ -94,7 +95,7 @@ func Test_ParseScript(t *testing.T) {
 			},
 		},
 		{
-			"VolumeClaim default case with subfolders /test/foo/test.js",
+			"VolumeClaim: with relative path",
 			false,
 			&types.Script{
 				Name:     "Test",
@@ -109,6 +110,74 @@ func Test_ParseScript(t *testing.T) {
 						Name: "Test",
 						File: "foo/test.js",
 					},
+				},
+			},
+		},
+		{
+			"VolumeClaim with no file defaults to /test/test.js",
+			false,
+			&types.Script{
+				Name:     "Test",
+				Path:     "/test/",
+				Filename: "test.js",
+				Type:     "VolumeClaim",
+			},
+			&TestRunSpec{
+				Script: K6Script{
+					VolumeClaim: K6VolumeClaim{
+						Name: "Test",
+					},
+				},
+			},
+		},
+		{
+			"VolumeClaim ReadOnly flag",
+			false,
+			&types.Script{
+				Name:     "Test",
+				Path:     "/test/",
+				Filename: "script.js",
+				Type:     "VolumeClaim",
+				ReadOnly: true,
+			},
+			&TestRunSpec{
+				Script: K6Script{
+					VolumeClaim: K6VolumeClaim{
+						Name:     "Test",
+						File:     "script.js",
+						ReadOnly: true,
+					},
+				},
+			},
+		},
+		{
+			"LocalFile",
+			false,
+			&types.Script{
+				Name:     "LocalFile",
+				Path:     "/custom/",
+				Filename: "my_test.js",
+				Type:     "LocalFile",
+			},
+
+			&TestRunSpec{
+				Script: K6Script{
+					LocalFile: "/custom/my_test.js",
+				},
+			},
+		},
+		{
+			"LocalFile at root path",
+			false,
+			&types.Script{
+				Name:     "LocalFile",
+				Path:     "/",
+				Filename: "test.js",
+				Type:     "LocalFile",
+			},
+			&TestRunSpec{
+				Script: K6Script{
+					LocalFile: "/test.js",
 				},
 			},
 		},

--- a/docs/crd-generated.md
+++ b/docs/crd-generated.md
@@ -17211,7 +17211,9 @@ are set, the values in SecurityContext take precedence.<br/>
         <td><b>disabled</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          Disabled is supported only for initializer pod, and it allows to skip initializer execution.
+Use it when absolutely certain k6 script is valid and set up correctly in Kubernetes.
+It is ignored by cloud output test runs, as they depend on initializer.<br/>
           <br/>
             <i>Default</i>: false<br/>
         </td>
@@ -26173,7 +26175,9 @@ are set, the values in SecurityContext take precedence.<br/>
         <td><b>disabled</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          Disabled is supported only for initializer pod, and it allows to skip initializer execution.
+Use it when absolutely certain k6 script is valid and set up correctly in Kubernetes.
+It is ignored by cloud output test runs, as they depend on initializer.<br/>
           <br/>
             <i>Default</i>: false<br/>
         </td>
@@ -35157,7 +35161,9 @@ are set, the values in SecurityContext take precedence.<br/>
         <td><b>disabled</b></td>
         <td>boolean</td>
         <td>
-          <br/>
+          Disabled is supported only for initializer pod, and it allows to skip initializer execution.
+Use it when absolutely certain k6 script is valid and set up correctly in Kubernetes.
+It is ignored by cloud output test runs, as they depend on initializer.<br/>
           <br/>
             <i>Default</i>: false<br/>
         </td>

--- a/pkg/resources/containers/curl_test.go
+++ b/pkg/resources/containers/curl_test.go
@@ -1,0 +1,119 @@
+package containers
+
+import (
+	"testing"
+
+	deep "github.com/go-test/deep"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func Test_NewStartContainer(t *testing.T) {
+	startPayload := `{"data":{"attributes":{"paused":false,"stopped":false},"id":"default","type":"status"}}`
+
+	tests := []struct {
+		name     string
+		hosts    []string
+		image    string
+		expected corev1.Container
+	}{
+		{
+			name:  "1 hostname",
+			hosts: []string{"test-1"},
+			image: "curlimages/curl:latest",
+			expected: corev1.Container{
+				Name:            "k6-curl",
+				Image:           "curlimages/curl:latest",
+				ImagePullPolicy: corev1.PullNever,
+				Env:             []corev1.EnvVar{{Name: "K6_VAR", Value: "val"}},
+				Resources:       corev1.ResourceRequirements{},
+				Command: []string{"sh", "-c",
+					"curl --retry 3 -X PATCH -H 'Content-Type: application/json' http://test-1:6565/v1/status -d '" + startPayload + "' -s -w '\n{\"http_code\":%{http_code},\"time_total\":%{time_total},\"time_starttransfer\":%{time_starttransfer},\"url\":\"%{url_effective}\",\"remote_ip\":\"%{remote_ip}\",\"errormsg\":\"%{errormsg}\"}'",
+				},
+				SecurityContext: &corev1.SecurityContext{},
+			},
+		},
+		{
+			name:  "N hostnames",
+			hosts: []string{"test-1", "test-2"},
+			image: "curlimages/curl:latest",
+			expected: corev1.Container{
+				Name:            "k6-curl",
+				Image:           "curlimages/curl:latest",
+				ImagePullPolicy: corev1.PullNever,
+				Env:             []corev1.EnvVar{{Name: "K6_VAR", Value: "val"}},
+				Resources:       corev1.ResourceRequirements{},
+				Command: []string{"sh", "-c",
+					"curl --retry 3 -X PATCH -H 'Content-Type: application/json' http://test-1:6565/v1/status -d '" + startPayload + "' -s -w '\n{\"http_code\":%{http_code},\"time_total\":%{time_total},\"time_starttransfer\":%{time_starttransfer},\"url\":\"%{url_effective}\",\"remote_ip\":\"%{remote_ip}\",\"errormsg\":\"%{errormsg}\"}';" +
+						"curl --retry 3 -X PATCH -H 'Content-Type: application/json' http://test-2:6565/v1/status -d '" + startPayload + "' -s -w '\n{\"http_code\":%{http_code},\"time_total\":%{time_total},\"time_starttransfer\":%{time_starttransfer},\"url\":\"%{url_effective}\",\"remote_ip\":\"%{remote_ip}\",\"errormsg\":\"%{errormsg}\"}'",
+				},
+				SecurityContext: &corev1.SecurityContext{},
+			},
+		},
+	}
+
+	env := []corev1.EnvVar{{Name: "K6_VAR", Value: "val"}}
+	cmd := []string{"sh", "-c"}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NewStartContainer(tt.hosts, tt.image, corev1.PullNever, cmd, env, corev1.SecurityContext{}, corev1.ResourceRequirements{})
+			if diff := deep.Equal(got, tt.expected); diff != nil {
+				t.Errorf("NewStartContainer() diff: %s", diff)
+			}
+		})
+	}
+}
+
+func Test_NewStopContainer(t *testing.T) {
+	stopPayload := `{"data":{"attributes":{"paused":false,"stopped":true},"id":"default","type":"status"}}`
+
+	tests := []struct {
+		name     string
+		hosts    []string
+		image    string
+		expected corev1.Container
+	}{
+		{
+			name:  "1 hostname",
+			hosts: []string{"test-1"},
+			image: "curlimages/curl:latest",
+			expected: corev1.Container{
+				Name:            "k6-curl",
+				Image:           "curlimages/curl:latest",
+				ImagePullPolicy: corev1.PullNever,
+				Resources:       corev1.ResourceRequirements{},
+				Command: []string{"sh", "-c",
+					"curl --retry 3 -X PATCH -H 'Content-Type: application/json' http://test-1:6565/v1/status -d '" + stopPayload + "' -s -w '\n{\"http_code\":%{http_code},\"time_total\":%{time_total},\"time_starttransfer\":%{time_starttransfer},\"url\":\"%{url_effective}\",\"remote_ip\":\"%{remote_ip}\",\"errormsg\":\"%{errormsg}\"}'",
+				},
+				SecurityContext: &corev1.SecurityContext{},
+			},
+		},
+		{
+			name:  "N hostnames",
+			hosts: []string{"test-1", "test-2"},
+			image: "curlimages/curl:latest",
+			expected: corev1.Container{
+				Name:            "k6-curl",
+				Image:           "curlimages/curl:latest",
+				ImagePullPolicy: corev1.PullNever,
+				Resources:       corev1.ResourceRequirements{},
+				Command: []string{"sh", "-c",
+					"curl --retry 3 -X PATCH -H 'Content-Type: application/json' http://test-1:6565/v1/status -d '" + stopPayload + "' -s -w '\n{\"http_code\":%{http_code},\"time_total\":%{time_total},\"time_starttransfer\":%{time_starttransfer},\"url\":\"%{url_effective}\",\"remote_ip\":\"%{remote_ip}\",\"errormsg\":\"%{errormsg}\"}';" +
+						"curl --retry 3 -X PATCH -H 'Content-Type: application/json' http://test-2:6565/v1/status -d '" + stopPayload + "' -s -w '\n{\"http_code\":%{http_code},\"time_total\":%{time_total},\"time_starttransfer\":%{time_starttransfer},\"url\":\"%{url_effective}\",\"remote_ip\":\"%{remote_ip}\",\"errormsg\":\"%{errormsg}\"}'",
+				},
+				SecurityContext: &corev1.SecurityContext{},
+			},
+		},
+	}
+
+	cmd := []string{"sh", "-c"}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NewStopContainer(tt.hosts, tt.image, corev1.PullNever, cmd, nil, corev1.SecurityContext{}, corev1.ResourceRequirements{})
+			if diff := deep.Equal(got, tt.expected); diff != nil {
+				t.Errorf("NewStopContainer() diff: %s", diff)
+			}
+		})
+	}
+}

--- a/pkg/resources/containers/s3_test.go
+++ b/pkg/resources/containers/s3_test.go
@@ -1,0 +1,52 @@
+package containers
+
+import (
+	"testing"
+
+	deep "github.com/go-test/deep"
+	"github.com/grafana/k6-operator/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func Test_NewS3InitContainer(t *testing.T) {
+	vm := corev1.VolumeMount{Name: "archive-volume", MountPath: "/test"}
+
+	tests := []struct {
+		name     string
+		uri      string
+		image    string
+		expected v1alpha1.InitContainer
+	}{
+		{
+			name:  "valid S3 URI",
+			uri:   "https://bucket.s3.amazonaws.com/archive.tar",
+			image: "curlimages/curl:latest",
+			expected: v1alpha1.InitContainer{
+				Name:         "archive-download",
+				Image:        "curlimages/curl:latest",
+				Command:      []string{"sh", "-c", "curl -X GET -L 'https://bucket.s3.amazonaws.com/archive.tar' > /test/archive.tar ; ls -l /test"},
+				VolumeMounts: []corev1.VolumeMount{vm},
+			},
+		},
+		{
+			name:  "empty URI is not validated here",
+			uri:   "",
+			image: "image:latest",
+			expected: v1alpha1.InitContainer{
+				Name:         "archive-download",
+				Image:        "image:latest",
+				Command:      []string{"sh", "-c", "curl -X GET -L '' > /test/archive.tar ; ls -l /test"},
+				VolumeMounts: []corev1.VolumeMount{vm},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NewS3InitContainer(tt.uri, tt.image, vm)
+			if diff := deep.Equal(got, tt.expected); diff != nil {
+				t.Errorf("NewS3InitContainer() diff: %s", diff)
+			}
+		})
+	}
+}

--- a/pkg/resources/jobs/runner_test.go
+++ b/pkg/resources/jobs/runner_test.go
@@ -366,8 +366,67 @@ func Test_NewRunnerJob(t *testing.T) {
 			},
 		},
 		{
-			name: "PLZ test run",
+			name: "priority class name",
 			setupTestRun: func(k6 *v1alpha1.TestRun) {
+				k6.Spec.Runner.PriorityClassName = "high-priority"
+			},
+			setupExpectedJob: func(j *batchv1.Job) {
+				j.Spec.Template.Spec.PriorityClassName = "high-priority"
+			},
+		},
+		{
+			name: "custom image",
+			setupTestRun: func(k6 *v1alpha1.TestRun) {
+				k6.Spec.Runner.Image = "grafana/k6:0.50.0"
+			},
+			setupExpectedJob: func(j *batchv1.Job) {
+				j.Spec.Template.Spec.Containers[0].Image = "grafana/k6:0.50.0"
+			},
+		},
+		{
+			name: "runner env vars",
+			setupTestRun: func(k6 *v1alpha1.TestRun) {
+				k6.Spec.Runner.Env = []corev1.EnvVar{
+					{Name: "MY_VAR", Value: "my-value"},
+					{Name: "CONN_STR", Value: "host=db;port=5432;user=k6&timeout=30s"},
+				}
+			},
+			setupExpectedJob: func(j *batchv1.Job) {
+				j.Spec.Template.Spec.Containers[0].Env = []corev1.EnvVar{
+					{Name: "MY_VAR", Value: "my-value"},
+					{Name: "CONN_STR", Value: "host=db;port=5432;user=k6&timeout=30s"},
+				}
+			},
+		},
+		{
+			name: "parallelism with segmentation",
+			setupTestRun: func(k6 *v1alpha1.TestRun) {
+				k6.Spec.Parallelism = 3
+			},
+			setupExpectedJob: func(j *batchv1.Job) {
+				j.Spec.Template.Spec.Containers[0].Command = []string{
+					"k6", "run", "--quiet",
+					"--execution-segment=0:1/3",
+					"--execution-segment-sequence=0,1/3,2/3,1",
+					"/test/test.js", "--address=0.0.0.0:6565", "--paused",
+					"--tag", "instance_id=1", "--tag", "job_name=test-1",
+				}
+			},
+		},
+		{
+			name: "separate triggers anti-affinity",
+			setupTestRun: func(k6 *v1alpha1.TestRun) {
+				k6.Spec.Separate = true
+			},
+			setupExpectedJob: func(j *batchv1.Job) {
+				j.Spec.Template.Spec.Affinity = newAntiAffinity()
+			},
+		},
+		{
+			name:      "PLZ test run",
+			tokenInfo: cloud.NewTokenInfo("plz-token-secret", "test"),
+			setupTestRun: func(k6 *v1alpha1.TestRun) {
+				k6.Spec.TestRunID = "plz-run-123"
 				k6.Spec.Runner.EnvFrom = envFromConfigMap("env")
 				k6.Spec.Runner.ImagePullPolicy = corev1.PullNever
 				k6.Status.Conditions = []metav1.Condition{
@@ -386,15 +445,18 @@ func Test_NewRunnerJob(t *testing.T) {
 					"--tag", "instance_id=1", "--tag", "job_name=test-1",
 					"--no-setup", "--no-teardown", "--linger",
 				}
-			},
-		},
-		{
-			name: "priority class name",
-			setupTestRun: func(k6 *v1alpha1.TestRun) {
-				k6.Spec.Runner.PriorityClassName = "high-priority"
-			},
-			setupExpectedJob: func(j *batchv1.Job) {
-				j.Spec.Template.Spec.PriorityClassName = "high-priority"
+				j.Spec.Template.Spec.Containers[0].Env = []corev1.EnvVar{
+					{Name: "K6_CLOUD_PUSH_REF_ID", Value: "plz-run-123"},
+					{
+						Name: "K6_CLOUD_TOKEN",
+						ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "plz-token-secret"},
+								Key:                  "token",
+							},
+						},
+					},
+				}
 			},
 		},
 	}

--- a/pkg/resources/jobs/runner_test.go
+++ b/pkg/resources/jobs/runner_test.go
@@ -1,7 +1,6 @@
 package jobs
 
 import (
-	"reflect"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -35,70 +34,406 @@ var aggregationEnvVars = []corev1.EnvVar{
 	},
 }
 
-func TestNewVolumeSpecVolumeClaim(t *testing.T) {
-	expectedOutcome := []corev1.Volume{
-		corev1.Volume{
-			Name: "k6-test-volume",
-			VolumeSource: corev1.VolumeSource{
-				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-					ClaimName: "test",
+func defaultScript() *types.Script {
+	return &types.Script{
+		Name:     "test",
+		Filename: "thing.js",
+		Type:     "ConfigMap",
+	}
+}
+
+func defaultLabels() map[string]string {
+	return map[string]string{
+		"app":    "k6",
+		"k6_cr":  "test",
+		"runner": "true",
+	}
+}
+
+func customAnnotations() map[string]string {
+	return map[string]string{
+		"awesomeAnnotation": "dope",
+	}
+}
+
+// Note: base TestRun in tests includes custom labels and annotations
+func defaultTestRun() *v1alpha1.TestRun {
+	return &v1alpha1.TestRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+		Spec: v1alpha1.TestRunSpec{
+			Script: v1alpha1.K6Script{
+				ConfigMap: v1alpha1.K6Configmap{
+					Name: "test",
+					File: "test.js",
+				},
+			},
+			Runner: v1alpha1.Pod{
+				Metadata: v1alpha1.PodMetadata{
+					Labels:      map[string]string{"label1": "awesome"},
+					Annotations: map[string]string{"awesomeAnnotation": "dope"},
 				},
 			},
 		},
 	}
+}
 
-	script := &types.Script{
-		Type: "VolumeClaim",
-		Name: "test",
-	}
+func defaultExpectedJob(script *types.Script) *batchv1.Job {
+	var zero int64 = 0
+	automountServiceAccountToken := true
 
-	volumeSpec := script.Volume()
-	if !reflect.DeepEqual(volumeSpec, expectedOutcome) {
-		t.Errorf("VolumeSpec wasn't as expected, got: %v, expected: %v", volumeSpec, expectedOutcome)
+	jobLabels := defaultLabels()
+	jobLabels["label1"] = "awesome"
+	podLabels := defaultLabels()
+	podLabels["label1"] = "awesome"
+
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test-1",
+			Namespace:   "test",
+			Labels:      jobLabels,
+			Annotations: customAnnotations(),
+		},
+		Spec: batchv1.JobSpec{
+			BackoffLimit: new(int32),
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels:      podLabels,
+					Annotations: customAnnotations(),
+				},
+				Spec: corev1.PodSpec{
+					Hostname:                     "test-1",
+					RestartPolicy:                corev1.RestartPolicyNever,
+					SecurityContext:              &corev1.PodSecurityContext{},
+					Affinity:                     nil,
+					NodeSelector:                 nil,
+					Tolerations:                  nil,
+					TopologySpreadConstraints:    nil,
+					ServiceAccountName:           "default",
+					AutomountServiceAccountToken: &automountServiceAccountToken,
+					Containers: []corev1.Container{{
+						Image:           "grafana/k6:latest",
+						ImagePullPolicy: "",
+						Name:            "k6",
+						Command:         []string{"k6", "run", "--quiet", "/test/test.js", "--address=0.0.0.0:6565", "--paused", "--tag", "instance_id=1", "--tag", "job_name=test-1"},
+						Env:             []corev1.EnvVar{},
+						Resources:       corev1.ResourceRequirements{},
+						VolumeMounts:    script.VolumeMount(),
+						Ports:           []corev1.ContainerPort{{ContainerPort: 6565}},
+						LivenessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								HTTPGet: &corev1.HTTPGetAction{
+									Path:   "/v1/status",
+									Port:   intstr.IntOrString{IntVal: 6565},
+									Scheme: "HTTP",
+								},
+							},
+						},
+						ReadinessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								HTTPGet: &corev1.HTTPGetAction{
+									Path:   "/v1/status",
+									Port:   intstr.IntOrString{IntVal: 6565},
+									Scheme: "HTTP",
+								},
+							},
+						},
+						SecurityContext: &corev1.SecurityContext{},
+					}},
+					TerminationGracePeriodSeconds: &zero,
+					Volumes:                       script.Volume(),
+				},
+			},
+		},
 	}
 }
 
-func TestNewVolumeSpecConfigMap(t *testing.T) {
-	expectedOutcome := []corev1.Volume{
-		corev1.Volume{
-			Name: "k6-test-volume",
-			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: "test",
+func envFromConfigMap(name string) []corev1.EnvFromSource {
+	return []corev1.EnvFromSource{
+		{
+			ConfigMapRef: &corev1.ConfigMapEnvSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: name,
+				},
+			},
+		},
+	}
+}
+
+func Test_NewRunnerJob(t *testing.T) {
+	tests := []struct {
+		name             string
+		script           *types.Script
+		tokenInfo        *cloud.TokenInfo
+		setupTestRun     func(*v1alpha1.TestRun)
+		setupExpectedJob func(*batchv1.Job)
+	}{
+		{
+			name:             "base",
+			setupTestRun:     func(k6 *v1alpha1.TestRun) {},
+			setupExpectedJob: func(j *batchv1.Job) {},
+		},
+		{
+			name: "passing basic fields",
+			setupTestRun: func(k6 *v1alpha1.TestRun) {
+				k6.Spec.Runner.ServiceAccountName = "test"
+				k6.Spec.Runner.EnvFrom = envFromConfigMap("env")
+				k6.Spec.Runner.ImagePullPolicy = corev1.PullNever
+			},
+			setupExpectedJob: func(j *batchv1.Job) {
+				j.Spec.Template.Spec.ServiceAccountName = "test"
+				j.Spec.Template.Spec.Containers[0].ImagePullPolicy = corev1.PullNever
+				j.Spec.Template.Spec.Containers[0].EnvFrom = envFromConfigMap("env")
+			},
+		},
+		{
+			name: "modifying k6 command: noisy",
+			setupTestRun: func(k6 *v1alpha1.TestRun) {
+				k6.Spec.Quiet = "false"
+			},
+			setupExpectedJob: func(j *batchv1.Job) {
+				j.Spec.Template.Spec.Containers[0].Command = []string{
+					"k6", "run", "/test/test.js", "--address=0.0.0.0:6565", "--paused",
+					"--tag", "instance_id=1", "--tag", "job_name=test-1",
+				}
+			},
+		},
+		{
+			name: "modifying k6 command: unpaused",
+			setupTestRun: func(k6 *v1alpha1.TestRun) {
+				k6.Spec.Paused = "false"
+			},
+			setupExpectedJob: func(j *batchv1.Job) {
+				j.Spec.Template.Spec.Containers[0].Command = []string{
+					"k6", "run", "--quiet", "/test/test.js", "--address=0.0.0.0:6565",
+					"--tag", "instance_id=1", "--tag", "job_name=test-1",
+				}
+			},
+		},
+		{
+			name: "modifying k6 command: arguments",
+			setupTestRun: func(k6 *v1alpha1.TestRun) {
+				k6.Spec.Arguments = "--cool-thing"
+			},
+			setupExpectedJob: func(j *batchv1.Job) {
+				j.Spec.Template.Spec.Containers[0].Command = []string{
+					"k6", "run", "--quiet", "--cool-thing", "/test/test.js", "--address=0.0.0.0:6565", "--paused",
+					"--tag", "instance_id=1", "--tag", "job_name=test-1",
+				}
+			},
+		},
+		{
+			name: "istio scuttle",
+			setupTestRun: func(k6 *v1alpha1.TestRun) {
+				k6.Spec.Scuttle = v1alpha1.K6Scuttle{Enabled: "true"}
+			},
+			setupExpectedJob: func(j *batchv1.Job) {
+				j.Spec.Template.Spec.Containers[0].Command = []string{
+					"scuttle", "k6", "run", "--quiet", "/test/test.js", "--address=0.0.0.0:6565", "--paused",
+					"--tag", "instance_id=1", "--tag", "job_name=test-1",
+				}
+				j.Spec.Template.Spec.Containers[0].Env = []corev1.EnvVar{
+					{Name: "ENVOY_ADMIN_API", Value: "http://127.0.0.1:15000"},
+					{Name: "ISTIO_QUIT_API", Value: "http://127.0.0.1:15020"},
+					{Name: "WAIT_FOR_ENVOY_TIMEOUT", Value: "15"},
+				}
+			},
+		},
+		{
+			name:      "cloud output mode",
+			tokenInfo: cloud.NewTokenInfo("", "").InjectValue("token"),
+			setupTestRun: func(k6 *v1alpha1.TestRun) {
+				k6.Spec.Arguments = "--out cloud"
+				k6.Spec.Runner.Metadata.Labels = nil
+				k6.Status.TestRunID = "testrunid"
+				k6.Status.AggregationVars = "2|5s|3s|10s|10"
+			},
+			setupExpectedJob: func(j *batchv1.Job) {
+				j.Labels = defaultLabels()
+				j.Spec.Template.Labels = defaultLabels()
+				j.Spec.Template.Spec.Containers[0].Command = []string{
+					"k6", "run", "--quiet", "--out", "cloud", "/test/test.js", "--address=0.0.0.0:6565", "--paused",
+					"--tag", "instance_id=1", "--tag", "job_name=test-1",
+				}
+				j.Spec.Template.Spec.Containers[0].Env = append(aggregationEnvVars,
+					corev1.EnvVar{Name: "K6_CLOUD_PUSH_REF_ID", Value: "testrunid"},
+					corev1.EnvVar{Name: "K6_CLOUD_TOKEN", Value: "token"},
+				)
+			},
+		},
+		{
+			name: "LocalFile",
+			script: &types.Script{
+				Name:     "test",
+				Filename: "/test/test.js",
+				Type:     "LocalFile",
+			},
+			setupTestRun: func(k6 *v1alpha1.TestRun) {
+				k6.Spec.Script = v1alpha1.K6Script{LocalFile: "/test/test.js"}
+				k6.Spec.Scuttle = v1alpha1.K6Scuttle{Enabled: "false"}
+			},
+			setupExpectedJob: func(j *batchv1.Job) {
+				localScript := &types.Script{
+					Name:     "test",
+					Filename: "/test/test.js",
+					Type:     "LocalFile",
+				}
+				j.Spec.Template.Spec.Containers[0].Command = []string{
+					"sh", "-c",
+					"if [ ! -f /test/test.js ]; then echo \"LocalFile not found exiting...\"; exit 1; fi;\nk6 run --quiet /test/test.js --address=0.0.0.0:6565 --paused --tag instance_id=1 --tag job_name=test-1",
+				}
+				j.Spec.Template.Spec.Containers[0].VolumeMounts = localScript.VolumeMount()
+				j.Spec.Template.Spec.Volumes = localScript.Volume()
+			},
+		},
+		{
+			name: "init container",
+			setupTestRun: func(k6 *v1alpha1.TestRun) {
+				k6.Spec.Runner.EnvFrom = envFromConfigMap("env")
+				k6.Spec.Runner.ImagePullPolicy = corev1.PullNever
+				k6.Spec.Runner.InitContainers = []v1alpha1.InitContainer{
+					{
+						Image:   "busybox:1.28",
+						Command: []string{"sh", "-c", "cat /test/test.js"},
+						EnvFrom: envFromConfigMap("env"),
 					},
-				},
+				}
+			},
+			setupExpectedJob: func(j *batchv1.Job) {
+				script := defaultScript()
+				j.Spec.Template.Spec.Containers[0].ImagePullPolicy = corev1.PullNever
+				j.Spec.Template.Spec.Containers[0].EnvFrom = envFromConfigMap("env")
+				j.Spec.Template.Spec.InitContainers = []corev1.Container{
+					{
+						Name:            "k6-init-0",
+						Image:           "busybox:1.28",
+						Command:         []string{"sh", "-c", "cat /test/test.js"},
+						VolumeMounts:    script.VolumeMount(),
+						ImagePullPolicy: corev1.PullNever,
+						EnvFrom:         envFromConfigMap("env"),
+						SecurityContext: &corev1.SecurityContext{},
+					},
+				}
+			},
+		},
+		{
+			name: "init container with volumes",
+			setupTestRun: func(k6 *v1alpha1.TestRun) {
+				k6.Spec.Runner.EnvFrom = envFromConfigMap("env")
+				k6.Spec.Runner.ImagePullPolicy = corev1.PullNever
+				extraMount := corev1.VolumeMount{Name: "k6-test-volume", MountPath: "/test/location"}
+				k6.Spec.Runner.InitContainers = []v1alpha1.InitContainer{
+					{
+						Image:        "busybox:1.28",
+						Command:      []string{"sh", "-c", "cat /test/test.js"},
+						EnvFrom:      envFromConfigMap("env"),
+						VolumeMounts: []corev1.VolumeMount{extraMount},
+					},
+				}
+				k6.Spec.Runner.Volumes = []corev1.Volume{
+					{
+						Name:         "k6-test-volume",
+						VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+					},
+				}
+				k6.Spec.Runner.VolumeMounts = []corev1.VolumeMount{extraMount}
+			},
+			setupExpectedJob: func(j *batchv1.Job) {
+				script := defaultScript()
+				extraMount := corev1.VolumeMount{Name: "k6-test-volume", MountPath: "/test/location"}
+				expectedVolumeMounts := append(script.VolumeMount(), extraMount)
+
+				j.Spec.Template.Spec.Containers[0].ImagePullPolicy = corev1.PullNever
+				j.Spec.Template.Spec.Containers[0].EnvFrom = envFromConfigMap("env")
+				j.Spec.Template.Spec.Containers[0].VolumeMounts = expectedVolumeMounts
+				j.Spec.Template.Spec.InitContainers = []corev1.Container{
+					{
+						Name:            "k6-init-0",
+						Image:           "busybox:1.28",
+						Command:         []string{"sh", "-c", "cat /test/test.js"},
+						VolumeMounts:    expectedVolumeMounts,
+						ImagePullPolicy: corev1.PullNever,
+						EnvFrom:         envFromConfigMap("env"),
+						SecurityContext: &corev1.SecurityContext{},
+					},
+				}
+				j.Spec.Template.Spec.Volumes = append(script.Volume(), corev1.Volume{
+					Name:         "k6-test-volume",
+					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+				})
+			},
+		},
+		{
+			name: "PLZ test run",
+			setupTestRun: func(k6 *v1alpha1.TestRun) {
+				k6.Spec.Runner.EnvFrom = envFromConfigMap("env")
+				k6.Spec.Runner.ImagePullPolicy = corev1.PullNever
+				k6.Status.Conditions = []metav1.Condition{
+					{
+						Type:               v1alpha1.CloudPLZTestRun,
+						Status:             metav1.ConditionTrue,
+						LastTransitionTime: metav1.Now(),
+					},
+				}
+			},
+			setupExpectedJob: func(j *batchv1.Job) {
+				j.Spec.Template.Spec.Containers[0].ImagePullPolicy = corev1.PullNever
+				j.Spec.Template.Spec.Containers[0].EnvFrom = envFromConfigMap("env")
+				j.Spec.Template.Spec.Containers[0].Command = []string{
+					"k6", "run", "--quiet", "/test/test.js", "--address=0.0.0.0:6565", "--paused",
+					"--tag", "instance_id=1", "--tag", "job_name=test-1",
+					"--no-setup", "--no-teardown", "--linger",
+				}
+			},
+		},
+		{
+			name: "priority class name",
+			setupTestRun: func(k6 *v1alpha1.TestRun) {
+				k6.Spec.Runner.PriorityClassName = "high-priority"
+			},
+			setupExpectedJob: func(j *batchv1.Job) {
+				j.Spec.Template.Spec.PriorityClassName = "high-priority"
 			},
 		},
 	}
 
-	script := &types.Script{
-		Type: "ConfigMap",
-		Name: "test",
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			script := tt.script
+			if script == nil {
+				script = defaultScript()
+			}
 
-	volumeSpec := script.Volume()
-	if !reflect.DeepEqual(volumeSpec, expectedOutcome) {
-		t.Errorf("VolumeSpec wasn't as expected, got: %v, expected: %v", volumeSpec, expectedOutcome)
+			k6 := defaultTestRun()
+			if tt.setupTestRun != nil {
+				tt.setupTestRun(k6)
+			}
+
+			expected := defaultExpectedJob(script)
+			if tt.setupExpectedJob != nil {
+				tt.setupExpectedJob(expected)
+			}
+
+			tokenInfo := tt.tokenInfo
+			if tokenInfo == nil {
+				tokenInfo = cloud.NewTokenInfo("", "")
+			}
+
+			job, err := NewRunnerJob(k6, 1, tokenInfo)
+			if err != nil {
+				t.Fatalf("NewRunnerJob errored: %v", err)
+			}
+			if diff := deep.Equal(job, expected); diff != nil {
+				t.Errorf("NewRunnerJob diff: %s", diff)
+			}
+		})
 	}
 }
 
-func TestNewVolumeSpecNoType(t *testing.T) {
-	expectedOutcome := []corev1.Volume{}
-
-	script := &types.Script{
-		Name: "test",
-	}
-
-	volumeSpec := script.Volume()
-	if !reflect.DeepEqual(volumeSpec, expectedOutcome) {
-		t.Errorf("VolumeSpec wasn't as expected, got: %v, expected: %v", volumeSpec, expectedOutcome)
-	}
-
-}
-
-func TestNewAntiAffinity(t *testing.T) {
-	expectedOutcome := &corev1.Affinity{
+func Test_NewAntiAffinity(t *testing.T) {
+	expected := &corev1.Affinity{
 		PodAntiAffinity: &corev1.PodAntiAffinity{
 			RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
 				{
@@ -107,16 +442,12 @@ func TestNewAntiAffinity(t *testing.T) {
 							{
 								Key:      "app",
 								Operator: "In",
-								Values: []string{
-									"k6",
-								},
+								Values:   []string{"k6"},
 							},
 							{
 								Key:      "runner",
 								Operator: "In",
-								Values: []string{
-									"true",
-								},
+								Values:   []string{"true"},
 							},
 						},
 					},
@@ -126,27 +457,22 @@ func TestNewAntiAffinity(t *testing.T) {
 		},
 	}
 
-	antiAffinity := newAntiAffinity()
-
-	if !reflect.DeepEqual(antiAffinity, expectedOutcome) {
-		t.Errorf("AntiAffinity returning unexpected values, got: %v, expected: %v", antiAffinity, expectedOutcome)
+	if diff := deep.Equal(newAntiAffinity(), expected); diff != nil {
+		t.Errorf("newAntiAffinity() diff: %s", diff)
 	}
 }
 
-func TestNewRunnerService(t *testing.T) {
-	expectedOutcome := &corev1.Service{
+func Test_NewRunnerService(t *testing.T) {
+	serviceLabels := defaultLabels()
+	serviceLabels["label1"] = "awesome"
+
+	expected := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-service-1",
-			Namespace: "test",
-			Labels: map[string]string{
-				"app":    "k6",
-				"k6_cr":  "test",
-				"runner": "true",
-				"label1": "awesome",
-			},
-			Annotations: map[string]string{
-				"awesomeAnnotation": "dope",
-			}},
+			Name:        "test-service-1",
+			Namespace:   "test",
+			Labels:      serviceLabels,
+			Annotations: customAnnotations(),
+		},
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{{
 				Name:     "http-api",
@@ -159,1625 +485,13 @@ func TestNewRunnerService(t *testing.T) {
 		},
 	}
 
-	k6 := &v1alpha1.TestRun{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: "test",
-		},
-		Spec: v1alpha1.TestRunSpec{
-			Runner: v1alpha1.Pod{
-				Metadata: v1alpha1.PodMetadata{
-					Labels: map[string]string{
-						"label1": "awesome",
-					},
-					Annotations: map[string]string{
-						"awesomeAnnotation": "dope",
-					},
-				},
-			},
-		},
-	}
+	k6 := defaultTestRun()
 
 	service, err := NewRunnerService(k6, 1)
 	if err != nil {
-		t.Errorf("NewRunnerService with errored, got: %v, want: %v", err, expectedOutcome)
+		t.Fatalf("NewRunnerService errored: %v", err)
 	}
-	if diff := deep.Equal(service, expectedOutcome); diff != nil {
-		t.Errorf("NewRunnerService returned unexpected data, diff: %s", diff)
-	}
-}
-
-func TestNewRunnerJob(t *testing.T) {
-	script := &types.Script{
-		Name:     "test",
-		Filename: "thing.js",
-		Type:     "ConfigMap",
-	}
-
-	var zero int64 = 0
-	automountServiceAccountToken := true
-
-	expectedLabels := map[string]string{
-		"app":    "k6",
-		"k6_cr":  "test",
-		"runner": "true",
-		"label1": "awesome",
-	}
-
-	expectedOutcome := &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-1",
-			Namespace: "test",
-			Labels:    expectedLabels,
-			Annotations: map[string]string{
-				"awesomeAnnotation": "dope",
-			},
-		},
-		Spec: batchv1.JobSpec{
-			BackoffLimit: new(int32),
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: expectedLabels,
-					Annotations: map[string]string{
-						"awesomeAnnotation": "dope",
-					},
-				},
-				Spec: corev1.PodSpec{
-					Hostname:                     "test-1",
-					RestartPolicy:                corev1.RestartPolicyNever,
-					SecurityContext:              &corev1.PodSecurityContext{},
-					Affinity:                     nil,
-					NodeSelector:                 nil,
-					Tolerations:                  nil,
-					TopologySpreadConstraints:    nil,
-					ServiceAccountName:           "default",
-					AutomountServiceAccountToken: &automountServiceAccountToken,
-					Containers: []corev1.Container{{
-						Image:           "grafana/k6:latest",
-						ImagePullPolicy: corev1.PullNever,
-						Name:            "k6",
-						Command:         []string{"k6", "run", "--quiet", "/test/test.js", "--address=0.0.0.0:6565", "--paused", "--tag", "instance_id=1", "--tag", "job_name=test-1"},
-						Env:             []corev1.EnvVar{},
-						Resources:       corev1.ResourceRequirements{},
-						VolumeMounts:    script.VolumeMount(),
-						Ports:           []corev1.ContainerPort{{ContainerPort: 6565}},
-						EnvFrom: []corev1.EnvFromSource{
-							{
-								ConfigMapRef: &corev1.ConfigMapEnvSource{
-									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "env",
-									},
-								},
-							},
-						},
-						LivenessProbe: &corev1.Probe{
-							ProbeHandler: corev1.ProbeHandler{
-								HTTPGet: &corev1.HTTPGetAction{
-									Path:   "/v1/status",
-									Port:   intstr.IntOrString{IntVal: 6565},
-									Scheme: "HTTP",
-								},
-							},
-						},
-						ReadinessProbe: &corev1.Probe{
-							ProbeHandler: corev1.ProbeHandler{
-								HTTPGet: &corev1.HTTPGetAction{
-									Path:   "/v1/status",
-									Port:   intstr.IntOrString{IntVal: 6565},
-									Scheme: "HTTP",
-								},
-							},
-						},
-						SecurityContext: &corev1.SecurityContext{},
-					}},
-					TerminationGracePeriodSeconds: &zero,
-					Volumes:                       script.Volume(),
-				},
-			},
-		},
-	}
-	k6 := &v1alpha1.TestRun{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: "test",
-		},
-		Spec: v1alpha1.TestRunSpec{
-			Script: v1alpha1.K6Script{
-				ConfigMap: v1alpha1.K6Configmap{
-					Name: "test",
-					File: "test.js",
-				},
-			},
-			Runner: v1alpha1.Pod{
-				Metadata: v1alpha1.PodMetadata{
-					Labels: map[string]string{
-						"label1": "awesome",
-					},
-					Annotations: map[string]string{
-						"awesomeAnnotation": "dope",
-					},
-				},
-				EnvFrom: []corev1.EnvFromSource{
-					{
-						ConfigMapRef: &corev1.ConfigMapEnvSource{
-							LocalObjectReference: corev1.LocalObjectReference{
-								Name: "env",
-							},
-						},
-					},
-				},
-				ImagePullPolicy: corev1.PullNever,
-			},
-		},
-	}
-
-	job, err := NewRunnerJob(k6, 1, cloud.NewTokenInfo("", ""))
-	if err != nil {
-		t.Errorf("NewRunnerJob errored, got: %v", err)
-	}
-	if diff := deep.Equal(job, expectedOutcome); diff != nil {
-		t.Errorf("NewRunnerJob returned unexpected data, diff: %s", diff)
-	}
-}
-
-func TestNewRunnerJobNoisy(t *testing.T) {
-	script := &types.Script{
-		Name:     "test",
-		Filename: "thing.js",
-		Type:     "ConfigMap",
-	}
-
-	var zero int64 = 0
-	automountServiceAccountToken := true
-
-	expectedLabels := map[string]string{
-		"app":    "k6",
-		"k6_cr":  "test",
-		"runner": "true",
-		"label1": "awesome",
-	}
-
-	expectedOutcome := &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-1",
-			Namespace: "test",
-			Labels:    expectedLabels,
-			Annotations: map[string]string{
-				"awesomeAnnotation": "dope",
-			},
-		},
-		Spec: batchv1.JobSpec{
-			BackoffLimit: new(int32),
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: expectedLabels,
-					Annotations: map[string]string{
-						"awesomeAnnotation": "dope",
-					},
-				},
-				Spec: corev1.PodSpec{
-					Hostname:                     "test-1",
-					RestartPolicy:                corev1.RestartPolicyNever,
-					Affinity:                     nil,
-					NodeSelector:                 nil,
-					Tolerations:                  nil,
-					TopologySpreadConstraints:    nil,
-					ServiceAccountName:           "default",
-					AutomountServiceAccountToken: &automountServiceAccountToken,
-					SecurityContext:              &corev1.PodSecurityContext{},
-					Containers: []corev1.Container{{
-						Image:           "grafana/k6:latest",
-						ImagePullPolicy: "",
-						Name:            "k6",
-						Command:         []string{"k6", "run", "/test/test.js", "--address=0.0.0.0:6565", "--paused", "--tag", "instance_id=1", "--tag", "job_name=test-1"},
-						Env:             []corev1.EnvVar{},
-						Resources:       corev1.ResourceRequirements{},
-						VolumeMounts:    script.VolumeMount(),
-						Ports:           []corev1.ContainerPort{{ContainerPort: 6565}},
-						LivenessProbe: &corev1.Probe{
-							ProbeHandler: corev1.ProbeHandler{
-								HTTPGet: &corev1.HTTPGetAction{
-									Path:   "/v1/status",
-									Port:   intstr.IntOrString{IntVal: 6565},
-									Scheme: "HTTP",
-								},
-							},
-						},
-						ReadinessProbe: &corev1.Probe{
-							ProbeHandler: corev1.ProbeHandler{
-								HTTPGet: &corev1.HTTPGetAction{
-									Path:   "/v1/status",
-									Port:   intstr.IntOrString{IntVal: 6565},
-									Scheme: "HTTP",
-								},
-							},
-						},
-						SecurityContext: &corev1.SecurityContext{},
-					}},
-					TerminationGracePeriodSeconds: &zero,
-					Volumes:                       script.Volume(),
-				},
-			},
-		},
-	}
-	k6 := &v1alpha1.TestRun{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: "test",
-		},
-		Spec: v1alpha1.TestRunSpec{
-			Quiet: "false",
-			Script: v1alpha1.K6Script{
-				ConfigMap: v1alpha1.K6Configmap{
-					Name: "test",
-					File: "test.js",
-				},
-			},
-			Runner: v1alpha1.Pod{
-				Metadata: v1alpha1.PodMetadata{
-					Labels: map[string]string{
-						"label1": "awesome",
-					},
-					Annotations: map[string]string{
-						"awesomeAnnotation": "dope",
-					},
-				},
-			},
-		},
-	}
-
-	job, err := NewRunnerJob(k6, 1, cloud.NewTokenInfo("", ""))
-	if err != nil {
-		t.Errorf("NewRunnerJob errored, got: %v", err)
-	}
-	if diff := deep.Equal(job, expectedOutcome); diff != nil {
-		t.Errorf("NewRunnerJob returned unexpected data, diff: %s", diff)
-	}
-}
-
-func TestNewRunnerJobUnpaused(t *testing.T) {
-	script := &types.Script{
-		Name:     "test",
-		Filename: "thing.js",
-		Type:     "ConfigMap",
-	}
-
-	var zero int64 = 0
-	automountServiceAccountToken := true
-
-	expectedLabels := map[string]string{
-		"app":    "k6",
-		"k6_cr":  "test",
-		"runner": "true",
-		"label1": "awesome",
-	}
-
-	expectedOutcome := &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-1",
-			Namespace: "test",
-			Labels:    expectedLabels,
-			Annotations: map[string]string{
-				"awesomeAnnotation": "dope",
-			},
-		},
-		Spec: batchv1.JobSpec{
-			BackoffLimit: new(int32),
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: expectedLabels,
-					Annotations: map[string]string{
-						"awesomeAnnotation": "dope",
-					},
-				},
-				Spec: corev1.PodSpec{
-					Hostname:                     "test-1",
-					RestartPolicy:                corev1.RestartPolicyNever,
-					Affinity:                     nil,
-					NodeSelector:                 nil,
-					Tolerations:                  nil,
-					TopologySpreadConstraints:    nil,
-					ServiceAccountName:           "default",
-					AutomountServiceAccountToken: &automountServiceAccountToken,
-					SecurityContext:              &corev1.PodSecurityContext{},
-					Containers: []corev1.Container{{
-						Image:           "grafana/k6:latest",
-						ImagePullPolicy: "",
-						Name:            "k6",
-						Command:         []string{"k6", "run", "--quiet", "/test/test.js", "--address=0.0.0.0:6565", "--tag", "instance_id=1", "--tag", "job_name=test-1"},
-						Env:             []corev1.EnvVar{},
-						Resources:       corev1.ResourceRequirements{},
-						VolumeMounts:    script.VolumeMount(),
-						Ports:           []corev1.ContainerPort{{ContainerPort: 6565}},
-						LivenessProbe: &corev1.Probe{
-							ProbeHandler: corev1.ProbeHandler{
-								HTTPGet: &corev1.HTTPGetAction{
-									Path:   "/v1/status",
-									Port:   intstr.IntOrString{IntVal: 6565},
-									Scheme: "HTTP",
-								},
-							},
-						},
-						ReadinessProbe: &corev1.Probe{
-							ProbeHandler: corev1.ProbeHandler{
-								HTTPGet: &corev1.HTTPGetAction{
-									Path:   "/v1/status",
-									Port:   intstr.IntOrString{IntVal: 6565},
-									Scheme: "HTTP",
-								},
-							},
-						},
-						SecurityContext: &corev1.SecurityContext{},
-					}},
-					TerminationGracePeriodSeconds: &zero,
-					Volumes:                       script.Volume(),
-				},
-			},
-		},
-	}
-	k6 := &v1alpha1.TestRun{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: "test",
-		},
-		Spec: v1alpha1.TestRunSpec{
-			Paused: "false",
-			Script: v1alpha1.K6Script{
-				ConfigMap: v1alpha1.K6Configmap{
-					Name: "test",
-					File: "test.js",
-				},
-			},
-			Runner: v1alpha1.Pod{
-				Metadata: v1alpha1.PodMetadata{
-					Labels: map[string]string{
-						"label1": "awesome",
-					},
-					Annotations: map[string]string{
-						"awesomeAnnotation": "dope",
-					},
-				},
-			},
-		},
-	}
-
-	job, err := NewRunnerJob(k6, 1, cloud.NewTokenInfo("", ""))
-	if err != nil {
-		t.Errorf("NewRunnerJob errored, got: %v", err)
-	}
-	if diff := deep.Equal(job, expectedOutcome); diff != nil {
-		t.Errorf("NewRunnerJob returned unexpected data, diff: %s", diff)
-	}
-}
-
-func TestNewRunnerJobArguments(t *testing.T) {
-	script := &types.Script{
-		Name:     "test",
-		Filename: "thing.js",
-		Type:     "ConfigMap",
-	}
-
-	var zero int64 = 0
-	automountServiceAccountToken := true
-
-	expectedLabels := map[string]string{
-		"app":    "k6",
-		"k6_cr":  "test",
-		"runner": "true",
-		"label1": "awesome",
-	}
-
-	expectedOutcome := &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-1",
-			Namespace: "test",
-			Labels:    expectedLabels,
-			Annotations: map[string]string{
-				"awesomeAnnotation": "dope",
-			},
-		},
-		Spec: batchv1.JobSpec{
-			BackoffLimit: new(int32),
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: expectedLabels,
-					Annotations: map[string]string{
-						"awesomeAnnotation": "dope",
-					},
-				},
-				Spec: corev1.PodSpec{
-					Hostname:                     "test-1",
-					RestartPolicy:                corev1.RestartPolicyNever,
-					Affinity:                     nil,
-					NodeSelector:                 nil,
-					Tolerations:                  nil,
-					TopologySpreadConstraints:    nil,
-					ServiceAccountName:           "default",
-					AutomountServiceAccountToken: &automountServiceAccountToken,
-					SecurityContext:              &corev1.PodSecurityContext{},
-					Containers: []corev1.Container{{
-						Image:           "grafana/k6:latest",
-						ImagePullPolicy: "",
-						Name:            "k6",
-						Command:         []string{"k6", "run", "--quiet", "--cool-thing", "/test/test.js", "--address=0.0.0.0:6565", "--paused", "--tag", "instance_id=1", "--tag", "job_name=test-1"},
-						Env:             []corev1.EnvVar{},
-						Resources:       corev1.ResourceRequirements{},
-						VolumeMounts:    script.VolumeMount(),
-						Ports:           []corev1.ContainerPort{{ContainerPort: 6565}},
-						LivenessProbe: &corev1.Probe{
-							ProbeHandler: corev1.ProbeHandler{
-								HTTPGet: &corev1.HTTPGetAction{
-									Path:   "/v1/status",
-									Port:   intstr.IntOrString{IntVal: 6565},
-									Scheme: "HTTP",
-								},
-							},
-						},
-						ReadinessProbe: &corev1.Probe{
-							ProbeHandler: corev1.ProbeHandler{
-								HTTPGet: &corev1.HTTPGetAction{
-									Path:   "/v1/status",
-									Port:   intstr.IntOrString{IntVal: 6565},
-									Scheme: "HTTP",
-								},
-							},
-						},
-						SecurityContext: &corev1.SecurityContext{},
-					}},
-					TerminationGracePeriodSeconds: &zero,
-					Volumes:                       script.Volume(),
-				},
-			},
-		},
-	}
-
-	k6 := &v1alpha1.TestRun{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: "test",
-		},
-		Spec: v1alpha1.TestRunSpec{
-			Arguments: "--cool-thing",
-			Script: v1alpha1.K6Script{
-				ConfigMap: v1alpha1.K6Configmap{
-					Name: "test",
-					File: "test.js",
-				},
-			},
-			Runner: v1alpha1.Pod{
-				Metadata: v1alpha1.PodMetadata{
-					Labels: map[string]string{
-						"label1": "awesome",
-					},
-					Annotations: map[string]string{
-						"awesomeAnnotation": "dope",
-					},
-				},
-			},
-		},
-	}
-
-	job, err := NewRunnerJob(k6, 1, cloud.NewTokenInfo("", ""))
-	if err != nil {
-		t.Errorf("NewRunnerJob errored, got: %v", err)
-	}
-	if diff := deep.Equal(job, expectedOutcome); diff != nil {
-		t.Errorf("NewRunnerJob returned unexpected data, diff: %s", diff)
-	}
-}
-
-func TestNewRunnerJobServiceAccount(t *testing.T) {
-	script := &types.Script{
-		Name:     "test",
-		Filename: "thing.js",
-		Type:     "ConfigMap",
-	}
-
-	var zero int64 = 0
-	automountServiceAccountToken := true
-
-	expectedLabels := map[string]string{
-		"app":    "k6",
-		"k6_cr":  "test",
-		"runner": "true",
-		"label1": "awesome",
-	}
-
-	expectedOutcome := &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-1",
-			Namespace: "test",
-			Labels:    expectedLabels,
-			Annotations: map[string]string{
-				"awesomeAnnotation": "dope",
-			},
-		},
-		Spec: batchv1.JobSpec{
-			BackoffLimit: new(int32),
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: expectedLabels,
-					Annotations: map[string]string{
-						"awesomeAnnotation": "dope",
-					},
-				},
-				Spec: corev1.PodSpec{
-					Hostname:                     "test-1",
-					RestartPolicy:                corev1.RestartPolicyNever,
-					Affinity:                     nil,
-					NodeSelector:                 nil,
-					Tolerations:                  nil,
-					TopologySpreadConstraints:    nil,
-					ServiceAccountName:           "test",
-					AutomountServiceAccountToken: &automountServiceAccountToken,
-					SecurityContext:              &corev1.PodSecurityContext{},
-					Containers: []corev1.Container{{
-						Image:           "grafana/k6:latest",
-						ImagePullPolicy: "",
-						Name:            "k6",
-						Command:         []string{"k6", "run", "--quiet", "/test/test.js", "--address=0.0.0.0:6565", "--paused", "--tag", "instance_id=1", "--tag", "job_name=test-1"},
-						Env:             []corev1.EnvVar{},
-						Resources:       corev1.ResourceRequirements{},
-						VolumeMounts:    script.VolumeMount(),
-						Ports:           []corev1.ContainerPort{{ContainerPort: 6565}},
-						LivenessProbe: &corev1.Probe{
-							ProbeHandler: corev1.ProbeHandler{
-								HTTPGet: &corev1.HTTPGetAction{
-									Path:   "/v1/status",
-									Port:   intstr.IntOrString{IntVal: 6565},
-									Scheme: "HTTP",
-								},
-							},
-						},
-						ReadinessProbe: &corev1.Probe{
-							ProbeHandler: corev1.ProbeHandler{
-								HTTPGet: &corev1.HTTPGetAction{
-									Path:   "/v1/status",
-									Port:   intstr.IntOrString{IntVal: 6565},
-									Scheme: "HTTP",
-								},
-							},
-						},
-						SecurityContext: &corev1.SecurityContext{},
-					}},
-					TerminationGracePeriodSeconds: &zero,
-					Volumes:                       script.Volume(),
-				},
-			},
-		},
-	}
-
-	k6 := &v1alpha1.TestRun{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: "test",
-		},
-		Spec: v1alpha1.TestRunSpec{
-
-			Script: v1alpha1.K6Script{
-				ConfigMap: v1alpha1.K6Configmap{
-					Name: "test",
-					File: "test.js",
-				},
-			},
-			Runner: v1alpha1.Pod{
-				ServiceAccountName: "test",
-				Metadata: v1alpha1.PodMetadata{
-					Labels: map[string]string{
-						"label1": "awesome",
-					},
-					Annotations: map[string]string{
-						"awesomeAnnotation": "dope",
-					},
-				},
-			},
-		},
-	}
-
-	job, err := NewRunnerJob(k6, 1, cloud.NewTokenInfo("", ""))
-	if err != nil {
-		t.Errorf("NewRunnerJob errored, got: %v", err)
-	}
-	if diff := deep.Equal(job, expectedOutcome); diff != nil {
-		t.Errorf("NewRunnerJob returned unexpected data, diff: %s", diff)
-	}
-}
-
-func TestNewRunnerJobIstio(t *testing.T) {
-	script := &types.Script{
-		Name:     "test",
-		Filename: "thing.js",
-		Type:     "ConfigMap",
-	}
-
-	var zero int64 = 0
-	automountServiceAccountToken := true
-
-	expectedLabels := map[string]string{
-		"app":    "k6",
-		"k6_cr":  "test",
-		"runner": "true",
-		"label1": "awesome",
-	}
-
-	expectedOutcome := &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-1",
-			Namespace: "test",
-			Labels:    expectedLabels,
-			Annotations: map[string]string{
-				"awesomeAnnotation": "dope",
-			},
-		},
-		Spec: batchv1.JobSpec{
-			BackoffLimit: new(int32),
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: expectedLabels,
-					Annotations: map[string]string{
-						"awesomeAnnotation": "dope",
-					},
-				},
-				Spec: corev1.PodSpec{
-					Hostname:                     "test-1",
-					RestartPolicy:                corev1.RestartPolicyNever,
-					Affinity:                     nil,
-					NodeSelector:                 nil,
-					Tolerations:                  nil,
-					TopologySpreadConstraints:    nil,
-					ServiceAccountName:           "default",
-					AutomountServiceAccountToken: &automountServiceAccountToken,
-					SecurityContext:              &corev1.PodSecurityContext{},
-					Containers: []corev1.Container{{
-						Image:           "grafana/k6:latest",
-						ImagePullPolicy: "",
-						Name:            "k6",
-						Command:         []string{"scuttle", "k6", "run", "--quiet", "/test/test.js", "--address=0.0.0.0:6565", "--paused", "--tag", "instance_id=1", "--tag", "job_name=test-1"},
-						Env: []corev1.EnvVar{
-							{
-								Name:  "ENVOY_ADMIN_API",
-								Value: "http://127.0.0.1:15000",
-							},
-							{
-								Name:  "ISTIO_QUIT_API",
-								Value: "http://127.0.0.1:15020",
-							},
-							{
-								Name:  "WAIT_FOR_ENVOY_TIMEOUT",
-								Value: "15",
-							},
-						},
-						Resources:    corev1.ResourceRequirements{},
-						VolumeMounts: script.VolumeMount(),
-						Ports:        []corev1.ContainerPort{{ContainerPort: 6565}},
-						LivenessProbe: &corev1.Probe{
-							ProbeHandler: corev1.ProbeHandler{
-								HTTPGet: &corev1.HTTPGetAction{
-									Path:   "/v1/status",
-									Port:   intstr.IntOrString{IntVal: 6565},
-									Scheme: "HTTP",
-								},
-							},
-						},
-						ReadinessProbe: &corev1.Probe{
-							ProbeHandler: corev1.ProbeHandler{
-								HTTPGet: &corev1.HTTPGetAction{
-									Path:   "/v1/status",
-									Port:   intstr.IntOrString{IntVal: 6565},
-									Scheme: "HTTP",
-								},
-							},
-						},
-						SecurityContext: &corev1.SecurityContext{},
-					}},
-					TerminationGracePeriodSeconds: &zero,
-					Volumes:                       script.Volume(),
-				},
-			},
-		},
-	}
-	k6 := &v1alpha1.TestRun{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: "test",
-		},
-		Spec: v1alpha1.TestRunSpec{
-			Scuttle: v1alpha1.K6Scuttle{
-				Enabled: "true",
-			},
-			Script: v1alpha1.K6Script{
-				ConfigMap: v1alpha1.K6Configmap{
-					Name: "test",
-					File: "test.js",
-				},
-			},
-			Runner: v1alpha1.Pod{
-				Metadata: v1alpha1.PodMetadata{
-					Labels: map[string]string{
-						"label1": "awesome",
-					},
-					Annotations: map[string]string{
-						"awesomeAnnotation": "dope",
-					},
-				},
-			},
-		},
-	}
-
-	job, err := NewRunnerJob(k6, 1, cloud.NewTokenInfo("", ""))
-	if err != nil {
-		t.Errorf("NewRunnerJob errored, got: %v", err)
-	}
-	if diff := deep.Equal(job, expectedOutcome); diff != nil {
-		t.Errorf("NewRunnerJob returned unexpected data, diff: %s", diff)
-	}
-}
-
-func TestNewRunnerJobCloud(t *testing.T) {
-	script := &types.Script{
-		Name:     "test",
-		Filename: "thing.js",
-		Type:     "ConfigMap",
-	}
-
-	var zero int64 = 0
-	automountServiceAccountToken := true
-
-	expectedLabels := map[string]string{
-		"app":    "k6",
-		"k6_cr":  "test",
-		"runner": "true",
-	}
-
-	expectedOutcome := &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-1",
-			Namespace: "test",
-			Labels:    expectedLabels,
-			Annotations: map[string]string{
-				"awesomeAnnotation": "dope",
-			},
-		},
-		Spec: batchv1.JobSpec{
-			BackoffLimit: new(int32),
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: expectedLabels,
-					Annotations: map[string]string{
-						"awesomeAnnotation": "dope",
-					},
-				},
-				Spec: corev1.PodSpec{
-					Hostname:                     "test-1",
-					RestartPolicy:                corev1.RestartPolicyNever,
-					Affinity:                     nil,
-					NodeSelector:                 nil,
-					Tolerations:                  nil,
-					TopologySpreadConstraints:    nil,
-					ServiceAccountName:           "default",
-					SecurityContext:              &corev1.PodSecurityContext{},
-					AutomountServiceAccountToken: &automountServiceAccountToken,
-					Containers: []corev1.Container{{
-						Image:           "grafana/k6:latest",
-						ImagePullPolicy: "",
-						Name:            "k6",
-						Command:         []string{"k6", "run", "--quiet", "--out", "cloud", "/test/test.js", "--address=0.0.0.0:6565", "--paused", "--tag", "instance_id=1", "--tag", "job_name=test-1"},
-						Env: append(aggregationEnvVars,
-							corev1.EnvVar{
-								Name:  "K6_CLOUD_PUSH_REF_ID",
-								Value: "testrunid",
-							},
-							corev1.EnvVar{
-								Name:  "K6_CLOUD_TOKEN",
-								Value: "token",
-							},
-						),
-						Resources:    corev1.ResourceRequirements{},
-						VolumeMounts: script.VolumeMount(),
-						Ports:        []corev1.ContainerPort{{ContainerPort: 6565}},
-						LivenessProbe: &corev1.Probe{
-							ProbeHandler: corev1.ProbeHandler{
-								HTTPGet: &corev1.HTTPGetAction{
-									Path:   "/v1/status",
-									Port:   intstr.IntOrString{IntVal: 6565},
-									Scheme: "HTTP",
-								},
-							},
-						},
-						ReadinessProbe: &corev1.Probe{
-							ProbeHandler: corev1.ProbeHandler{
-								HTTPGet: &corev1.HTTPGetAction{
-									Path:   "/v1/status",
-									Port:   intstr.IntOrString{IntVal: 6565},
-									Scheme: "HTTP",
-								},
-							},
-						},
-						SecurityContext: &corev1.SecurityContext{},
-					}},
-					TerminationGracePeriodSeconds: &zero,
-					Volumes:                       script.Volume(),
-				},
-			},
-		},
-	}
-	k6 := &v1alpha1.TestRun{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: "test",
-		},
-		Spec: v1alpha1.TestRunSpec{
-			Script: v1alpha1.K6Script{
-				ConfigMap: v1alpha1.K6Configmap{
-					Name: "test",
-					File: "test.js",
-				},
-			},
-			Arguments: "--out cloud",
-			Runner: v1alpha1.Pod{
-				Metadata: v1alpha1.PodMetadata{
-					Annotations: map[string]string{
-						"awesomeAnnotation": "dope",
-					},
-				},
-			},
-		},
-		// Since this test only creates a runner's spec so
-		// testrunid has to be set hard-coded here.
-		Status: v1alpha1.TestRunStatus{
-			TestRunID:       "testrunid",
-			AggregationVars: "2|5s|3s|10s|10",
-		},
-	}
-
-	job, err := NewRunnerJob(k6, 1, cloud.NewTokenInfo("", "").InjectValue("token"))
-	if err != nil {
-		t.Errorf("NewRunnerJob errored, got: %v", err)
-	}
-	if diff := deep.Equal(job, expectedOutcome); diff != nil {
-		t.Errorf("NewRunnerJob returned unexpected data, diff: %s", diff)
-	}
-}
-
-func TestNewRunnerJobLocalFile(t *testing.T) {
-	script := &types.Script{
-		Name:     "test",
-		Filename: "/test/test.js",
-		Type:     "LocalFile",
-	}
-
-	var zero int64 = 0
-	automountServiceAccountToken := true
-
-	expectedLabels := map[string]string{
-		"app":    "k6",
-		"k6_cr":  "test",
-		"runner": "true",
-		"label1": "awesome",
-	}
-	expectedOutcome := &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-1",
-			Namespace: "test",
-			Labels:    expectedLabels,
-			Annotations: map[string]string{
-				"awesomeAnnotation": "dope",
-			},
-		},
-		Spec: batchv1.JobSpec{
-			BackoffLimit: new(int32),
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: expectedLabels,
-					Annotations: map[string]string{
-						"awesomeAnnotation": "dope",
-					},
-				},
-				Spec: corev1.PodSpec{
-					Hostname:                     "test-1",
-					RestartPolicy:                corev1.RestartPolicyNever,
-					Affinity:                     nil,
-					NodeSelector:                 nil,
-					Tolerations:                  nil,
-					TopologySpreadConstraints:    nil,
-					ServiceAccountName:           "default",
-					AutomountServiceAccountToken: &automountServiceAccountToken,
-					SecurityContext:              &corev1.PodSecurityContext{},
-					Containers: []corev1.Container{{
-						Image:           "grafana/k6:latest",
-						ImagePullPolicy: "",
-						Name:            "k6",
-						Command:         []string{"sh", "-c", "if [ ! -f /test/test.js ]; then echo \"LocalFile not found exiting...\"; exit 1; fi;\nk6 run --quiet /test/test.js --address=0.0.0.0:6565 --paused --tag instance_id=1 --tag job_name=test-1"},
-						Env:             []corev1.EnvVar{},
-						Resources:       corev1.ResourceRequirements{},
-						VolumeMounts:    script.VolumeMount(),
-						Ports:           []corev1.ContainerPort{{ContainerPort: 6565}},
-						LivenessProbe: &corev1.Probe{
-							ProbeHandler: corev1.ProbeHandler{
-								HTTPGet: &corev1.HTTPGetAction{
-									Path:   "/v1/status",
-									Port:   intstr.IntOrString{IntVal: 6565},
-									Scheme: "HTTP",
-								},
-							},
-						},
-						ReadinessProbe: &corev1.Probe{
-							ProbeHandler: corev1.ProbeHandler{
-								HTTPGet: &corev1.HTTPGetAction{
-									Path:   "/v1/status",
-									Port:   intstr.IntOrString{IntVal: 6565},
-									Scheme: "HTTP",
-								},
-							},
-						},
-						SecurityContext: &corev1.SecurityContext{},
-					}},
-					TerminationGracePeriodSeconds: &zero,
-					Volumes:                       script.Volume(),
-				},
-			},
-		},
-	}
-	k6 := &v1alpha1.TestRun{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: "test",
-		},
-		Spec: v1alpha1.TestRunSpec{
-			Scuttle: v1alpha1.K6Scuttle{
-				Enabled: "false",
-			},
-			Script: v1alpha1.K6Script{
-				LocalFile: "/test/test.js",
-			},
-			Runner: v1alpha1.Pod{
-				Metadata: v1alpha1.PodMetadata{
-					Labels: map[string]string{
-						"label1": "awesome",
-					},
-					Annotations: map[string]string{
-						"awesomeAnnotation": "dope",
-					},
-				},
-			},
-		},
-	}
-
-	job, err := NewRunnerJob(k6, 1, cloud.NewTokenInfo("", ""))
-	if err != nil {
-		t.Errorf("NewRunnerJob errored, got: %v", err)
-	}
-	if diff := deep.Equal(job, expectedOutcome); diff != nil {
-		t.Errorf("NewRunnerJob returned unexpected data, diff: %s", diff)
-	}
-}
-
-func TestNewRunnerJobWithInitContainer(t *testing.T) {
-	script := &types.Script{
-		Name:     "test",
-		Filename: "thing.js",
-		Type:     "ConfigMap",
-	}
-
-	var zero int64 = 0
-	automountServiceAccountToken := true
-
-	expectedLabels := map[string]string{
-		"app":    "k6",
-		"k6_cr":  "test",
-		"runner": "true",
-		"label1": "awesome",
-	}
-
-	expectedOutcome := &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-1",
-			Namespace: "test",
-			Labels:    expectedLabels,
-			Annotations: map[string]string{
-				"awesomeAnnotation": "dope",
-			},
-		},
-		Spec: batchv1.JobSpec{
-			BackoffLimit: new(int32),
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: expectedLabels,
-					Annotations: map[string]string{
-						"awesomeAnnotation": "dope",
-					},
-				},
-				Spec: corev1.PodSpec{
-					Hostname:                     "test-1",
-					RestartPolicy:                corev1.RestartPolicyNever,
-					SecurityContext:              &corev1.PodSecurityContext{},
-					Affinity:                     nil,
-					NodeSelector:                 nil,
-					Tolerations:                  nil,
-					TopologySpreadConstraints:    nil,
-					ServiceAccountName:           "default",
-					AutomountServiceAccountToken: &automountServiceAccountToken,
-					InitContainers: []corev1.Container{
-						{
-							Name:            "k6-init-0",
-							Image:           "busybox:1.28",
-							Command:         []string{"sh", "-c", "cat /test/test.js"},
-							VolumeMounts:    script.VolumeMount(),
-							ImagePullPolicy: corev1.PullNever,
-							EnvFrom: []corev1.EnvFromSource{
-								{
-									ConfigMapRef: &corev1.ConfigMapEnvSource{
-										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "env",
-										},
-									},
-								},
-							},
-							SecurityContext: &corev1.SecurityContext{},
-						},
-					},
-					Containers: []corev1.Container{{
-						Image:           "grafana/k6:latest",
-						ImagePullPolicy: corev1.PullNever,
-						Name:            "k6",
-						Command:         []string{"k6", "run", "--quiet", "/test/test.js", "--address=0.0.0.0:6565", "--paused", "--tag", "instance_id=1", "--tag", "job_name=test-1"},
-						Env:             []corev1.EnvVar{},
-						Resources:       corev1.ResourceRequirements{},
-						VolumeMounts:    script.VolumeMount(),
-						Ports:           []corev1.ContainerPort{{ContainerPort: 6565}},
-						EnvFrom: []corev1.EnvFromSource{
-							{
-								ConfigMapRef: &corev1.ConfigMapEnvSource{
-									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "env",
-									},
-								},
-							},
-						},
-						LivenessProbe: &corev1.Probe{
-							ProbeHandler: corev1.ProbeHandler{
-								HTTPGet: &corev1.HTTPGetAction{
-									Path:   "/v1/status",
-									Port:   intstr.IntOrString{IntVal: 6565},
-									Scheme: "HTTP",
-								},
-							},
-						},
-						ReadinessProbe: &corev1.Probe{
-							ProbeHandler: corev1.ProbeHandler{
-								HTTPGet: &corev1.HTTPGetAction{
-									Path:   "/v1/status",
-									Port:   intstr.IntOrString{IntVal: 6565},
-									Scheme: "HTTP",
-								},
-							},
-						},
-						SecurityContext: &corev1.SecurityContext{},
-					}},
-					TerminationGracePeriodSeconds: &zero,
-					Volumes:                       script.Volume(),
-				},
-			},
-		},
-	}
-	k6 := &v1alpha1.TestRun{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: "test",
-		},
-		Spec: v1alpha1.TestRunSpec{
-			Script: v1alpha1.K6Script{
-				ConfigMap: v1alpha1.K6Configmap{
-					Name: "test",
-					File: "test.js",
-				},
-			},
-			Runner: v1alpha1.Pod{
-				Metadata: v1alpha1.PodMetadata{
-					Labels: map[string]string{
-						"label1": "awesome",
-					},
-					Annotations: map[string]string{
-						"awesomeAnnotation": "dope",
-					},
-				},
-				EnvFrom: []corev1.EnvFromSource{
-					{
-						ConfigMapRef: &corev1.ConfigMapEnvSource{
-							LocalObjectReference: corev1.LocalObjectReference{
-								Name: "env",
-							},
-						},
-					},
-				},
-				ImagePullPolicy: corev1.PullNever,
-				InitContainers: []v1alpha1.InitContainer{
-					{
-						Image:   "busybox:1.28",
-						Command: []string{"sh", "-c", "cat /test/test.js"},
-						EnvFrom: []corev1.EnvFromSource{
-							{
-								ConfigMapRef: &corev1.ConfigMapEnvSource{
-									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "env",
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	job, err := NewRunnerJob(k6, 1, cloud.NewTokenInfo("", ""))
-	if err != nil {
-		t.Errorf("NewRunnerJob errored, got: %v", err)
-	}
-	if diff := deep.Equal(job, expectedOutcome); diff != nil {
-		t.Errorf("NewRunnerJob returned unexpected data, diff: %s", diff)
-	}
-}
-
-func TestNewRunnerJobWithVolume(t *testing.T) {
-	script := &types.Script{
-		Name:     "test",
-		Filename: "thing.js",
-		Type:     "ConfigMap",
-	}
-
-	var zero int64 = 0
-	automountServiceAccountToken := true
-
-	expectedLabels := map[string]string{
-		"app":    "k6",
-		"k6_cr":  "test",
-		"runner": "true",
-		"label1": "awesome",
-	}
-
-	expectedVolumes := append(script.Volume(), corev1.Volume{
-		Name: "k6-test-volume",
-		VolumeSource: corev1.VolumeSource{
-			EmptyDir: &corev1.EmptyDirVolumeSource{},
-		},
-	})
-
-	expectedVolumeMounts := append(script.VolumeMount(), corev1.VolumeMount{
-		Name:      "k6-test-volume",
-		MountPath: "/test/location",
-	})
-
-	expectedOutcome := &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-1",
-			Namespace: "test",
-			Labels:    expectedLabels,
-			Annotations: map[string]string{
-				"awesomeAnnotation": "dope",
-			},
-		},
-		Spec: batchv1.JobSpec{
-			BackoffLimit: new(int32),
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: expectedLabels,
-					Annotations: map[string]string{
-						"awesomeAnnotation": "dope",
-					},
-				},
-				Spec: corev1.PodSpec{
-					Hostname:                     "test-1",
-					RestartPolicy:                corev1.RestartPolicyNever,
-					SecurityContext:              &corev1.PodSecurityContext{},
-					Affinity:                     nil,
-					NodeSelector:                 nil,
-					Tolerations:                  nil,
-					TopologySpreadConstraints:    nil,
-					ServiceAccountName:           "default",
-					AutomountServiceAccountToken: &automountServiceAccountToken,
-					InitContainers: []corev1.Container{
-						{
-							Name:            "k6-init-0",
-							Image:           "busybox:1.28",
-							Command:         []string{"sh", "-c", "cat /test/test.js"},
-							VolumeMounts:    expectedVolumeMounts,
-							ImagePullPolicy: corev1.PullNever,
-							EnvFrom: []corev1.EnvFromSource{
-								{
-									ConfigMapRef: &corev1.ConfigMapEnvSource{
-										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "env",
-										},
-									},
-								},
-							},
-							SecurityContext: &corev1.SecurityContext{},
-						},
-					},
-					Containers: []corev1.Container{{
-						Image:           "grafana/k6:latest",
-						ImagePullPolicy: corev1.PullNever,
-						Name:            "k6",
-						Command:         []string{"k6", "run", "--quiet", "/test/test.js", "--address=0.0.0.0:6565", "--paused", "--tag", "instance_id=1", "--tag", "job_name=test-1"},
-						Env:             []corev1.EnvVar{},
-						Resources:       corev1.ResourceRequirements{},
-						VolumeMounts:    expectedVolumeMounts,
-						Ports:           []corev1.ContainerPort{{ContainerPort: 6565}},
-						EnvFrom: []corev1.EnvFromSource{
-							{
-								ConfigMapRef: &corev1.ConfigMapEnvSource{
-									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "env",
-									},
-								},
-							},
-						},
-						LivenessProbe: &corev1.Probe{
-							ProbeHandler: corev1.ProbeHandler{
-								HTTPGet: &corev1.HTTPGetAction{
-									Path:   "/v1/status",
-									Port:   intstr.IntOrString{IntVal: 6565},
-									Scheme: "HTTP",
-								},
-							},
-						},
-						ReadinessProbe: &corev1.Probe{
-							ProbeHandler: corev1.ProbeHandler{
-								HTTPGet: &corev1.HTTPGetAction{
-									Path:   "/v1/status",
-									Port:   intstr.IntOrString{IntVal: 6565},
-									Scheme: "HTTP",
-								},
-							},
-						},
-						SecurityContext: &corev1.SecurityContext{},
-					}},
-					TerminationGracePeriodSeconds: &zero,
-					Volumes:                       expectedVolumes,
-				},
-			},
-		},
-	}
-	k6 := &v1alpha1.TestRun{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: "test",
-		},
-		Spec: v1alpha1.TestRunSpec{
-			Script: v1alpha1.K6Script{
-				ConfigMap: v1alpha1.K6Configmap{
-					Name: "test",
-					File: "test.js",
-				},
-			},
-			Runner: v1alpha1.Pod{
-				Metadata: v1alpha1.PodMetadata{
-					Labels: map[string]string{
-						"label1": "awesome",
-					},
-					Annotations: map[string]string{
-						"awesomeAnnotation": "dope",
-					},
-				},
-				EnvFrom: []corev1.EnvFromSource{
-					{
-						ConfigMapRef: &corev1.ConfigMapEnvSource{
-							LocalObjectReference: corev1.LocalObjectReference{
-								Name: "env",
-							},
-						},
-					},
-				},
-				ImagePullPolicy: corev1.PullNever,
-				InitContainers: []v1alpha1.InitContainer{
-					{
-						Image:   "busybox:1.28",
-						Command: []string{"sh", "-c", "cat /test/test.js"},
-						EnvFrom: []corev1.EnvFromSource{
-							{
-								ConfigMapRef: &corev1.ConfigMapEnvSource{
-									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "env",
-									},
-								},
-							},
-						},
-						VolumeMounts: []corev1.VolumeMount{
-							corev1.VolumeMount{
-								Name:      "k6-test-volume",
-								MountPath: "/test/location",
-							},
-						},
-					},
-				},
-				Volumes: []corev1.Volume{
-					corev1.Volume{
-						Name: "k6-test-volume",
-						VolumeSource: corev1.VolumeSource{
-							EmptyDir: &corev1.EmptyDirVolumeSource{},
-						},
-					},
-				},
-				VolumeMounts: []corev1.VolumeMount{
-					corev1.VolumeMount{
-						Name:      "k6-test-volume",
-						MountPath: "/test/location",
-					},
-				},
-			},
-		},
-	}
-
-	job, err := NewRunnerJob(k6, 1, cloud.NewTokenInfo("", ""))
-	if err != nil {
-		t.Errorf("NewRunnerJob errored, got: %v", err)
-	}
-	if diff := deep.Equal(job, expectedOutcome); diff != nil {
-		t.Errorf("NewRunnerJob returned unexpected data, diff: %s", diff)
-	}
-}
-
-func TestNewRunnerJobPLZTestRun(t *testing.T) {
-	// NewRunnerJob does not validate the type of Script for
-	// internal consistency (like in PLZ case) so it can be anything.
-	script := &types.Script{
-		Name:     "test",
-		Filename: "thing.js",
-		Type:     "ConfigMap",
-	}
-
-	var zero int64 = 0
-	automountServiceAccountToken := true
-
-	expectedLabels := map[string]string{
-		"app":    "k6",
-		"k6_cr":  "test",
-		"runner": "true",
-		"label1": "awesome",
-	}
-
-	expectedOutcome := &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-1",
-			Namespace: "test",
-			Labels:    expectedLabels,
-			Annotations: map[string]string{
-				"awesomeAnnotation": "dope",
-			},
-		},
-		Spec: batchv1.JobSpec{
-			BackoffLimit: new(int32),
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: expectedLabels,
-					Annotations: map[string]string{
-						"awesomeAnnotation": "dope",
-					},
-				},
-				Spec: corev1.PodSpec{
-					Hostname:                     "test-1",
-					RestartPolicy:                corev1.RestartPolicyNever,
-					SecurityContext:              &corev1.PodSecurityContext{},
-					Affinity:                     nil,
-					NodeSelector:                 nil,
-					Tolerations:                  nil,
-					TopologySpreadConstraints:    nil,
-					ServiceAccountName:           "default",
-					AutomountServiceAccountToken: &automountServiceAccountToken,
-					Containers: []corev1.Container{{
-						Image:           "grafana/k6:latest",
-						ImagePullPolicy: corev1.PullNever,
-						Name:            "k6",
-						Command:         []string{"k6", "run", "--quiet", "/test/test.js", "--address=0.0.0.0:6565", "--paused", "--tag", "instance_id=1", "--tag", "job_name=test-1", "--no-setup", "--no-teardown", "--linger"},
-						Env:             []corev1.EnvVar{},
-						Resources:       corev1.ResourceRequirements{},
-						VolumeMounts:    script.VolumeMount(),
-						Ports:           []corev1.ContainerPort{{ContainerPort: 6565}},
-						EnvFrom: []corev1.EnvFromSource{
-							{
-								ConfigMapRef: &corev1.ConfigMapEnvSource{
-									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "env",
-									},
-								},
-							},
-						},
-						LivenessProbe: &corev1.Probe{
-							ProbeHandler: corev1.ProbeHandler{
-								HTTPGet: &corev1.HTTPGetAction{
-									Path:   "/v1/status",
-									Port:   intstr.IntOrString{IntVal: 6565},
-									Scheme: "HTTP",
-								},
-							},
-						},
-						ReadinessProbe: &corev1.Probe{
-							ProbeHandler: corev1.ProbeHandler{
-								HTTPGet: &corev1.HTTPGetAction{
-									Path:   "/v1/status",
-									Port:   intstr.IntOrString{IntVal: 6565},
-									Scheme: "HTTP",
-								},
-							},
-						},
-						SecurityContext: &corev1.SecurityContext{},
-					}},
-					TerminationGracePeriodSeconds: &zero,
-					Volumes:                       script.Volume(),
-				},
-			},
-		},
-	}
-	k6 := &v1alpha1.TestRun{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: "test",
-		},
-		Spec: v1alpha1.TestRunSpec{
-			Script: v1alpha1.K6Script{
-				ConfigMap: v1alpha1.K6Configmap{
-					Name: "test",
-					File: "test.js",
-				},
-			},
-			Runner: v1alpha1.Pod{
-				Metadata: v1alpha1.PodMetadata{
-					Labels: map[string]string{
-						"label1": "awesome",
-					},
-					Annotations: map[string]string{
-						"awesomeAnnotation": "dope",
-					},
-				},
-				EnvFrom: []corev1.EnvFromSource{
-					{
-						ConfigMapRef: &corev1.ConfigMapEnvSource{
-							LocalObjectReference: corev1.LocalObjectReference{
-								Name: "env",
-							},
-						},
-					},
-				},
-				ImagePullPolicy: corev1.PullNever,
-			},
-		},
-		Status: v1alpha1.TestRunStatus{
-			Conditions: []metav1.Condition{
-				{
-					Type:               v1alpha1.CloudPLZTestRun,
-					Status:             metav1.ConditionTrue,
-					LastTransitionTime: metav1.Now(),
-				},
-			},
-		},
-	}
-
-	job, err := NewRunnerJob(k6, 1, cloud.NewTokenInfo("", ""))
-	if err != nil {
-		t.Errorf("NewRunnerJob errored, got: %v", err)
-	}
-	if diff := deep.Equal(job, expectedOutcome); diff != nil {
-		t.Errorf("NewRunnerJob returned unexpected data, diff: %s", diff)
-	}
-}
-
-func TestNewRunnerJobPriorityClassName(t *testing.T) {
-
-	script := &types.Script{
-		Name:     "test",
-		Filename: "thing.js",
-		Type:     "ConfigMap",
-	}
-
-	var zero int64 = 0
-	automountServiceAccountToken := true
-
-	expectedLabels := map[string]string{
-		"app":    "k6",
-		"k6_cr":  "test",
-		"runner": "true",
-		"label1": "awesome",
-	}
-
-	expectedOutcome := &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-1",
-			Namespace: "test",
-			Labels:    expectedLabels,
-			Annotations: map[string]string{
-				"awesomeAnnotation": "dope",
-			},
-		},
-		Spec: batchv1.JobSpec{
-			BackoffLimit: new(int32),
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: expectedLabels,
-					Annotations: map[string]string{
-						"awesomeAnnotation": "dope",
-					},
-				},
-				Spec: corev1.PodSpec{
-					Hostname:                     "test-1",
-					RestartPolicy:                corev1.RestartPolicyNever,
-					Affinity:                     nil,
-					NodeSelector:                 nil,
-					Tolerations:                  nil,
-					TopologySpreadConstraints:    nil,
-					ServiceAccountName:           "default",
-					AutomountServiceAccountToken: &automountServiceAccountToken,
-					SecurityContext:              &corev1.PodSecurityContext{},
-					Containers: []corev1.Container{{
-						Image:           "grafana/k6:latest",
-						ImagePullPolicy: "",
-						Name:            "k6",
-						Command:         []string{"k6", "run", "--quiet", "/test/test.js", "--address=0.0.0.0:6565", "--paused", "--tag", "instance_id=1", "--tag", "job_name=test-1"},
-						Env:             []corev1.EnvVar{},
-						Resources:       corev1.ResourceRequirements{},
-						VolumeMounts:    script.VolumeMount(),
-						Ports:           []corev1.ContainerPort{{ContainerPort: 6565}},
-						LivenessProbe: &corev1.Probe{
-							ProbeHandler: corev1.ProbeHandler{
-								HTTPGet: &corev1.HTTPGetAction{
-									Path:   "/v1/status",
-									Port:   intstr.IntOrString{IntVal: 6565},
-									Scheme: "HTTP",
-								},
-							},
-						},
-						ReadinessProbe: &corev1.Probe{
-							ProbeHandler: corev1.ProbeHandler{
-								HTTPGet: &corev1.HTTPGetAction{
-									Path:   "/v1/status",
-									Port:   intstr.IntOrString{IntVal: 6565},
-									Scheme: "HTTP",
-								},
-							},
-						},
-						SecurityContext: &corev1.SecurityContext{},
-					}},
-					TerminationGracePeriodSeconds: &zero,
-					Volumes:                       script.Volume(),
-					PriorityClassName:             "high-priority",
-				},
-			},
-		},
-	}
-
-	k6 := &v1alpha1.TestRun{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: "test",
-		},
-		Spec: v1alpha1.TestRunSpec{
-
-			Script: v1alpha1.K6Script{
-				ConfigMap: v1alpha1.K6Configmap{
-					Name: "test",
-					File: "test.js",
-				},
-			},
-			Runner: v1alpha1.Pod{
-				Metadata: v1alpha1.PodMetadata{
-					Labels: map[string]string{
-						"label1": "awesome",
-					},
-					Annotations: map[string]string{
-						"awesomeAnnotation": "dope",
-					},
-				},
-				PriorityClassName: "high-priority",
-			},
-		},
-	}
-
-	job, err := NewRunnerJob(k6, 1, cloud.NewTokenInfo("", ""))
-	if err != nil {
-		t.Errorf("NewRunnerJob errored, got: %v", err)
-	}
-
-	if diff := deep.Equal(job, expectedOutcome); diff != nil {
-		t.Errorf("NewRunnerJob returned unexpected data, diff: %s", diff)
+	if diff := deep.Equal(service, expected); diff != nil {
+		t.Errorf("NewRunnerService diff: %s", diff)
 	}
 }

--- a/pkg/testrun/k6client_test.go
+++ b/pkg/testrun/k6client_test.go
@@ -1,0 +1,22 @@
+package testrun
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_RunTeardownNoHost(t *testing.T) {
+	err := RunTeardown(context.Background(), []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no k6 Service is available to run teardown")
+}
+
+func Test_SetSetupDataNoHost(t *testing.T) {
+	data := json.RawMessage(`{"foo":"bar"}`)
+	err := SetSetupData(context.Background(), []string{}, data)
+	assert.NoError(t, err)
+}

--- a/pkg/testrun/template_test.go
+++ b/pkg/testrun/template_test.go
@@ -1,0 +1,40 @@
+package testrun
+
+import (
+	"testing"
+
+	"github.com/grafana/k6-operator/api/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_PLZTestName(t *testing.T) {
+	assert.Equal(t, "plz-test-abc123", PLZTestName("abc123"))
+	assert.Equal(t, "plz-test-0", PLZTestName("0"))
+	assert.Equal(t, "plz-test-", PLZTestName("")) // no validation at this point
+}
+
+func Test_TemplateCreate(t *testing.T) {
+	tmpl := Template(v1alpha1.TestRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "base",
+			Namespace: "ns",
+		},
+	})
+
+	tr1 := tmpl.Create()
+	tr2 := tmpl.Create()
+
+	assert.Equal(t, "base", tr1.Name)
+	assert.Equal(t, "ns", tr1.Namespace)
+	assert.Equal(t, "base", tr2.Name)
+	assert.Equal(t, "ns", tr2.Namespace)
+
+	// mutations to one copy must not have side effects
+	tr1.Name = "modified"
+
+	assert.Equal(t, "modified", tr1.Name)
+	assert.Equal(t, "base", tr2.Name)
+
+	assert.Equal(t, "base", Template(v1alpha1.TestRun(tmpl)).Name)
+}

--- a/pkg/types/script_test.go
+++ b/pkg/types/script_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	deep "github.com/go-test/deep"
+	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -55,6 +56,124 @@ func Test_Script_Volume(t *testing.T) {
 			if diff := deep.Equal(tt.script.Volume(), tt.expected); diff != nil {
 				t.Errorf("Volume() diff: %s", diff)
 			}
+		})
+	}
+}
+
+func Test_Script_VolumeMount(t *testing.T) {
+	tests := []struct {
+		name     string
+		script   Script
+		expected []corev1.VolumeMount
+	}{
+		{
+			name:   "ConfigMap always mounts at /test readonly",
+			script: Script{Type: "ConfigMap", Name: "my-cm"},
+			expected: []corev1.VolumeMount{
+				{Name: "k6-test-volume", MountPath: "/test", ReadOnly: true},
+			},
+		},
+		{
+			name:   "VolumeClaim writable",
+			script: Script{Type: "VolumeClaim", ReadOnly: false},
+			expected: []corev1.VolumeMount{
+				{Name: "k6-test-volume", ReadOnly: false},
+			},
+		},
+		{
+			name:   "VolumeClaim mounts at absolute path",
+			script: Script{Type: "VolumeClaim", Path: "/data", ReadOnly: true},
+			expected: []corev1.VolumeMount{
+				{Name: "k6-test-volume", MountPath: "/data", ReadOnly: true},
+			},
+		},
+		{
+			name:   "VolumeClaim with relative path (blocked by earlier validation in practice)",
+			script: Script{Type: "VolumeClaim", Path: "data/scripts"},
+			expected: []corev1.VolumeMount{
+				{Name: "k6-test-volume", MountPath: "data/scripts"},
+			},
+		},
+		{
+			name:   "VolumeClaim with no path (blocked by earlier validation in practice)",
+			script: Script{Type: "VolumeClaim"},
+			expected: []corev1.VolumeMount{
+				{Name: "k6-test-volume", MountPath: ""},
+			},
+		},
+		{
+			name:     "LocalFile returns empty volumeMount",
+			script:   Script{Type: "LocalFile"},
+			expected: []corev1.VolumeMount{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if diff := deep.Equal(tt.script.VolumeMount(), tt.expected); diff != nil {
+				t.Errorf("VolumeMount() diff: %s", diff)
+			}
+		})
+	}
+}
+
+func Test_Script_FullName(t *testing.T) {
+	tests := []struct {
+		name     string
+		script   Script
+		expected string
+	}{
+		{"path and filename present", Script{Path: "/test/", Filename: "script.js"}, "/test/script.js"},
+		{"empty path", Script{Filename: "script.js"}, "script.js"},
+		{"empty filename", Script{Path: "/test/"}, "/test/"},
+		{"both empty", Script{}, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.script.FullName())
+		})
+	}
+}
+
+func Test_Script_UpdateCommand(t *testing.T) {
+	baseCmd := []string{"k6", "run", "script.js"}
+
+	tests := []struct {
+		name   string
+		script Script
+		check  func(t *testing.T, result []string)
+	}{
+		{
+			name:   "LocalFile wraps command with existence check",
+			script: Script{Type: "LocalFile", Path: "/test/", Filename: "script.js"},
+			check: func(t *testing.T, result []string) {
+				assert.Equal(t, []string{"sh", "-c"}, result[:2])
+				assert.Contains(t, result[2], "/test/script.js")
+				assert.Contains(t, result[2], "LocalFile not found exiting...")
+				assert.Contains(t, result[2], "k6 run script.js")
+			},
+		},
+		{
+			name:   "ConfigMap returns command unchanged",
+			script: Script{Type: "ConfigMap"},
+			check: func(t *testing.T, result []string) {
+				assert.Equal(t, baseCmd, result)
+			},
+		},
+		{
+			name:   "VolumeClaim returns command unchanged",
+			script: Script{Type: "VolumeClaim"},
+			check: func(t *testing.T, result []string) {
+				assert.Equal(t, baseCmd, result)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.script.UpdateCommand(baseCmd)
+			tt.check(t, result)
 		})
 	}
 }

--- a/pkg/types/script_test.go
+++ b/pkg/types/script_test.go
@@ -1,0 +1,60 @@
+package types
+
+import (
+	"testing"
+
+	deep "github.com/go-test/deep"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func Test_Script_Volume(t *testing.T) {
+	tests := []struct {
+		name     string
+		script   Script
+		expected []corev1.Volume
+	}{
+		{
+			name:   "VolumeClaim",
+			script: Script{Type: "VolumeClaim", Name: "test"},
+			expected: []corev1.Volume{
+				{
+					Name: "k6-test-volume",
+					VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+							ClaimName: "test",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:   "ConfigMap",
+			script: Script{Type: "ConfigMap", Name: "test"},
+			expected: []corev1.Volume{
+				{
+					Name: "k6-test-volume",
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "test",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "no type (should be blocked by early validation)",
+			script:   Script{Name: "test"},
+			expected: []corev1.Volume{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if diff := deep.Equal(tt.script.Volume(), tt.expected); diff != nil {
+				t.Errorf("Volume() diff: %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Another maintenance PR. Changes:

- Refactor outdated monstrosity in `runner_test.go`
- Add some missing unit tests, esp. around `volumeClaim`
- Comment on `initializer.disabled` behaviour
    - With this field, we basically introduced ad-hoc, conditional logic, which may seem convoluted on the first glance. Comment is propagated to generated CRD docs and hopefully, should help understanding a bit.