### PR TITLE
[feat] Transmit new environment variables in the k6 Operator when running the k6 binary

### DIFF
--- a/internal/controller/testrun_controller.go
+++ b/internal/controller/testrun_controller.go
@@ -327,13 +327,9 @@ func (r *TestRunReconciler) reconcile(ctx context.Context, req ctrl.Request, log
 			}
 		}
 
-		// If this is a non-PLZ cloud test run, try to finalize it.
-		// PLZ test runs are finalized by k6's own cloud output when the scheduler
-		// stops; the operator's FinishTestRun call (POST /v1/tests/{id}) returns
-		// 404 for PLZ runs and must be skipped to avoid getting stuck here.
+		// If this is a cloud test run in any mode, try to finalize it.
 		if v1alpha1.IsTrue(k6, v1alpha1.CloudTestRun) &&
-			v1alpha1.IsFalse(k6, v1alpha1.CloudTestRunFinalized) &&
-			v1alpha1.IsFalse(k6, v1alpha1.CloudPLZTestRun) {
+			v1alpha1.IsFalse(k6, v1alpha1.CloudTestRunFinalized) {
 
 			// If TestRunRunning has just been updated, wait for a bit before
 			// acting, to avoid race condition between different reconcile loops.

--- a/internal/controller/testrun_controller.go
+++ b/internal/controller/testrun_controller.go
@@ -327,9 +327,13 @@ func (r *TestRunReconciler) reconcile(ctx context.Context, req ctrl.Request, log
 			}
 		}
 
-		// If this is a cloud test run in any mode, try to finalize it.
+		// If this is a non-PLZ cloud test run, try to finalize it.
+		// PLZ test runs are finalized by k6's own cloud output when the scheduler
+		// stops; the operator's FinishTestRun call (POST /v1/tests/{id}) returns
+		// 404 for PLZ runs and must be skipped to avoid getting stuck here.
 		if v1alpha1.IsTrue(k6, v1alpha1.CloudTestRun) &&
-			v1alpha1.IsFalse(k6, v1alpha1.CloudTestRunFinalized) {
+			v1alpha1.IsFalse(k6, v1alpha1.CloudTestRunFinalized) &&
+			v1alpha1.IsFalse(k6, v1alpha1.CloudPLZTestRun) {
 
 			// If TestRunRunning has just been updated, wait for a bit before
 			// acting, to avoid race condition between different reconcile loops.

--- a/pkg/cloud/test_runs.go
+++ b/pkg/cloud/test_runs.go
@@ -109,7 +109,7 @@ func getTestRun(client *cloudapi.Client, url string) (*TestRunData, error) {
 
 // called by PLZworker
 func GetTestRunData(client *cloudapi.Client, refID string) (*TestRunData, error) {
-	url := fmt.Sprintf("%s/loadtests/v4/test_runs(%s)?$select=id,run_status,k8s_load_zones_config,k6_runtime_config", strings.TrimSuffix(client.BaseURL(), "/v1"), refID)
+	url := fmt.Sprintf("%s/loadtests/v4/test_runs(%s)?$select=id,run_status,k8s_load_zones_config,k6_runtime_config,test_run_token,secrets_config", strings.TrimSuffix(client.BaseURL(), "/v1"), refID)
 	return getTestRun(client, url)
 }
 

--- a/pkg/cloud/types.go
+++ b/pkg/cloud/types.go
@@ -57,6 +57,12 @@ type testRunList struct {
 	} `json:"object"`
 }
 
+// SecretsConfig holds the secrets configuration returned by k6 Cloud.
+type SecretsConfig struct {
+	Endpoint     string `json:"endpoint"`
+	ResponsePath string `json:"response_path"`
+}
+
 // TestRunData holds the output from /loadtests/v4/test_runs(%s)
 type TestRunData struct {
 	TestRunId     int `json:"id"`
@@ -64,6 +70,8 @@ type TestRunData struct {
 	LZConfig      `json:"k8s_load_zones_config"`
 	RunStatus     cloudapi.RunStatus `json:"run_status"`
 	RuntimeConfig cloudapi.Config    `json:"k6_runtime_config"`
+	TestRunToken  string             `json:"test_run_token,omitempty"`
+	SecretsConfig *SecretsConfig     `json:"secrets_config,omitempty"`
 }
 
 type LZConfig struct {

--- a/pkg/cloud/types.go
+++ b/pkg/cloud/types.go
@@ -63,6 +63,13 @@ type SecretsConfig struct {
 	ResponsePath string `json:"response_path"`
 }
 
+const (
+	secretSourceEnvVar      = "K6_SECRET_SOURCE"
+	secretSourceURLTemplate = "K6_SECRET_SOURCE_URL_URL_TEMPLATE"
+	secretSourceURLRespPath = "K6_SECRET_SOURCE_URL_RESPONSE_PATH"
+	secretSourceURLAuthKey  = "K6_SECRET_SOURCE_URL_HEADER_AUTHORIZATION"
+)
+
 // TestRunData holds the output from /loadtests/v4/test_runs(%s)
 type TestRunData struct {
 	TestRunId     int `json:"id"`
@@ -100,6 +107,26 @@ func (lz *LZConfig) EnvVars() []corev1.EnvVar {
 		return ev[i].Name < ev[j].Name
 	})
 
+	return ev
+}
+
+// SecretsEnvVars returns the env vars required by the k6 URL secret source.
+// Returns nil when no secrets configuration is present.
+func (trd *TestRunData) SecretsEnvVars() []corev1.EnvVar {
+	if trd.SecretsConfig == nil {
+		return nil
+	}
+	ev := []corev1.EnvVar{
+		{Name: secretSourceEnvVar, Value: "url"},
+		{Name: secretSourceURLTemplate, Value: trd.SecretsConfig.Endpoint},
+		{Name: secretSourceURLRespPath, Value: trd.SecretsConfig.ResponsePath},
+	}
+	if trd.TestRunToken != "" {
+		ev = append(ev, corev1.EnvVar{
+			Name:  secretSourceURLAuthKey,
+			Value: "Bearer " + trd.TestRunToken,
+		})
+	}
 	return ev
 }
 

--- a/pkg/cloud/types.go
+++ b/pkg/cloud/types.go
@@ -77,7 +77,8 @@ type TestRunData struct {
 	LZConfig      `json:"k8s_load_zones_config"`
 	RunStatus     cloudapi.RunStatus `json:"run_status"`
 	RuntimeConfig cloudapi.Config    `json:"k6_runtime_config"`
-	TestRunToken  string             `json:"test_run_token,omitempty"`
+	// SecretsToken is a short-lived, test-run-scoped token for read-only access to secrets.
+	SecretsToken  string             `json:"test_run_token,omitempty"`
 	SecretsConfig *SecretsConfig     `json:"secrets_config,omitempty"`
 }
 
@@ -121,10 +122,10 @@ func (trd *TestRunData) SecretsEnvVars() []corev1.EnvVar {
 		{Name: secretSourceURLTemplate, Value: trd.SecretsConfig.Endpoint},
 		{Name: secretSourceURLRespPath, Value: trd.SecretsConfig.ResponsePath},
 	}
-	if trd.TestRunToken != "" {
+	if trd.SecretsToken != "" {
 		ev = append(ev, corev1.EnvVar{
 			Name:  secretSourceURLAuthKey,
-			Value: "Bearer " + trd.TestRunToken,
+			Value: "Bearer " + trd.SecretsToken,
 		})
 	}
 	return ev

--- a/pkg/cloud/types_test.go
+++ b/pkg/cloud/types_test.go
@@ -110,12 +110,6 @@ func TestTestRunData_SecretsEnvVars(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := tt.trd.SecretsEnvVars()
-			if tt.expected == nil {
-				if got != nil {
-					t.Errorf("SecretsEnvVars() = %+v, want nil", got)
-				}
-				return
-			}
 			if len(got) != len(tt.expected) {
 				t.Fatalf("SecretsEnvVars() len = %d, want %d; got %+v", len(got), len(tt.expected), got)
 			}

--- a/pkg/cloud/types_test.go
+++ b/pkg/cloud/types_test.go
@@ -80,17 +80,6 @@ func TestTestRunData_SecretsEnvVars(t *testing.T) {
 			expected: nil,
 		},
 		{
-			name: "secrets config without token omits auth header",
-			trd: TestRunData{
-				SecretsConfig: &SecretsConfig{Endpoint: someEndpoint, ResponsePath: someRespPath},
-			},
-			expected: []corev1.EnvVar{
-				{Name: secretSourceEnvVar, Value: "url"},
-				{Name: secretSourceURLTemplate, Value: someEndpoint},
-				{Name: secretSourceURLRespPath, Value: someRespPath},
-			},
-		},
-		{
 			name: "secrets config with token includes auth header",
 			trd: TestRunData{
 				SecretsConfig: &SecretsConfig{Endpoint: someEndpoint, ResponsePath: someRespPath},

--- a/pkg/cloud/types_test.go
+++ b/pkg/cloud/types_test.go
@@ -83,7 +83,7 @@ func TestTestRunData_SecretsEnvVars(t *testing.T) {
 			name: "secrets config with token includes auth header",
 			trd: TestRunData{
 				SecretsConfig: &SecretsConfig{Endpoint: someEndpoint, ResponsePath: someRespPath},
-				TestRunToken:  someToken,
+				SecretsToken:  someToken,
 			},
 			expected: []corev1.EnvVar{
 				{Name: secretSourceEnvVar, Value: "url"},

--- a/pkg/cloud/types_test.go
+++ b/pkg/cloud/types_test.go
@@ -3,6 +3,8 @@ package cloud
 import (
 	"encoding/json"
 	"testing"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
 func TestInspectOutput_TestNameAndProjectID(t *testing.T) {
@@ -55,6 +57,66 @@ func TestInspectOutput_TestNameAndProjectID(t *testing.T) {
 
 			if got := io.TestName(); got != tt.expectedName {
 				t.Errorf("InspectOutput.TestName() = %v, want %v", got, tt.expectedName)
+			}
+		})
+	}
+}
+
+func TestTestRunData_SecretsEnvVars(t *testing.T) {
+	t.Parallel()
+
+	someEndpoint := "https://api.k6.io/provisioning/v1/test_runs/42/decrypt_secret?name={key}"
+	someRespPath := "plaintext"
+	someToken := "abc123"
+
+	tests := []struct {
+		name     string
+		trd      TestRunData
+		expected []corev1.EnvVar
+	}{
+		{
+			name:     "nil secrets config returns nil",
+			trd:      TestRunData{},
+			expected: nil,
+		},
+		{
+			name: "secrets config without token omits auth header",
+			trd: TestRunData{
+				SecretsConfig: &SecretsConfig{Endpoint: someEndpoint, ResponsePath: someRespPath},
+			},
+			expected: []corev1.EnvVar{
+				{Name: "K6_SECRET_SOURCE", Value: "url"},
+				{Name: "K6_SECRET_SOURCE_URL_URL_TEMPLATE", Value: someEndpoint},
+				{Name: "K6_SECRET_SOURCE_URL_RESPONSE_PATH", Value: someRespPath},
+			},
+		},
+		{
+			name: "secrets config with token includes auth header",
+			trd: TestRunData{
+				SecretsConfig: &SecretsConfig{Endpoint: someEndpoint, ResponsePath: someRespPath},
+				TestRunToken:  someToken,
+			},
+			expected: []corev1.EnvVar{
+				{Name: "K6_SECRET_SOURCE", Value: "url"},
+				{Name: "K6_SECRET_SOURCE_URL_URL_TEMPLATE", Value: someEndpoint},
+				{Name: "K6_SECRET_SOURCE_URL_RESPONSE_PATH", Value: someRespPath},
+				{Name: "K6_SECRET_SOURCE_URL_HEADER_AUTHORIZATION", Value: "Bearer " + someToken},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := tt.trd.SecretsEnvVars()
+			if len(got) != len(tt.expected) {
+				t.Fatalf("SecretsEnvVars() len = %d, want %d; got %+v", len(got), len(tt.expected), got)
+			}
+			for i := range got {
+				if got[i] != tt.expected[i] {
+					t.Errorf("SecretsEnvVars()[%d] = %+v, want %+v", i, got[i], tt.expected[i])
+				}
 			}
 		})
 	}

--- a/pkg/cloud/types_test.go
+++ b/pkg/cloud/types_test.go
@@ -110,6 +110,12 @@ func TestTestRunData_SecretsEnvVars(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := tt.trd.SecretsEnvVars()
+			if tt.expected == nil {
+				if got != nil {
+					t.Errorf("SecretsEnvVars() = %+v, want nil", got)
+				}
+				return
+			}
 			if len(got) != len(tt.expected) {
 				t.Fatalf("SecretsEnvVars() len = %d, want %d; got %+v", len(got), len(tt.expected), got)
 			}

--- a/pkg/cloud/types_test.go
+++ b/pkg/cloud/types_test.go
@@ -72,7 +72,7 @@ func TestTestRunData_SecretsEnvVars(t *testing.T) {
 	tests := []struct {
 		name     string
 		trd      TestRunData
-		expected []corev1.EnvVar
+		expected []corev1.EnvVar // order of env vars is important
 	}{
 		{
 			name:     "nil secrets config returns nil",

--- a/pkg/cloud/types_test.go
+++ b/pkg/cloud/types_test.go
@@ -85,9 +85,9 @@ func TestTestRunData_SecretsEnvVars(t *testing.T) {
 				SecretsConfig: &SecretsConfig{Endpoint: someEndpoint, ResponsePath: someRespPath},
 			},
 			expected: []corev1.EnvVar{
-				{Name: "K6_SECRET_SOURCE", Value: "url"},
-				{Name: "K6_SECRET_SOURCE_URL_URL_TEMPLATE", Value: someEndpoint},
-				{Name: "K6_SECRET_SOURCE_URL_RESPONSE_PATH", Value: someRespPath},
+				{Name: secretSourceEnvVar, Value: "url"},
+				{Name: secretSourceURLTemplate, Value: someEndpoint},
+				{Name: secretSourceURLRespPath, Value: someRespPath},
 			},
 		},
 		{
@@ -97,10 +97,10 @@ func TestTestRunData_SecretsEnvVars(t *testing.T) {
 				TestRunToken:  someToken,
 			},
 			expected: []corev1.EnvVar{
-				{Name: "K6_SECRET_SOURCE", Value: "url"},
-				{Name: "K6_SECRET_SOURCE_URL_URL_TEMPLATE", Value: someEndpoint},
-				{Name: "K6_SECRET_SOURCE_URL_RESPONSE_PATH", Value: someRespPath},
-				{Name: "K6_SECRET_SOURCE_URL_HEADER_AUTHORIZATION", Value: "Bearer " + someToken},
+				{Name: secretSourceEnvVar, Value: "url"},
+				{Name: secretSourceURLTemplate, Value: someEndpoint},
+				{Name: secretSourceURLRespPath, Value: someRespPath},
+				{Name: secretSourceURLAuthKey, Value: "Bearer " + someToken},
 			},
 		},
 	}

--- a/pkg/plz/worker.go
+++ b/pkg/plz/worker.go
@@ -177,6 +177,20 @@ func (w *PLZWorker) complete(tr *v1alpha1.TestRun, trData *cloud.TestRunData) {
 
 	envVars = append(envVars, cloud.AggregationEnvVars(&trData.RuntimeConfig)...)
 
+	if trData.SecretsConfig != nil {
+		envVars = append(envVars,
+			corev1.EnvVar{Name: "K6_SECRET_SOURCE", Value: "url"},
+			corev1.EnvVar{Name: "K6_SECRET_SOURCE_URL_URL_TEMPLATE", Value: trData.SecretsConfig.Endpoint},
+			corev1.EnvVar{Name: "K6_SECRET_SOURCE_URL_RESPONSE_PATH", Value: trData.SecretsConfig.ResponsePath},
+		)
+		if trData.TestRunToken != "" {
+			envVars = append(envVars, corev1.EnvVar{
+				Name:  "K6_SECRET_SOURCE_URL_HEADER_AUTHORIZATION",
+				Value: "Bearer " + trData.TestRunToken,
+			})
+		}
+	}
+
 	tr.Spec.Runner.Image = trData.RunnerImage
 	tr.Spec.Runner.InitContainers = []v1alpha1.InitContainer{
 		initContainer,

--- a/pkg/plz/worker.go
+++ b/pkg/plz/worker.go
@@ -177,19 +177,7 @@ func (w *PLZWorker) complete(tr *v1alpha1.TestRun, trData *cloud.TestRunData) {
 
 	envVars = append(envVars, cloud.AggregationEnvVars(&trData.RuntimeConfig)...)
 
-	if trData.SecretsConfig != nil {
-		envVars = append(envVars,
-			corev1.EnvVar{Name: "K6_SECRET_SOURCE", Value: "url"},
-			corev1.EnvVar{Name: "K6_SECRET_SOURCE_URL_URL_TEMPLATE", Value: trData.SecretsConfig.Endpoint},
-			corev1.EnvVar{Name: "K6_SECRET_SOURCE_URL_RESPONSE_PATH", Value: trData.SecretsConfig.ResponsePath},
-		)
-		if trData.TestRunToken != "" {
-			envVars = append(envVars, corev1.EnvVar{
-				Name:  "K6_SECRET_SOURCE_URL_HEADER_AUTHORIZATION",
-				Value: "Bearer " + trData.TestRunToken,
-			})
-		}
-	}
+	envVars = append(envVars, trData.SecretsEnvVars()...)
 
 	tr.Spec.Runner.Image = trData.RunnerImage
 	tr.Spec.Runner.InitContainers = []v1alpha1.InitContainer{

--- a/pkg/plz/worker_test.go
+++ b/pkg/plz/worker_test.go
@@ -239,7 +239,7 @@ func Test_complete_correctDefinitionOfTestRun(t *testing.T) {
 
 	secretsWithTokenTestRun = cloudFieldsTestRun
 	secretsWithTokenTestRun.Spec.Runner.Env = append(
-		append([]corev1.EnvVar{}, defaultTestRun.Spec.Runner.Env...),
+		append([]corev1.EnvVar{}, cloudFieldsTestRun.Spec.Runner.Env...),
 		corev1.EnvVar{Name: "K6_SECRET_SOURCE", Value: "url"},
 		corev1.EnvVar{Name: "K6_SECRET_SOURCE_URL_URL_TEMPLATE", Value: someSecretsConfig.Endpoint},
 		corev1.EnvVar{Name: "K6_SECRET_SOURCE_URL_RESPONSE_PATH", Value: someSecretsConfig.ResponsePath},
@@ -248,7 +248,7 @@ func Test_complete_correctDefinitionOfTestRun(t *testing.T) {
 
 	secretsWithoutTokenTestRun = cloudFieldsTestRun
 	secretsWithoutTokenTestRun.Spec.Runner.Env = append(
-		append([]corev1.EnvVar{}, defaultTestRun.Spec.Runner.Env...),
+		append([]corev1.EnvVar{}, cloudFieldsTestRun.Spec.Runner.Env...),
 		corev1.EnvVar{Name: "K6_SECRET_SOURCE", Value: "url"},
 		corev1.EnvVar{Name: "K6_SECRET_SOURCE_URL_URL_TEMPLATE", Value: someSecretsConfig.Endpoint},
 		corev1.EnvVar{Name: "K6_SECRET_SOURCE_URL_RESPONSE_PATH", Value: someSecretsConfig.ResponsePath},

--- a/pkg/plz/worker_test.go
+++ b/pkg/plz/worker_test.go
@@ -440,7 +440,7 @@ func Test_complete_correctDefinitionOfTestRun(t *testing.T) {
 					InstanceCount: someInstances,
 					ArchiveURL:    someArchiveURL,
 				},
-				TestRunToken:  someTestRunToken,
+				SecretsToken:  someTestRunToken,
 				SecretsConfig: someSecretsConfig,
 			},
 			ingestUrl: mainIngest,

--- a/pkg/plz/worker_test.go
+++ b/pkg/plz/worker_test.go
@@ -166,8 +166,7 @@ func Test_complete_correctDefinitionOfTestRun(t *testing.T) {
 		podTemplateAllTestRun             = defaultTestRun //nolint:ineffassign
 
 		// TestRuns expected for secrets cases
-		secretsWithTokenTestRun    = defaultTestRun //nolint:ineffassign
-		secretsWithoutTokenTestRun = defaultTestRun //nolint:ineffassign
+		secretsWithTokenTestRun = defaultTestRun //nolint:ineffassign
 	)
 
 	// populate TestRuns for different test cases
@@ -244,14 +243,6 @@ func Test_complete_correctDefinitionOfTestRun(t *testing.T) {
 		corev1.EnvVar{Name: "K6_SECRET_SOURCE_URL_URL_TEMPLATE", Value: someSecretsConfig.Endpoint},
 		corev1.EnvVar{Name: "K6_SECRET_SOURCE_URL_RESPONSE_PATH", Value: someSecretsConfig.ResponsePath},
 		corev1.EnvVar{Name: "K6_SECRET_SOURCE_URL_HEADER_AUTHORIZATION", Value: "Bearer " + someTestRunToken},
-	)
-
-	secretsWithoutTokenTestRun = cloudFieldsTestRun
-	secretsWithoutTokenTestRun.Spec.Runner.Env = append(
-		append([]corev1.EnvVar{}, cloudFieldsTestRun.Spec.Runner.Env...),
-		corev1.EnvVar{Name: "K6_SECRET_SOURCE", Value: "url"},
-		corev1.EnvVar{Name: "K6_SECRET_SOURCE_URL_URL_TEMPLATE", Value: someSecretsConfig.Endpoint},
-		corev1.EnvVar{Name: "K6_SECRET_SOURCE_URL_RESPONSE_PATH", Value: someSecretsConfig.ResponsePath},
 	)
 
 	testCases := []struct {
@@ -454,28 +445,6 @@ func Test_complete_correctDefinitionOfTestRun(t *testing.T) {
 			},
 			ingestUrl: mainIngest,
 			expected:  &secretsWithTokenTestRun,
-		},
-		{
-			name: "secrets config without token",
-			plz: &v1alpha1.PrivateLoadZone{
-				Spec: v1alpha1.PrivateLoadZoneSpec{
-					Token: someToken,
-					Resources: corev1.ResourceRequirements{
-						Limits: resourceLimits,
-					},
-				},
-			},
-			cloudData: &cloud.TestRunData{
-				TestRunId: someTestRunID,
-				LZConfig: cloud.LZConfig{
-					RunnerImage:   someRunnerImage,
-					InstanceCount: someInstances,
-					ArchiveURL:    someArchiveURL,
-				},
-				SecretsConfig: someSecretsConfig,
-			},
-			ingestUrl: mainIngest,
-			expected:  &secretsWithoutTokenTestRun,
 		},
 	}
 

--- a/pkg/plz/worker_test.go
+++ b/pkg/plz/worker_test.go
@@ -164,6 +164,10 @@ func Test_complete_correctDefinitionOfTestRun(t *testing.T) {
 		podTemplateContainerSecCtxTestRun = defaultTestRun //nolint:ineffassign
 		podTemplatePodSecCtxTestRun       = defaultTestRun //nolint:ineffassign
 		podTemplateAllTestRun             = defaultTestRun //nolint:ineffassign
+
+		// TestRuns expected for secrets cases
+		secretsWithTokenTestRun    = defaultTestRun //nolint:ineffassign
+		secretsWithoutTokenTestRun = defaultTestRun //nolint:ineffassign
 	)
 
 	// populate TestRuns for different test cases
@@ -226,6 +230,29 @@ func Test_complete_correctDefinitionOfTestRun(t *testing.T) {
 	podTemplateAllTestRun.Spec.Starter.ContainerSecurityContext = someContainerSecCtx
 	podTemplateAllTestRun.Spec.Runner.SecurityContext = somePodSecCtx
 	podTemplateAllTestRun.Spec.Starter.SecurityContext = somePodSecCtx
+
+	someSecretsConfig := &cloud.SecretsConfig{
+		Endpoint:     "https://api.k6.io/provisioning/v1/test_runs/6543/decrypt_secret?name={key}",
+		ResponsePath: "plaintext",
+	}
+	someTestRunToken := "abc123token"
+
+	secretsWithTokenTestRun = cloudFieldsTestRun
+	secretsWithTokenTestRun.Spec.Runner.Env = append(
+		append([]corev1.EnvVar{}, defaultTestRun.Spec.Runner.Env...),
+		corev1.EnvVar{Name: "K6_SECRET_SOURCE", Value: "url"},
+		corev1.EnvVar{Name: "K6_SECRET_SOURCE_URL_URL_TEMPLATE", Value: someSecretsConfig.Endpoint},
+		corev1.EnvVar{Name: "K6_SECRET_SOURCE_URL_RESPONSE_PATH", Value: someSecretsConfig.ResponsePath},
+		corev1.EnvVar{Name: "K6_SECRET_SOURCE_URL_HEADER_AUTHORIZATION", Value: "Bearer " + someTestRunToken},
+	)
+
+	secretsWithoutTokenTestRun = cloudFieldsTestRun
+	secretsWithoutTokenTestRun.Spec.Runner.Env = append(
+		append([]corev1.EnvVar{}, defaultTestRun.Spec.Runner.Env...),
+		corev1.EnvVar{Name: "K6_SECRET_SOURCE", Value: "url"},
+		corev1.EnvVar{Name: "K6_SECRET_SOURCE_URL_URL_TEMPLATE", Value: someSecretsConfig.Endpoint},
+		corev1.EnvVar{Name: "K6_SECRET_SOURCE_URL_RESPONSE_PATH", Value: someSecretsConfig.ResponsePath},
+	)
 
 	testCases := []struct {
 		name      string
@@ -404,6 +431,51 @@ func Test_complete_correctDefinitionOfTestRun(t *testing.T) {
 			cloudData: &cloud.TestRunData{},
 			ingestUrl: mainIngest,
 			expected:  &podTemplateAllTestRun,
+		},
+		{
+			name: "secrets config with token",
+			plz: &v1alpha1.PrivateLoadZone{
+				Spec: v1alpha1.PrivateLoadZoneSpec{
+					Token: someToken,
+					Resources: corev1.ResourceRequirements{
+						Limits: resourceLimits,
+					},
+				},
+			},
+			cloudData: &cloud.TestRunData{
+				TestRunId: someTestRunID,
+				LZConfig: cloud.LZConfig{
+					RunnerImage:   someRunnerImage,
+					InstanceCount: someInstances,
+					ArchiveURL:    someArchiveURL,
+				},
+				TestRunToken:  someTestRunToken,
+				SecretsConfig: someSecretsConfig,
+			},
+			ingestUrl: mainIngest,
+			expected:  &secretsWithTokenTestRun,
+		},
+		{
+			name: "secrets config without token",
+			plz: &v1alpha1.PrivateLoadZone{
+				Spec: v1alpha1.PrivateLoadZoneSpec{
+					Token: someToken,
+					Resources: corev1.ResourceRequirements{
+						Limits: resourceLimits,
+					},
+				},
+			},
+			cloudData: &cloud.TestRunData{
+				TestRunId: someTestRunID,
+				LZConfig: cloud.LZConfig{
+					RunnerImage:   someRunnerImage,
+					InstanceCount: someInstances,
+					ArchiveURL:    someArchiveURL,
+				},
+				SecretsConfig: someSecretsConfig,
+			},
+			ingestUrl: mainIngest,
+			expected:  &secretsWithoutTokenTestRun,
 		},
 	}
 


### PR DESCRIPTION
https://github.com/grafana/k6-cloud/issues/4267

- Extend the GetTestRunData query to fetch `test_run_token` and `secrets_config` from the metrics-api endpoint.                                                                                                                                                          
- When secrets_config is present, inject `K6_SECRET_SOURCE=url`, `K6_SECRET_SOURCE_URL_URL_TEMPLATE`, `K6_SECRET_SOURCE_URL_RESPONSE_PATH`, and (if a token exists) `K6_SECRET_SOURCE_URL_HEADER_AUTHORIZATION` into the runner pod's environment, enabling k6 to decrypt secrets via the k6 Cloud secrets API.                                                                                                                                                                                                                                              
- Env-var-only approach (no `--secret-source url` CLI flag) ensures backward compatibility: runner images with k6 < v1.5.0 silently ignore the unknown vars and continue working normally.
   

Fixes: https://github.com/grafana/k6-operator/issues/747 