### PR TITLE
Adding support to specify SchedularName (optional) in Initializer/Starter/Runner/Stopper Specs/Jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ testbin
 *.env
 
 .devspace/
+
+.go-version

--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,3 @@ testbin
 *.env
 
 .devspace/
-
-.go-version

--- a/api/v1alpha1/testrun_types.go
+++ b/api/v1alpha1/testrun_types.go
@@ -59,6 +59,7 @@ type Pod struct {
 	Volumes                      []corev1.Volume                   `json:"volumes,omitempty"`
 	VolumeMounts                 []corev1.VolumeMount              `json:"volumeMounts,omitempty"`
 	PriorityClassName            string                            `json:"priorityClassName,omitempty"`
+	SchedulerName                string                            `json:"schedulerName,omitempty"`
 }
 
 type InitContainer struct {

--- a/config/crd/bases/k6.io_testruns.yaml
+++ b/config/crd/bases/k6.io_testruns.yaml
@@ -1078,6 +1078,8 @@ spec:
                           x-kubernetes-int-or-string: true
                         type: object
                     type: object
+                  schedulerName:
+                    type: string
                   securityContext:
                     properties:
                       appArmorProfile:
@@ -3116,6 +3118,8 @@ spec:
                           x-kubernetes-int-or-string: true
                         type: object
                     type: object
+                  schedulerName:
+                    type: string
                   securityContext:
                     properties:
                       appArmorProfile:
@@ -5175,6 +5179,8 @@ spec:
                           x-kubernetes-int-or-string: true
                         type: object
                     type: object
+                  schedulerName:
+                    type: string
                   securityContext:
                     properties:
                       appArmorProfile:

--- a/docs/crd-generated.md
+++ b/docs/crd-generated.md
@@ -17305,6 +17305,13 @@ alive or ready to receive traffic.<br/>
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>schedulerName</b></td>
+        <td>string</td>
+        <td>
+          <br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b><a href="#testrunspecinitializersecuritycontext">securityContext</a></b></td>
         <td>object</td>
         <td>
@@ -26266,6 +26273,13 @@ alive or ready to receive traffic.<br/>
         <td>object</td>
         <td>
           ResourceRequirements describes the compute resource requirements.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>schedulerName</b></td>
+        <td>string</td>
+        <td>
+          <br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -35252,6 +35266,13 @@ alive or ready to receive traffic.<br/>
         <td>object</td>
         <td>
           ResourceRequirements describes the compute resource requirements.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>schedulerName</b></td>
+        <td>string</td>
+        <td>
+          <br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/pkg/cloud/types.go
+++ b/pkg/cloud/types.go
@@ -78,8 +78,8 @@ type TestRunData struct {
 	RunStatus     cloudapi.RunStatus `json:"run_status"`
 	RuntimeConfig cloudapi.Config    `json:"k6_runtime_config"`
 	// SecretsToken is a short-lived, test-run-scoped token for read-only access to secrets.
-	SecretsToken  string             `json:"test_run_token,omitempty"`
-	SecretsConfig *SecretsConfig     `json:"secrets_config,omitempty"`
+	SecretsToken  string         `json:"test_run_token,omitempty"`
+	SecretsConfig *SecretsConfig `json:"secrets_config,omitempty"`
 }
 
 type LZConfig struct {

--- a/pkg/resources/jobs/initializer.go
+++ b/pkg/resources/jobs/initializer.go
@@ -24,6 +24,7 @@ func NewInitializerJob(k6 *v1alpha1.TestRun, argLine string) (*batchv1.Job, erro
 		serviceAccountName           = "default"
 		automountServiceAccountToken = true
 		ports                        = append([]corev1.ContainerPort{{ContainerPort: 6565}}, k6.GetSpec().Ports...)
+		schedulerName                = "default-scheduler"
 	)
 
 	if k6.GetSpec().Initializer == nil {
@@ -94,6 +95,10 @@ func NewInitializerJob(k6 *v1alpha1.TestRun, argLine string) (*batchv1.Job, erro
 	volumeMounts := script.VolumeMount()
 	volumeMounts = append(volumeMounts, k6.GetSpec().Initializer.VolumeMounts...)
 
+	if k6.GetSpec().Initializer.SchedulerName != "" {
+		schedulerName = k6.GetSpec().Initializer.SchedulerName
+	}
+
 	var zero32 int32
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
@@ -118,6 +123,7 @@ func NewInitializerJob(k6 *v1alpha1.TestRun, argLine string) (*batchv1.Job, erro
 					TopologySpreadConstraints:    k6.GetSpec().Initializer.TopologySpreadConstraints,
 					SecurityContext:              &k6.GetSpec().Initializer.SecurityContext,
 					RestartPolicy:                corev1.RestartPolicyNever,
+					SchedulerName:                schedulerName,
 					ImagePullSecrets:             k6.GetSpec().Initializer.ImagePullSecrets,
 					InitContainers:               getInitContainers(k6.GetSpec().Initializer, script),
 					Containers: []corev1.Container{

--- a/pkg/resources/jobs/initializer.go
+++ b/pkg/resources/jobs/initializer.go
@@ -24,7 +24,7 @@ func NewInitializerJob(k6 *v1alpha1.TestRun, argLine string) (*batchv1.Job, erro
 		serviceAccountName           = "default"
 		automountServiceAccountToken = true
 		ports                        = append([]corev1.ContainerPort{{ContainerPort: 6565}}, k6.GetSpec().Ports...)
-		schedulerName                = "default-scheduler"
+		schedulerName                = corev1.DefaultSchedulerName
 	)
 
 	if k6.GetSpec().Initializer == nil {

--- a/pkg/resources/jobs/initializer_test.go
+++ b/pkg/resources/jobs/initializer_test.go
@@ -51,6 +51,7 @@ func Test_NewInitializerJob(t *testing.T) {
 				Spec: corev1.PodSpec{
 					AutomountServiceAccountToken: &automountServiceAccountToken,
 					ServiceAccountName:           "default",
+					SchedulerName:                "default-scheduler",
 					Affinity:                     nil,
 					NodeSelector:                 nil,
 					Tolerations:                  nil,
@@ -252,5 +253,128 @@ func Test_InitializerEnvVarFlags(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func Test_NewInitializerJobWithSchedulerName(t *testing.T) {
+	script := &types.Script{
+		Name:     "test",
+		Filename: "test.js",
+		Type:     "ConfigMap",
+	}
+
+	automountServiceAccountToken := true
+	zero := int32(0)
+
+	expectedOutcome := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-initializer",
+			Namespace: "test",
+			Labels: map[string]string{
+				"app":    "k6",
+				"k6_cr":  "test",
+				"label1": "awesome",
+			},
+			Annotations: map[string]string{
+				"awesomeAnnotation": "dope",
+			},
+		},
+		Spec: batchv1.JobSpec{
+			BackoffLimit: &zero,
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app":    "k6",
+						"k6_cr":  "test",
+						"label1": "awesome",
+					},
+					Annotations: map[string]string{
+						"awesomeAnnotation": "dope",
+					},
+				},
+				Spec: corev1.PodSpec{
+					AutomountServiceAccountToken: &automountServiceAccountToken,
+					ServiceAccountName:           "default",
+					SchedulerName:                "custom-scheduler",
+					Affinity:                     nil,
+					NodeSelector:                 nil,
+					Tolerations:                  nil,
+					TopologySpreadConstraints:    nil,
+					RestartPolicy:                corev1.RestartPolicyNever,
+					SecurityContext:              &corev1.PodSecurityContext{},
+					Containers: []corev1.Container{
+						{
+							Image:           "grafana/k6:latest",
+							ImagePullPolicy: "",
+							Name:            "k6",
+							Command: []string{
+								"sh", "-c",
+								"mkdir -p $(dirname /tmp/test.js.archived.tar) && k6 archive /test/test.js -O /tmp/test.js.archived.tar --out cloud 2> /tmp/k6logs && k6 inspect --execution-requirements /tmp/test.js.archived.tar 2> /tmp/k6logs ; ! cat /tmp/k6logs | grep 'level.*error'",
+							},
+							Env: []corev1.EnvVar{},
+							EnvFrom: []corev1.EnvFromSource{
+								{
+									ConfigMapRef: &corev1.ConfigMapEnvSource{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "env",
+										},
+									},
+								},
+							},
+							Resources:       corev1.ResourceRequirements{},
+							VolumeMounts:    script.VolumeMount(),
+							Ports:           []corev1.ContainerPort{{ContainerPort: 6565}},
+							SecurityContext: &corev1.SecurityContext{},
+						},
+					},
+					Volumes: script.Volume(),
+				},
+			},
+		},
+	}
+
+	k6 := &v1alpha1.TestRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+		Spec: v1alpha1.TestRunSpec{
+			Script: v1alpha1.K6Script{
+				ConfigMap: v1alpha1.K6Configmap{
+					Name: "test",
+					File: "test.js",
+				},
+			},
+			Arguments: "--out cloud",
+			Initializer: &v1alpha1.Pod{
+				Metadata: v1alpha1.PodMetadata{
+					Labels: map[string]string{
+						"label1": "awesome",
+					},
+					Annotations: map[string]string{
+						"awesomeAnnotation": "dope",
+					},
+				},
+				EnvFrom: []corev1.EnvFromSource{
+					{
+						ConfigMapRef: &corev1.ConfigMapEnvSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "env",
+							},
+						},
+					},
+				},
+				SchedulerName: "custom-scheduler",
+			},
+		},
+	}
+
+	job, err := NewInitializerJob(k6, "--out cloud")
+	if err != nil {
+		t.Errorf("NewInitializerJob errored, got: %v", err)
+	}
+
+	if diff := deep.Equal(job, expectedOutcome); diff != nil {
+		t.Error(diff)
 	}
 }

--- a/pkg/resources/jobs/initializer_test.go
+++ b/pkg/resources/jobs/initializer_test.go
@@ -12,7 +12,44 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func Test_NewInitializerJob(t *testing.T) {
+func defaultTestRunForInitializer() *v1alpha1.TestRun {
+	return &v1alpha1.TestRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+		Spec: v1alpha1.TestRunSpec{
+			Script: v1alpha1.K6Script{
+				ConfigMap: v1alpha1.K6Configmap{
+					Name: "test",
+					File: "test.js",
+				},
+			},
+			Arguments: "--out cloud",
+			Initializer: &v1alpha1.Pod{
+				Metadata: v1alpha1.PodMetadata{
+					Labels: map[string]string{
+						"label1": "awesome",
+					},
+					Annotations: map[string]string{
+						"awesomeAnnotation": "dope",
+					},
+				},
+				EnvFrom: []corev1.EnvFromSource{
+					{
+						ConfigMapRef: &corev1.ConfigMapEnvSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "env",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func defaultExpectedJobForInitializer() *batchv1.Job {
 	script := &types.Script{
 		Name:     "test",
 		Filename: "test.js",
@@ -22,7 +59,7 @@ func Test_NewInitializerJob(t *testing.T) {
 	automountServiceAccountToken := true
 	zero := int32(0)
 
-	expectedOutcome := &batchv1.Job{
+	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-initializer",
 			Namespace: "test",
@@ -88,49 +125,60 @@ func Test_NewInitializerJob(t *testing.T) {
 			},
 		},
 	}
-
-	k6 := &v1alpha1.TestRun{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: "test",
+}
+func Test_NewInitializerJob(t *testing.T) {
+	tests := []struct {
+		name             string
+		argLine          string
+		setupTestRun     func(*v1alpha1.TestRun)
+		setupExpectedJob func(*batchv1.Job)
+	}{
+		{
+			name:             "base",
+			argLine:          "--out cloud",
+			setupTestRun:     func(k6 *v1alpha1.TestRun) {},
+			setupExpectedJob: func(j *batchv1.Job) {},
 		},
-		Spec: v1alpha1.TestRunSpec{
-			Script: v1alpha1.K6Script{
-				ConfigMap: v1alpha1.K6Configmap{
-					Name: "test",
-					File: "test.js",
-				},
+		{
+			name:    "with custom scheduler name",
+			argLine: "--out cloud",
+			setupTestRun: func(k6 *v1alpha1.TestRun) {
+				k6.Spec.Initializer.SchedulerName = "custom-scheduler"
 			},
-			Arguments: "--out cloud",
-			Initializer: &v1alpha1.Pod{
-				Metadata: v1alpha1.PodMetadata{
-					Labels: map[string]string{
-						"label1": "awesome",
-					},
-					Annotations: map[string]string{
-						"awesomeAnnotation": "dope",
-					},
-				},
-				EnvFrom: []corev1.EnvFromSource{
-					{
-						ConfigMapRef: &corev1.ConfigMapEnvSource{
-							LocalObjectReference: corev1.LocalObjectReference{
-								Name: "env",
-							},
-						},
-					},
-				},
+			setupExpectedJob: func(j *batchv1.Job) {
+				j.Spec.Template.Spec.SchedulerName = "custom-scheduler"
 			},
 		},
 	}
 
-	job, err := NewInitializerJob(k6, "--out cloud")
-	if err != nil {
-		t.Errorf("NewInitializerJob errored, got: %v", err)
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 
-	if diff := deep.Equal(job, expectedOutcome); diff != nil {
-		t.Error(diff)
+			k6 := defaultTestRunForInitializer()
+
+			if tt.setupTestRun != nil {
+				tt.setupTestRun(k6)
+			}
+
+			expectedJob := defaultExpectedJobForInitializer()
+
+			if tt.setupExpectedJob != nil {
+				tt.setupExpectedJob(expectedJob)
+			}
+
+			job, err := NewInitializerJob(k6, tt.argLine)
+
+			if err != nil {
+				t.Fatalf("NewInitializerJob errored: %v", err)
+			}
+
+			diff := deep.Equal(job, expectedJob)
+
+			if diff != nil {
+				t.Errorf("NewInitializerJob difference: %v", diff)
+			}
+
+		})
 	}
 }
 
@@ -253,128 +301,5 @@ func Test_InitializerEnvVarFlags(t *testing.T) {
 				}
 			}
 		})
-	}
-}
-
-func Test_NewInitializerJobWithSchedulerName(t *testing.T) {
-	script := &types.Script{
-		Name:     "test",
-		Filename: "test.js",
-		Type:     "ConfigMap",
-	}
-
-	automountServiceAccountToken := true
-	zero := int32(0)
-
-	expectedOutcome := &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-initializer",
-			Namespace: "test",
-			Labels: map[string]string{
-				"app":    "k6",
-				"k6_cr":  "test",
-				"label1": "awesome",
-			},
-			Annotations: map[string]string{
-				"awesomeAnnotation": "dope",
-			},
-		},
-		Spec: batchv1.JobSpec{
-			BackoffLimit: &zero,
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						"app":    "k6",
-						"k6_cr":  "test",
-						"label1": "awesome",
-					},
-					Annotations: map[string]string{
-						"awesomeAnnotation": "dope",
-					},
-				},
-				Spec: corev1.PodSpec{
-					AutomountServiceAccountToken: &automountServiceAccountToken,
-					ServiceAccountName:           "default",
-					SchedulerName:                "custom-scheduler",
-					Affinity:                     nil,
-					NodeSelector:                 nil,
-					Tolerations:                  nil,
-					TopologySpreadConstraints:    nil,
-					RestartPolicy:                corev1.RestartPolicyNever,
-					SecurityContext:              &corev1.PodSecurityContext{},
-					Containers: []corev1.Container{
-						{
-							Image:           "grafana/k6:latest",
-							ImagePullPolicy: "",
-							Name:            "k6",
-							Command: []string{
-								"sh", "-c",
-								"mkdir -p $(dirname /tmp/test.js.archived.tar) && k6 archive /test/test.js -O /tmp/test.js.archived.tar --out cloud 2> /tmp/k6logs && k6 inspect --execution-requirements /tmp/test.js.archived.tar 2> /tmp/k6logs ; ! cat /tmp/k6logs | grep 'level.*error'",
-							},
-							Env: []corev1.EnvVar{},
-							EnvFrom: []corev1.EnvFromSource{
-								{
-									ConfigMapRef: &corev1.ConfigMapEnvSource{
-										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "env",
-										},
-									},
-								},
-							},
-							Resources:       corev1.ResourceRequirements{},
-							VolumeMounts:    script.VolumeMount(),
-							Ports:           []corev1.ContainerPort{{ContainerPort: 6565}},
-							SecurityContext: &corev1.SecurityContext{},
-						},
-					},
-					Volumes: script.Volume(),
-				},
-			},
-		},
-	}
-
-	k6 := &v1alpha1.TestRun{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: "test",
-		},
-		Spec: v1alpha1.TestRunSpec{
-			Script: v1alpha1.K6Script{
-				ConfigMap: v1alpha1.K6Configmap{
-					Name: "test",
-					File: "test.js",
-				},
-			},
-			Arguments: "--out cloud",
-			Initializer: &v1alpha1.Pod{
-				Metadata: v1alpha1.PodMetadata{
-					Labels: map[string]string{
-						"label1": "awesome",
-					},
-					Annotations: map[string]string{
-						"awesomeAnnotation": "dope",
-					},
-				},
-				EnvFrom: []corev1.EnvFromSource{
-					{
-						ConfigMapRef: &corev1.ConfigMapEnvSource{
-							LocalObjectReference: corev1.LocalObjectReference{
-								Name: "env",
-							},
-						},
-					},
-				},
-				SchedulerName: "custom-scheduler",
-			},
-		},
-	}
-
-	job, err := NewInitializerJob(k6, "--out cloud")
-	if err != nil {
-		t.Errorf("NewInitializerJob errored, got: %v", err)
-	}
-
-	if diff := deep.Equal(job, expectedOutcome); diff != nil {
-		t.Error(diff)
 	}
 }

