### PR TITLE
Add and refactor unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS_ROOT)/kubebuilder/bin
 
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run unit tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -race $$(go list ./... | grep -v /e2e) -coverprofile cover.out
 
 e2e: deploy ## Run an end-to-end test.
 	kubectl create configmap crocodile-stress-test --from-file e2e/test.js

--- a/api/v1alpha1/testrun_types_test.go
+++ b/api/v1alpha1/testrun_types_test.go
@@ -8,11 +8,12 @@ import (
 )
 
 func Test_ParseScript(t *testing.T) {
-	testCases := []struct {
+	t.Parallel()
+	tests := []struct {
 		name        string
 		expectedErr bool
 		expected    *types.Script
-		tr          *TestRunSpec
+		spec        *TestRunSpec
 	}{
 		{
 			"Empty script",
@@ -183,20 +184,19 @@ func Test_ParseScript(t *testing.T) {
 		},
 	}
 
-	for _, testCase := range testCases {
-		testCase := testCase
-		t.Run(testCase.name, func(t *testing.T) {
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			script, err := testCase.tr.ParseScript()
-			if testCase.expectedErr && err == nil {
+			script, err := tt.spec.ParseScript()
+			if tt.expectedErr && err == nil {
 				t.Errorf("ParseScript should have returned an error.")
 			}
-			if !testCase.expectedErr && err != nil {
+			if !tt.expectedErr && err != nil {
 				t.Errorf("ParseScript returned unexpected error: %v", err)
 			}
-			if !reflect.DeepEqual(script, testCase.expected) {
-				t.Errorf("ParseScript failed to return expected output, got: %v, expected: %v", script, testCase.expected)
+			if !reflect.DeepEqual(script, tt.expected) {
+				t.Errorf("ParseScript() = %v, want %v", script, tt.expected)
 			}
 		})
 	}

--- a/pkg/plz/workers_test.go
+++ b/pkg/plz/workers_test.go
@@ -1,0 +1,157 @@
+package plz
+
+import (
+	"fmt"
+	rand "math/rand/v2"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/grafana/k6-operator/api/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func newTestWorker() *PLZWorker {
+	c, _ := client.New(nil, client.Options{})
+	return NewPLZWorker(&v1alpha1.PrivateLoadZone{}, "token", c, logr.Logger{})
+}
+
+func Test_PLZWorkers_AddWorker(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		var workers PLZWorkers
+		w := newTestWorker()
+
+		err := workers.AddWorker("foo", w)
+		assert.NoError(t, err)
+	})
+
+	t.Run("duplicate", func(t *testing.T) {
+		var workers PLZWorkers
+		w := newTestWorker()
+
+		require.NoError(t, workers.AddWorker("foo", w))
+		err := workers.AddWorker("foo", w)
+		assert.Error(t, err)
+	})
+}
+
+func Test_PLZWorkers_GetWorker(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		var workers PLZWorkers
+		w := newTestWorker()
+		require.NoError(t, workers.AddWorker("foo", w))
+
+		got, err := workers.GetWorker("foo")
+		assert.NoError(t, err)
+		assert.Equal(t, w, got)
+	})
+
+	t.Run("missing", func(t *testing.T) {
+		var workers PLZWorkers
+		_, err := workers.GetWorker("nonexistent")
+		assert.Error(t, err)
+	})
+}
+
+func Test_PLZWorkers_DeleteWorker(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		var workers PLZWorkers
+		w := newTestWorker()
+		require.NoError(t, workers.AddWorker("foo", w))
+
+		workers.DeleteWorker("foo")
+
+		_, err := workers.GetWorker("foo")
+		assert.Error(t, err)
+	})
+
+	t.Run("nonexistent", func(t *testing.T) {
+		var workers PLZWorkers
+		// should not panic
+		workers.DeleteWorker("nonexistent")
+	})
+}
+
+func Test_PLZWorkers_Concurrent(t *testing.T) {
+	t.Run("add with different keys", func(t *testing.T) {
+		var workers PLZWorkers
+		var wg sync.WaitGroup
+
+		const n = 20
+		for i := 0; i < n; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				w := newTestWorker()
+				err := workers.AddWorker(fmt.Sprintf("plz-%d", i), w)
+				assert.NoError(t, err)
+			}()
+		}
+		wg.Wait()
+
+		for i := 0; i < n; i++ {
+			_, err := workers.GetWorker(fmt.Sprintf("plz-%d", i))
+			assert.NoError(t, err)
+		}
+	})
+
+	t.Run("add with same key", func(t *testing.T) {
+		var workers PLZWorkers
+		var wg sync.WaitGroup
+		var successes atomic.Int32
+
+		const n = 20
+		for i := 0; i < n; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				w := newTestWorker()
+				if err := workers.AddWorker("contested", w); err == nil {
+					successes.Add(1)
+				}
+			}()
+		}
+		wg.Wait()
+
+		assert.Equal(t, int32(1), successes.Load(), "exactly one AddWorker should succeed")
+
+		_, err := workers.GetWorker("contested")
+		assert.NoError(t, err)
+	})
+
+	t.Run("all ops", func(t *testing.T) {
+		var workers PLZWorkers
+
+		const n = 20
+		keys := make([]string, n)
+		for i := 0; i < n; i++ {
+			keys[i] = fmt.Sprintf("plz-%d", i)
+		}
+
+		for _, key := range keys {
+			require.NoError(t, workers.AddWorker(key, newTestWorker()))
+		}
+
+		var wg sync.WaitGroup
+		for i := 0; i < n*3; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				key := keys[rand.IntN(n)]
+				switch rand.IntN(3) {
+				case 0:
+					_ = workers.AddWorker(key, newTestWorker())
+				case 1:
+					_, _ = workers.GetWorker(key)
+				case 2:
+					workers.DeleteWorker(key)
+				}
+			}()
+		}
+
+		wg.Wait()
+	})
+}


### PR DESCRIPTION
Pulling some unit tests out from https://github.com/grafana/k6-operator/pull/755 as it will be delayed.

Additionally, adding `-race` to `make test`.