--- a/pkg/resources/jobs/runner.go
+++ b/pkg/resources/jobs/runner.go
@@ -80,8 +80,9 @@ func NewRunnerJob(k6 *v1alpha1.TestRun, index int, tokenInfo *cloud.TokenInfo) (
 	command = script.UpdateCommand(command)
 
 	var (
-		zero   int64 = 0
-		zero32 int32 = 0
+		zero          int64 = 0
+		zero32        int32 = 0
+		schedulerName       = "default-scheduler"
 	)
 
 	image := "grafana/k6:latest"
@@ -160,6 +161,10 @@ func NewRunnerJob(k6 *v1alpha1.TestRun, index int, tokenInfo *cloud.TokenInfo) (
 	volumeMounts := script.VolumeMount()
 	volumeMounts = append(volumeMounts, k6.GetSpec().Runner.VolumeMounts...)
 
+	if k6.GetSpec().Runner.SchedulerName != "" {
+		schedulerName = k6.GetSpec().Runner.SchedulerName
+	}
+
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
@@ -179,6 +184,7 @@ func NewRunnerJob(k6 *v1alpha1.TestRun, index int, tokenInfo *cloud.TokenInfo) (
 					ServiceAccountName:           serviceAccountName,
 					Hostname:                     name,
 					RestartPolicy:                corev1.RestartPolicyNever,
+					SchedulerName:                schedulerName,
 					Affinity:                     k6.GetSpec().Runner.Affinity,
 					NodeSelector:                 k6.GetSpec().Runner.NodeSelector,
 					Tolerations:                  k6.GetSpec().Runner.Tolerations,

--- a/pkg/resources/jobs/runner.go
+++ b/pkg/resources/jobs/runner.go
@@ -82,7 +82,7 @@ func NewRunnerJob(k6 *v1alpha1.TestRun, index int, tokenInfo *cloud.TokenInfo) (
 	var (
 		zero          int64 = 0
 		zero32        int32 = 0
-		schedulerName       = "default-scheduler"
+		schedulerName       = corev1.DefaultSchedulerName
 	)
 
 	image := "grafana/k6:latest"

--- a/pkg/resources/jobs/runner_test.go
+++ b/pkg/resources/jobs/runner_test.go
@@ -112,6 +112,7 @@ func defaultExpectedJob(script *types.Script) *batchv1.Job {
 					Tolerations:                  nil,
 					TopologySpreadConstraints:    nil,
 					ServiceAccountName:           "default",
+					SchedulerName:                "default-scheduler",
 					AutomountServiceAccountToken: &automountServiceAccountToken,
 					Containers: []corev1.Container{{
 						Image:           "grafana/k6:latest",
@@ -186,6 +187,15 @@ func Test_NewRunnerJob(t *testing.T) {
 				j.Spec.Template.Spec.ServiceAccountName = "test"
 				j.Spec.Template.Spec.Containers[0].ImagePullPolicy = corev1.PullNever
 				j.Spec.Template.Spec.Containers[0].EnvFrom = envFromConfigMap("env")
+			},
+		},
+		{
+			name: "custom scheduler name",
+			setupTestRun: func(k6 *v1alpha1.TestRun) {
+				k6.Spec.Runner.SchedulerName = "custom-scheduler"
+			},
+			setupExpectedJob: func(j *batchv1.Job) {
+				j.Spec.Template.Spec.SchedulerName = "custom-scheduler"
 			},
 		},
 		{

--- a/pkg/resources/jobs/starter.go
+++ b/pkg/resources/jobs/starter.go
@@ -15,6 +15,10 @@ import (
 // NewStarterJob builds a template used for creating a starter job
 func NewStarterJob(k6 *v1alpha1.TestRun, hostname []string) *batchv1.Job {
 
+	var (
+		schedulerName = "default-scheduler"
+	)
+
 	starterAnnotations := make(map[string]string)
 	if k6.GetSpec().Starter.Metadata.Annotations != nil {
 		starterAnnotations = k6.GetSpec().Starter.Metadata.Annotations
@@ -62,6 +66,10 @@ func NewStarterJob(k6 *v1alpha1.TestRun, hostname []string) *batchv1.Job {
 		resourceRequirements = k6.GetSpec().Starter.Resources
 	}
 
+	if k6.GetSpec().Starter.SchedulerName != "" {
+		schedulerName = k6.GetSpec().Starter.SchedulerName
+	}
+
 	var zero32 int32
 
 	return &batchv1.Job{
@@ -86,6 +94,7 @@ func NewStarterJob(k6 *v1alpha1.TestRun, hostname []string) *batchv1.Job {
 					Tolerations:                  k6.GetSpec().Starter.Tolerations,
 					TopologySpreadConstraints:    k6.GetSpec().Starter.TopologySpreadConstraints,
 					RestartPolicy:                corev1.RestartPolicyNever,
+					SchedulerName:                schedulerName,
 					SecurityContext:              &k6.GetSpec().Starter.SecurityContext,
 					ImagePullSecrets:             k6.GetSpec().Starter.ImagePullSecrets,
 					Containers: []corev1.Container{

--- a/pkg/resources/jobs/starter.go
+++ b/pkg/resources/jobs/starter.go
@@ -16,7 +16,7 @@ import (
 func NewStarterJob(k6 *v1alpha1.TestRun, hostname []string) *batchv1.Job {
 
 	var (
-		schedulerName = "default-scheduler"
+		schedulerName = corev1.DefaultSchedulerName
 	)
 
 	starterAnnotations := make(map[string]string)

--- a/pkg/resources/jobs/starter_test.go
+++ b/pkg/resources/jobs/starter_test.go
@@ -46,6 +46,7 @@ func TestNewStarterJob(t *testing.T) {
 				Spec: corev1.PodSpec{
 					AutomountServiceAccountToken: &automountServiceAccountToken,
 					ServiceAccountName:           "default",
+					SchedulerName:                "default-scheduler",
 					Affinity:                     nil,
 					NodeSelector:                 nil,
 					Tolerations:                  nil,
@@ -139,6 +140,7 @@ func TestNewStarterJobIstio(t *testing.T) {
 				Spec: corev1.PodSpec{
 					AutomountServiceAccountToken: &automountServiceAccountToken,
 					ServiceAccountName:           "default",
+					SchedulerName:                "default-scheduler",
 					Affinity:                     nil,
 					NodeSelector:                 nil,
 					Tolerations:                  nil,
@@ -281,4 +283,99 @@ func TestNewStarterJobCustomResources(t *testing.T) {
 	if diff := deep.Equal(gotCustomRes, customRes); diff != nil {
 		t.Errorf("custom resources not applied: %v", diff)
 	}
+}
+
+func TestNewStarterJobWithSchedulerName(t *testing.T) {
+
+	automountServiceAccountToken := true
+	zero := int32(0)
+
+	expectedOutcome := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-starter",
+			Namespace: "test",
+			Labels: map[string]string{
+				"app":    "k6",
+				"k6_cr":  "test",
+				"label1": "awesome",
+			},
+			Annotations: map[string]string{
+				"awesomeAnnotation": "dope",
+			},
+		},
+		Spec: batchv1.JobSpec{
+			BackoffLimit: &zero,
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app":    "k6",
+						"k6_cr":  "test",
+						"label1": "awesome",
+					},
+					Annotations: map[string]string{
+						"awesomeAnnotation": "dope",
+					},
+				},
+				Spec: corev1.PodSpec{
+					AutomountServiceAccountToken: &automountServiceAccountToken,
+					ServiceAccountName:           "default",
+					SchedulerName:                "custom-scheduler",
+					Affinity:                     nil,
+					NodeSelector:                 nil,
+					Tolerations:                  nil,
+					TopologySpreadConstraints:    nil,
+					RestartPolicy:                corev1.RestartPolicyNever,
+					SecurityContext:              &corev1.PodSecurityContext{},
+					Containers: []corev1.Container{
+						containers.NewStartContainer([]string{"testing"}, "image", corev1.PullNever, []string{"sh", "-c"},
+							[]corev1.EnvVar{}, corev1.SecurityContext{}, corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    *resource.NewMilliQuantity(50, resource.DecimalSI),
+									corev1.ResourceMemory: *resource.NewQuantity(2097152, resource.BinarySI),
+								},
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    *resource.NewMilliQuantity(100, resource.DecimalSI),
+									corev1.ResourceMemory: *resource.NewQuantity(209715200, resource.BinarySI),
+								},
+							},
+						),
+					},
+				},
+			},
+		},
+	}
+
+	k6 := &v1alpha1.TestRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+		Spec: v1alpha1.TestRunSpec{
+			Script: v1alpha1.K6Script{
+				ConfigMap: v1alpha1.K6Configmap{
+					Name: "test",
+					File: "test.js",
+				},
+			},
+			Starter: v1alpha1.Pod{
+				Metadata: v1alpha1.PodMetadata{
+					Labels: map[string]string{
+						"label1": "awesome",
+					},
+					Annotations: map[string]string{
+						"awesomeAnnotation": "dope",
+					},
+				},
+				Image:           "image",
+				ImagePullPolicy: corev1.PullNever,
+				SchedulerName:   "custom-scheduler",
+			},
+		},
+	}
+
+	job := NewStarterJob(k6, []string{"testing"})
+	if diff := deep.Equal(job, expectedOutcome); diff != nil {
+		t.Error(diff)
+	}
+
 }

--- a/pkg/resources/jobs/starter_test.go
+++ b/pkg/resources/jobs/starter_test.go
@@ -12,12 +12,41 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestNewStarterJob(t *testing.T) {
+func defaultTestRunForStarter() *v1alpha1.TestRun {
+	return &v1alpha1.TestRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+		Spec: v1alpha1.TestRunSpec{
+			Script: v1alpha1.K6Script{
+				ConfigMap: v1alpha1.K6Configmap{
+					Name: "test",
+					File: "test.js",
+				},
+			},
+			Starter: v1alpha1.Pod{
+				Metadata: v1alpha1.PodMetadata{
+					Labels: map[string]string{
+						"label1": "awesome",
+					},
+					Annotations: map[string]string{
+						"awesomeAnnotation": "dope",
+					},
+				},
+				Image:           "image",
+				ImagePullPolicy: corev1.PullNever,
+			},
+		},
+	}
+}
+
+func defaultExpectedJobForStarter() *batchv1.Job {
 
 	automountServiceAccountToken := true
 	zero := int32(0)
 
-	expectedOutcome := &batchv1.Job{
+	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-starter",
 			Namespace: "test",
@@ -71,39 +100,86 @@ func TestNewStarterJob(t *testing.T) {
 			},
 		},
 	}
-
-	k6 := &v1alpha1.TestRun{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: "test",
+}
+func Test_NewStarterJob(t *testing.T) {
+	tests := []struct {
+		name             string
+		hostname         []string
+		setupTestRun     func(*v1alpha1.TestRun)
+		setupExpectedJob func(*batchv1.Job)
+	}{
+		{
+			name:             "base",
+			hostname:         []string{"testing"},
+			setupTestRun:     func(k6 *v1alpha1.TestRun) {},
+			setupExpectedJob: func(j *batchv1.Job) {},
 		},
-		Spec: v1alpha1.TestRunSpec{
-			Script: v1alpha1.K6Script{
-				ConfigMap: v1alpha1.K6Configmap{
-					Name: "test",
-					File: "test.js",
-				},
+		{
+			name:     "custom scheduler name",
+			hostname: []string{"testing"},
+			setupTestRun: func(k6 *v1alpha1.TestRun) {
+				k6.Spec.Starter.SchedulerName = "custom-scheduler"
 			},
-			Starter: v1alpha1.Pod{
-				Metadata: v1alpha1.PodMetadata{
-					Labels: map[string]string{
-						"label1": "awesome",
+			setupExpectedJob: func(j *batchv1.Job) {
+				j.Spec.Template.Spec.SchedulerName = "custom-scheduler"
+			},
+		},
+		{
+			name:     "custom resources",
+			hostname: []string{"testing"},
+			setupTestRun: func(k6 *v1alpha1.TestRun) {
+				k6.Spec.Starter.Resources = corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("100m"),
+						corev1.ResourceMemory: resource.MustParse("2Gi"),
 					},
-					Annotations: map[string]string{
-						"awesomeAnnotation": "dope",
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("50m"),
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
 					},
-				},
-				Image:           "image",
-				ImagePullPolicy: corev1.PullNever,
+				}
+
+			},
+			setupExpectedJob: func(j *batchv1.Job) {
+				j.Spec.Template.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("100m"),
+						corev1.ResourceMemory: resource.MustParse("2Gi"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("50m"),
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+					},
+				}
 			},
 		},
 	}
 
-	job := NewStarterJob(k6, []string{"testing"})
-	if diff := deep.Equal(job, expectedOutcome); diff != nil {
-		t.Error(diff)
-	}
+	for _, tt := range tests {
 
+		t.Run(tt.name, func(t *testing.T) {
+
+			k6 := defaultTestRunForStarter()
+
+			if tt.setupTestRun != nil {
+				tt.setupTestRun(k6)
+			}
+
+			expectedJob := defaultExpectedJobForStarter()
+
+			if tt.setupExpectedJob != nil {
+				tt.setupExpectedJob(expectedJob)
+			}
+
+			job := NewStarterJob(k6, tt.hostname)
+
+			diff := deep.Equal(job, expectedJob)
+
+			if diff != nil {
+				t.Errorf("NewStarterJob difference: %v", diff)
+			}
+		})
+	}
 }
 
 func TestNewStarterJobIstio(t *testing.T) {
@@ -204,171 +280,6 @@ func TestNewStarterJobIstio(t *testing.T) {
 					},
 				},
 				Image: "image",
-			},
-		},
-	}
-
-	job := NewStarterJob(k6, []string{"testing"})
-	if diff := deep.Equal(job, expectedOutcome); diff != nil {
-		t.Error(diff)
-	}
-
-}
-
-func TestNewStarterJobCustomResources(t *testing.T) {
-	// Test case 1: Default resources should be applied when no custom resources are specified
-	k6Default := &v1alpha1.TestRun{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: "test",
-		},
-		Spec: v1alpha1.TestRunSpec{
-			Starter: v1alpha1.Pod{
-				Image: "image",
-			},
-			Script: v1alpha1.K6Script{
-				ConfigMap: v1alpha1.K6Configmap{Name: "test", File: "test.js"},
-			},
-		},
-	}
-
-	jobDefault := NewStarterJob(k6Default, []string{"testing"})
-	gotDefaultRes := jobDefault.Spec.Template.Spec.Containers[0].Resources
-
-	expectedDefaultRes := corev1.ResourceRequirements{
-		Requests: corev1.ResourceList{
-			corev1.ResourceCPU:    *resource.NewMilliQuantity(50, resource.DecimalSI),
-			corev1.ResourceMemory: *resource.NewQuantity(2097152, resource.BinarySI),
-		},
-		Limits: corev1.ResourceList{
-			corev1.ResourceCPU:    *resource.NewMilliQuantity(100, resource.DecimalSI),
-			corev1.ResourceMemory: *resource.NewQuantity(209715200, resource.BinarySI),
-		},
-	}
-
-	if diff := deep.Equal(gotDefaultRes, expectedDefaultRes); diff != nil {
-		t.Errorf("default resources not applied: %v", diff)
-	}
-
-	// Test case 2: Custom resources should override defaults
-	reqs := corev1.ResourceList{
-		corev1.ResourceCPU:    *resource.NewMilliQuantity(100, resource.DecimalSI),
-		corev1.ResourceMemory: *resource.NewQuantity(64*1024*1024, resource.BinarySI), // 64 Mi
-	}
-	lims := corev1.ResourceList{
-		corev1.ResourceCPU:    *resource.NewMilliQuantity(250, resource.DecimalSI),
-		corev1.ResourceMemory: *resource.NewQuantity(160*1024*1024, resource.BinarySI), // 160 Mi
-	}
-	customRes := corev1.ResourceRequirements{Requests: reqs, Limits: lims}
-
-	k6Custom := &v1alpha1.TestRun{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: "test",
-		},
-		Spec: v1alpha1.TestRunSpec{
-			Starter: v1alpha1.Pod{
-				Image:     "image",
-				Resources: customRes,
-			},
-			Script: v1alpha1.K6Script{
-				ConfigMap: v1alpha1.K6Configmap{Name: "test", File: "test.js"},
-			},
-		},
-	}
-
-	jobCustom := NewStarterJob(k6Custom, []string{"testing"})
-	gotCustomRes := jobCustom.Spec.Template.Spec.Containers[0].Resources
-
-	if diff := deep.Equal(gotCustomRes, customRes); diff != nil {
-		t.Errorf("custom resources not applied: %v", diff)
-	}
-}
-
-func TestNewStarterJobWithSchedulerName(t *testing.T) {
-
-	automountServiceAccountToken := true
-	zero := int32(0)
-
-	expectedOutcome := &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-starter",
-			Namespace: "test",
-			Labels: map[string]string{
-				"app":    "k6",
-				"k6_cr":  "test",
-				"label1": "awesome",
-			},
-			Annotations: map[string]string{
-				"awesomeAnnotation": "dope",
-			},
-		},
-		Spec: batchv1.JobSpec{
-			BackoffLimit: &zero,
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						"app":    "k6",
-						"k6_cr":  "test",
-						"label1": "awesome",
-					},
-					Annotations: map[string]string{
-						"awesomeAnnotation": "dope",
-					},
-				},
-				Spec: corev1.PodSpec{
-					AutomountServiceAccountToken: &automountServiceAccountToken,
-					ServiceAccountName:           "default",
-					SchedulerName:                "custom-scheduler",
-					Affinity:                     nil,
-					NodeSelector:                 nil,
-					Tolerations:                  nil,
-					TopologySpreadConstraints:    nil,
-					RestartPolicy:                corev1.RestartPolicyNever,
-					SecurityContext:              &corev1.PodSecurityContext{},
-					Containers: []corev1.Container{
-						containers.NewStartContainer([]string{"testing"}, "image", corev1.PullNever, []string{"sh", "-c"},
-							[]corev1.EnvVar{}, corev1.SecurityContext{}, corev1.ResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:    *resource.NewMilliQuantity(50, resource.DecimalSI),
-									corev1.ResourceMemory: *resource.NewQuantity(2097152, resource.BinarySI),
-								},
-								Limits: corev1.ResourceList{
-									corev1.ResourceCPU:    *resource.NewMilliQuantity(100, resource.DecimalSI),
-									corev1.ResourceMemory: *resource.NewQuantity(209715200, resource.BinarySI),
-								},
-							},
-						),
-					},
-				},
-			},
-		},
-	}
-
-	k6 := &v1alpha1.TestRun{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: "test",
-		},
-		Spec: v1alpha1.TestRunSpec{
-			Script: v1alpha1.K6Script{
-				ConfigMap: v1alpha1.K6Configmap{
-					Name: "test",
-					File: "test.js",
-				},
-			},
-			Starter: v1alpha1.Pod{
-				Metadata: v1alpha1.PodMetadata{
-					Labels: map[string]string{
-						"label1": "awesome",
-					},
-					Annotations: map[string]string{
-						"awesomeAnnotation": "dope",
-					},
-				},
-				Image:           "image",
-				ImagePullPolicy: corev1.PullNever,
-				SchedulerName:   "custom-scheduler",
 			},
 		},
 	}

--- a/pkg/resources/jobs/stopper_test.go
+++ b/pkg/resources/jobs/stopper_test.go
@@ -44,6 +44,7 @@ func TestNewStopperJob(t *testing.T) {
 				Spec: corev1.PodSpec{
 					AutomountServiceAccountToken: &automountServiceAccountToken,
 					ServiceAccountName:           "default",
+					SchedulerName:                "default-scheduler",
 					Affinity:                     nil,
 					NodeSelector:                 nil,
 					Tolerations:                  nil,
@@ -126,6 +127,7 @@ func TestNewStopJobIstio(t *testing.T) {
 				Spec: corev1.PodSpec{
 					AutomountServiceAccountToken: &automountServiceAccountToken,
 					ServiceAccountName:           "default",
+					SchedulerName:                "default-scheduler",
 					Affinity:                     nil,
 					NodeSelector:                 nil,
 					Tolerations:                  nil,
@@ -188,4 +190,88 @@ func TestNewStopJobIstio(t *testing.T) {
 	if diff := deep.Equal(job, expectedOutcome); diff != nil {
 		t.Error(diff)
 	}
+}
+
+func TestNewStopperJobWithSchedulerName(t *testing.T) {
+	automountServiceAccountToken := true
+	zero := int32(0)
+
+	expectedOutcome := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-stopper",
+			Namespace: "test",
+			Labels: map[string]string{
+				"app":    "k6",
+				"k6_cr":  "test",
+				"label1": "awesome",
+			},
+			Annotations: map[string]string{
+				"awesomeAnnotation": "dope",
+			},
+		},
+		Spec: batchv1.JobSpec{
+			BackoffLimit: &zero,
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app":    "k6",
+						"k6_cr":  "test",
+						"label1": "awesome",
+					},
+					Annotations: map[string]string{
+						"awesomeAnnotation": "dope",
+					},
+				},
+				Spec: corev1.PodSpec{
+					AutomountServiceAccountToken: &automountServiceAccountToken,
+					ServiceAccountName:           "default",
+					SchedulerName:                "custom-scheduler",
+					Affinity:                     nil,
+					NodeSelector:                 nil,
+					Tolerations:                  nil,
+					TopologySpreadConstraints:    nil,
+					RestartPolicy:                corev1.RestartPolicyNever,
+					SecurityContext:              &corev1.PodSecurityContext{},
+					Containers: []corev1.Container{
+						containers.NewStopContainer([]string{"testing"}, "image", corev1.PullNever, []string{"sh", "-c"},
+							[]corev1.EnvVar{}, corev1.SecurityContext{}, corev1.ResourceRequirements{}),
+					},
+				},
+			},
+		},
+	}
+
+	k6 := &v1alpha1.TestRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+		Spec: v1alpha1.TestRunSpec{
+			Script: v1alpha1.K6Script{
+				ConfigMap: v1alpha1.K6Configmap{
+					Name: "test",
+					File: "test.js",
+				},
+			},
+			Starter: v1alpha1.Pod{
+				Metadata: v1alpha1.PodMetadata{
+					Labels: map[string]string{
+						"label1": "awesome",
+					},
+					Annotations: map[string]string{
+						"awesomeAnnotation": "dope",
+					},
+				},
+				Image:           "image",
+				ImagePullPolicy: corev1.PullNever,
+				SchedulerName:   "custom-scheduler",
+			},
+		},
+	}
+
+	job := NewStopJob(k6, []string{"testing"})
+	if diff := deep.Equal(job, expectedOutcome); diff != nil {
+		t.Error(diff)
+	}
+
 }

--- a/pkg/resources/jobs/stopper_test.go
+++ b/pkg/resources/jobs/stopper_test.go
@@ -11,11 +11,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestNewStopperJob(t *testing.T) {
+func defaultExpectedJobForStopper() *batchv1.Job {
 	automountServiceAccountToken := true
 	zero := int32(0)
 
-	expectedOutcome := &batchv1.Job{
+	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-stopper",
 			Namespace: "test",
@@ -59,8 +59,10 @@ func TestNewStopperJob(t *testing.T) {
 			},
 		},
 	}
+}
 
-	k6 := &v1alpha1.TestRun{
+func defaultTestRunForStopper() *v1alpha1.TestRun {
+	return &v1alpha1.TestRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test",
 			Namespace: "test",
@@ -86,10 +88,58 @@ func TestNewStopperJob(t *testing.T) {
 			},
 		},
 	}
+}
 
-	job := NewStopJob(k6, []string{"testing"})
-	if diff := deep.Equal(job, expectedOutcome); diff != nil {
-		t.Error(diff)
+func Test_NewStopperJob(t *testing.T) {
+
+	tests := []struct {
+		name             string
+		hostname         []string
+		setupTestRun     func(*v1alpha1.TestRun)
+		setupExpectedJob func(*batchv1.Job)
+	}{
+		{
+			name:             "base",
+			hostname:         []string{"testing"},
+			setupTestRun:     func(k6 *v1alpha1.TestRun) {},
+			setupExpectedJob: func(j *batchv1.Job) {},
+		},
+		{
+			name:     "custom scheduler name",
+			hostname: []string{"testing"},
+			setupTestRun: func(k6 *v1alpha1.TestRun) {
+				k6.Spec.Starter.SchedulerName = "custom-scheduler"
+			},
+			setupExpectedJob: func(j *batchv1.Job) {
+				j.Spec.Template.Spec.SchedulerName = "custom-scheduler"
+			},
+		},
+	}
+
+	for _, tt := range tests {
+
+		t.Run(tt.name, func(t *testing.T) {
+
+			k6 := defaultTestRunForStopper()
+
+			if tt.setupTestRun != nil {
+				tt.setupTestRun(k6)
+			}
+
+			expectedJob := defaultExpectedJobForStopper()
+
+			if tt.setupExpectedJob != nil {
+				tt.setupExpectedJob(expectedJob)
+			}
+
+			job := NewStopJob(k6, tt.hostname)
+
+			diff := deep.Equal(job, expectedJob)
+
+			if diff != nil {
+				t.Errorf("NewStopperJob difference: %v", diff)
+			}
+		})
 	}
 
 }
@@ -190,88 +240,4 @@ func TestNewStopJobIstio(t *testing.T) {
 	if diff := deep.Equal(job, expectedOutcome); diff != nil {
 		t.Error(diff)
 	}
-}
-
-func TestNewStopperJobWithSchedulerName(t *testing.T) {
-	automountServiceAccountToken := true
-	zero := int32(0)
-
-	expectedOutcome := &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-stopper",
-			Namespace: "test",
-			Labels: map[string]string{
-				"app":    "k6",
-				"k6_cr":  "test",
-				"label1": "awesome",
-			},
-			Annotations: map[string]string{
-				"awesomeAnnotation": "dope",
-			},
-		},
-		Spec: batchv1.JobSpec{
-			BackoffLimit: &zero,
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						"app":    "k6",
-						"k6_cr":  "test",
-						"label1": "awesome",
-					},
-					Annotations: map[string]string{
-						"awesomeAnnotation": "dope",
-					},
-				},
-				Spec: corev1.PodSpec{
-					AutomountServiceAccountToken: &automountServiceAccountToken,
-					ServiceAccountName:           "default",
-					SchedulerName:                "custom-scheduler",
-					Affinity:                     nil,
-					NodeSelector:                 nil,
-					Tolerations:                  nil,
-					TopologySpreadConstraints:    nil,
-					RestartPolicy:                corev1.RestartPolicyNever,
-					SecurityContext:              &corev1.PodSecurityContext{},
-					Containers: []corev1.Container{
-						containers.NewStopContainer([]string{"testing"}, "image", corev1.PullNever, []string{"sh", "-c"},
-							[]corev1.EnvVar{}, corev1.SecurityContext{}, corev1.ResourceRequirements{}),
-					},
-				},
-			},
-		},
-	}
-
-	k6 := &v1alpha1.TestRun{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: "test",
-		},
-		Spec: v1alpha1.TestRunSpec{
-			Script: v1alpha1.K6Script{
-				ConfigMap: v1alpha1.K6Configmap{
-					Name: "test",
-					File: "test.js",
-				},
-			},
-			Starter: v1alpha1.Pod{
-				Metadata: v1alpha1.PodMetadata{
-					Labels: map[string]string{
-						"label1": "awesome",
-					},
-					Annotations: map[string]string{
-						"awesomeAnnotation": "dope",
-					},
-				},
-				Image:           "image",
-				ImagePullPolicy: corev1.PullNever,
-				SchedulerName:   "custom-scheduler",
-			},
-		},
-	}
-
-	job := NewStopJob(k6, []string{"testing"})
-	if diff := deep.Equal(job, expectedOutcome); diff != nil {
-		t.Error(diff)
-	}
-
 }


### PR DESCRIPTION
**Issue**:
https://github.com/grafana/k6-operator/issues/627

**PR Changes**:
1. Adding support to specify SchedularName
2. Added test cases for both scenario in initializer/Starter/Runner/Stopper
3. Added ".go-version" in gitignore as I use "goenv" CLI tool to maintain multiple versions of GO. Other people might use that too

**Thoughts**:
I understand that using a custom scheduler is a niche use-case, but we should still support all specifications of a Kubernetes Pod when we create a Job

**Additional**:
I've also raised this improvement issue (easy change)
https://github.com/grafana/k6-operator/issues/784

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds an optional `schedulerName` field that influences how initializer/starter/runner/stopper Jobs are scheduled; risk is low but could affect deployments that rely on a non-default scheduler configuration.
> 
> **Overview**
> Adds optional `spec.*.schedulerName` support to `TestRun` so initializer, runner, and starter Pods set `PodSpec.SchedulerName` (defaulting to Kubernetes `default-scheduler`), with stopper inheriting it via the starter template.
> 
> Updates the CRD schema and generated docs to expose the new field, and refactors job unit tests into table-driven cases covering both default and custom scheduler names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b85276cd24c7b2ef6f3a1409fb111ab1a47bb6a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->