### PR TITLE
[feat] Get secrets configuration from `/v1/test` in cloud output mode to support `Secrets`

### DIFF
--- a/api/v1alpha1/k6conditions.go
+++ b/api/v1alpha1/k6conditions.go
@@ -145,6 +145,10 @@ func (k6status *TestRunStatus) SetIfNewer(proposedStatus TestRunStatus) (isNewer
 				k6status.AggregationVars = proposedStatus.AggregationVars
 			}
 
+			if len(proposedStatus.SecretsVars) > 0 && len(k6status.SecretsVars) == 0 {
+				k6status.SecretsVars = proposedStatus.SecretsVars
+			}
+
 			return
 		})
 

--- a/api/v1alpha1/k6conditions.go
+++ b/api/v1alpha1/k6conditions.go
@@ -143,10 +143,12 @@ func (k6status *TestRunStatus) SetIfNewer(proposedStatus TestRunStatus) (isNewer
 			// similarly with aggregation vars
 			if len(proposedStatus.AggregationVars) > 0 && len(k6status.AggregationVars) == 0 {
 				k6status.AggregationVars = proposedStatus.AggregationVars
+				isNewer = true
 			}
 
 			if len(proposedStatus.SecretsVars) > 0 && len(k6status.SecretsVars) == 0 {
 				k6status.SecretsVars = proposedStatus.SecretsVars
+				isNewer = true
 			}
 
 			return

--- a/api/v1alpha1/testrun_types.go
+++ b/api/v1alpha1/testrun_types.go
@@ -180,6 +180,7 @@ type TestRunStatus struct {
 	Stage           Stage  `json:"stage,omitempty"`
 	TestRunID       string `json:"testRunId,omitempty"`
 	AggregationVars string `json:"aggregationVars,omitempty"`
+	SecretsVars     string `json:"secretsVars,omitempty"`
 
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }

--- a/config/crd/bases/k6.io_testruns.yaml
+++ b/config/crd/bases/k6.io_testruns.yaml
@@ -6161,6 +6161,8 @@ spec:
             properties:
               aggregationVars:
                 type: string
+              secretsVars:
+                type: string
               conditions:
                 items:
                   properties:

--- a/internal/controller/k6_initialize.go
+++ b/internal/controller/k6_initialize.go
@@ -180,12 +180,7 @@ func SetupCloudTest(ctx context.Context, log logr.Logger, k6 *v1alpha1.TestRun, 
 			v1alpha1.UpdateCondition(k6, v1alpha1.CloudTestRunCreated, metav1.ConditionTrue)
 
 			k6.GetStatus().AggregationVars = cloud.EncodeAggregationConfig(testRunData.ConfigOverride)
-
-			if trData, err := cloud.GetTestRunData(r.k6CloudClient, testRunData.ReferenceID); err != nil {
-				log.Error(err, "Failed to fetch test run data for secrets config")
-			} else {
-				k6.GetStatus().SecretsVars = cloud.EncodeSecretsConfig(trData.SecretsConfig, trData.SecretsToken)
-			}
+			k6.GetStatus().SecretsVars = cloud.EncodeSecretsConfig(testRunData.SecretsConfig, testRunData.SecretsToken)
 
 			_, err := r.UpdateStatus(ctx, k6, log)
 			if err != nil {

--- a/internal/controller/k6_initialize.go
+++ b/internal/controller/k6_initialize.go
@@ -181,6 +181,12 @@ func SetupCloudTest(ctx context.Context, log logr.Logger, k6 *v1alpha1.TestRun, 
 
 			k6.GetStatus().AggregationVars = cloud.EncodeAggregationConfig(testRunData.ConfigOverride)
 
+			if trData, err := cloud.GetTestRunData(r.k6CloudClient, testRunData.ReferenceID); err != nil {
+				log.Error(err, "Failed to fetch test run data for secrets config")
+			} else {
+				k6.GetStatus().SecretsVars = cloud.EncodeSecretsConfig(trData.SecretsConfig, trData.SecretsToken)
+			}
+
 			_, err := r.UpdateStatus(ctx, k6, log)
 			if err != nil {
 				return ctrl.Result{}, err

--- a/pkg/cloud/cloud_output.go
+++ b/pkg/cloud/cloud_output.go
@@ -46,7 +46,13 @@ func NewClient(logger logr.Logger, token, host string) *cloudapi.Client {
 	return cloudapi.NewClient(logrusLogger, token, host, "1.2.3", time.Duration(time.Minute))
 }
 
-func CreateTestRun(opts InspectOutput, instances int32, host, token string, log logr.Logger) (*cloudapi.CreateTestRunResponse, error) {
+// CreateTestRunResult holds the parsed result of creating a cloud test run.
+type CreateTestRunResult struct {
+	ReferenceID    string
+	ConfigOverride *cloudapi.Config
+}
+
+func CreateTestRun(opts InspectOutput, instances int32, host, token string, log logr.Logger) (*CreateTestRunResult, error) {
 	cloudConfig := cloudapi.NewConfig()
 
 	if opts.ProjectID() > 0 {
@@ -82,24 +88,30 @@ func CreateTestRun(opts InspectOutput, instances int32, host, token string, log 
 
 // We cannot use cloudapi.TestRun struct and cloudapi.Client.CreateTestRun call because they're not aware of
 // process_thresholds argument; so let's use custom struct and function instead
-func createTestRun(client *cloudapi.Client, host string, testRun *TestRun) (*cloudapi.CreateTestRunResponse, error) {
+func createTestRun(client *cloudapi.Client, host string, testRun *TestRun) (*CreateTestRunResult, error) {
 	url := host + "/v1/tests"
 	req, err := client.NewRequest("POST", url, testRun)
 	if err != nil {
 		return nil, err
 	}
 
-	ctrr := cloudapi.CreateTestRunResponse{}
-	err = client.Do(req, &ctrr)
+	var resp struct {
+		ReferenceID    string           `json:"reference_id"`
+		ConfigOverride *cloudapi.Config `json:"config"`
+	}
+	err = client.Do(req, &resp)
 	if err != nil {
 		return nil, err
 	}
 
-	if ctrr.ReferenceID == "" {
+	if resp.ReferenceID == "" {
 		return nil, fmt.Errorf("failed to get a reference ID")
 	}
 
-	return &ctrr, nil
+	return &CreateTestRunResult{
+		ReferenceID:    resp.ReferenceID,
+		ConfigOverride: resp.ConfigOverride,
+	}, nil
 }
 
 func FinishTestRun(c *cloudapi.Client, refID string) error {

--- a/pkg/cloud/cloud_output.go
+++ b/pkg/cloud/cloud_output.go
@@ -50,6 +50,8 @@ func NewClient(logger logr.Logger, token, host string) *cloudapi.Client {
 type CreateTestRunResult struct {
 	ReferenceID    string
 	ConfigOverride *cloudapi.Config
+	SecretsConfig  *SecretsConfig
+	SecretsToken   string
 }
 
 func CreateTestRun(opts InspectOutput, instances int32, host, token string, log logr.Logger) (*CreateTestRunResult, error) {
@@ -98,6 +100,8 @@ func createTestRun(client *cloudapi.Client, host string, testRun *TestRun) (*Cre
 	var resp struct {
 		ReferenceID    string           `json:"reference_id"`
 		ConfigOverride *cloudapi.Config `json:"config"`
+		SecretsConfig  *SecretsConfig   `json:"secrets_config"`
+		SecretsToken   string           `json:"test_run_token"`
 	}
 	err = client.Do(req, &resp)
 	if err != nil {
@@ -111,6 +115,8 @@ func createTestRun(client *cloudapi.Client, host string, testRun *TestRun) (*Cre
 	return &CreateTestRunResult{
 		ReferenceID:    resp.ReferenceID,
 		ConfigOverride: resp.ConfigOverride,
+		SecretsConfig:  resp.SecretsConfig,
+		SecretsToken:   resp.SecretsToken,
 	}, nil
 }
 

--- a/pkg/cloud/cloud_output_test.go
+++ b/pkg/cloud/cloud_output_test.go
@@ -1,0 +1,118 @@
+package cloud
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.k6.io/k6/cloudapi"
+)
+
+func newTestClient(t *testing.T, host string) *cloudapi.Client {
+	t.Helper()
+	l := logrus.New()
+	l.SetOutput(testWriter{t})
+	return cloudapi.NewClient(l, "test-token", host, "1.2.3", time.Minute)
+}
+
+// testWriter routes logrus output to t.Log so it only appears on failure.
+type testWriter struct{ t *testing.T }
+
+func (tw testWriter) Write(p []byte) (int, error) {
+	tw.t.Log(string(p))
+	return len(p), nil
+}
+
+func TestCreateTestRun_SecretsFields(t *testing.T) {
+	t.Parallel()
+
+	endpoint := "https://api.k6.io/provisioning/v1/test_runs/42/decrypt_secret?name={key}"
+	respPath := "plaintext"
+	token := "run-scoped-token"
+
+	tests := []struct {
+		name           string
+		serverResp     map[string]any
+		wantSecretsNil bool
+		wantToken      string
+		wantEndpoint   string
+		wantRespPath   string
+	}{
+		{
+			name: "secrets_config and test_run_token are parsed from response",
+			serverResp: map[string]any{
+				"reference_id":   "42",
+				"config":         map[string]any{},
+				"test_run_token": token,
+				"secrets_config": map[string]any{
+					"endpoint":      endpoint,
+					"response_path": respPath,
+				},
+			},
+			wantSecretsNil: false,
+			wantToken:      token,
+			wantEndpoint:   endpoint,
+			wantRespPath:   respPath,
+		},
+		{
+			name: "missing secrets fields are nil/empty (backwards compatibility)",
+			serverResp: map[string]any{
+				"reference_id": "42",
+				"config":       map[string]any{},
+			},
+			wantSecretsNil: true,
+			wantToken:      "",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(tt.serverResp)
+			}))
+			defer srv.Close()
+
+			c := newTestClient(t, srv.URL)
+			result, err := createTestRun(c, srv.URL, &TestRun{
+				Name:     "test",
+				VUsMax:   10,
+				Duration: 60,
+			})
+
+			require.NoError(t, err)
+			assert.Equal(t, "42", result.ReferenceID)
+			assert.Equal(t, tt.wantToken, result.SecretsToken)
+
+			if tt.wantSecretsNil {
+				assert.Nil(t, result.SecretsConfig)
+			} else {
+				require.NotNil(t, result.SecretsConfig)
+				assert.Equal(t, tt.wantEndpoint, result.SecretsConfig.Endpoint)
+				assert.Equal(t, tt.wantRespPath, result.SecretsConfig.ResponsePath)
+			}
+		})
+	}
+}
+
+func TestCreateTestRun_MissingReferenceID(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"config": map[string]any{}})
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	_, err := createTestRun(c, srv.URL, &TestRun{Name: "test", VUsMax: 1, Duration: 10})
+	assert.EqualError(t, err, "failed to get a reference ID")
+}

--- a/pkg/cloud/secrets.go
+++ b/pkg/cloud/secrets.go
@@ -1,0 +1,37 @@
+package cloud
+
+import (
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// EncodeSecretsConfig encodes the secrets configuration into a pipe-separated
+// string for storage in TestRun.Status.SecretsVars.
+// Returns an empty string when cfg is nil.
+func EncodeSecretsConfig(cfg *SecretsConfig, token string) string {
+	if cfg == nil {
+		return ""
+	}
+	return strings.Join([]string{cfg.Endpoint, cfg.ResponsePath, token}, "|")
+}
+
+// DecodeSecretsConfig decodes a previously encoded secrets configuration and
+// returns the corresponding env vars. Returns nil when encoded is empty.
+func DecodeSecretsConfig(encoded string) []corev1.EnvVar {
+	if encoded == "" {
+		return nil
+	}
+	parts := strings.SplitN(encoded, "|", 3)
+	if len(parts) != 3 {
+		return nil
+	}
+	trData := &TestRunData{
+		SecretsToken: parts[2],
+		SecretsConfig: &SecretsConfig{
+			Endpoint:     parts[0],
+			ResponsePath: parts[1],
+		},
+	}
+	return trData.SecretsEnvVars()
+}

--- a/pkg/cloud/secrets_test.go
+++ b/pkg/cloud/secrets_test.go
@@ -1,0 +1,129 @@
+package cloud
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestEncodeSecretsConfig(t *testing.T) {
+	t.Parallel()
+
+	endpoint := "https://api.k6.io/provisioning/v1/test_runs/42/decrypt_secret?name={key}"
+	respPath := "plaintext"
+	token := "abc123"
+
+	tests := []struct {
+		name     string
+		cfg      *SecretsConfig
+		token    string
+		expected string
+	}{
+		{
+			name:     "nil cfg returns empty string",
+			cfg:      nil,
+			token:    token,
+			expected: "",
+		},
+		{
+			name:     "valid cfg encodes to pipe-separated string",
+			cfg:      &SecretsConfig{Endpoint: endpoint, ResponsePath: respPath},
+			token:    token,
+			expected: endpoint + "|" + respPath + "|" + token,
+		},
+		{
+			name:     "empty token is preserved in encoding",
+			cfg:      &SecretsConfig{Endpoint: endpoint, ResponsePath: respPath},
+			token:    "",
+			expected: endpoint + "|" + respPath + "|",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, EncodeSecretsConfig(tt.cfg, tt.token))
+		})
+	}
+}
+
+func TestDecodeSecretsConfig(t *testing.T) {
+	t.Parallel()
+
+	endpoint := "https://api.k6.io/provisioning/v1/test_runs/42/decrypt_secret?name={key}"
+	respPath := "plaintext"
+	token := "abc123"
+
+	tests := []struct {
+		name     string
+		encoded  string
+		expected []corev1.EnvVar
+	}{
+		{
+			name:     "empty string returns nil",
+			encoded:  "",
+			expected: nil,
+		},
+		{
+			name:     "malformed string with one part returns nil",
+			encoded:  "only-one-part",
+			expected: nil,
+		},
+		{
+			name:     "malformed string with two parts returns nil",
+			encoded:  "part1|part2",
+			expected: nil,
+		},
+		{
+			name:    "valid encoded string returns env vars",
+			encoded: endpoint + "|" + respPath + "|" + token,
+			expected: []corev1.EnvVar{
+				{Name: secretSourceEnvVar, Value: "url"},
+				{Name: secretSourceURLTemplate, Value: endpoint},
+				{Name: secretSourceURLRespPath, Value: respPath},
+				{Name: secretSourceURLAuthKey, Value: "Bearer " + token},
+			},
+		},
+		{
+			// SplitN(n=3) means only the first two pipes are used as separators,
+			// so a pipe character inside the token is preserved correctly.
+			name:    "pipe character in token is preserved by SplitN",
+			encoded: endpoint + "|" + respPath + "|token|with|pipes",
+			expected: []corev1.EnvVar{
+				{Name: secretSourceEnvVar, Value: "url"},
+				{Name: secretSourceURLTemplate, Value: endpoint},
+				{Name: secretSourceURLRespPath, Value: respPath},
+				{Name: secretSourceURLAuthKey, Value: "Bearer token|with|pipes"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, DecodeSecretsConfig(tt.encoded))
+		})
+	}
+}
+
+func TestEncodeDecodeSecretsConfigRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	cfg := &SecretsConfig{
+		Endpoint:     "https://api.k6.io/provisioning/v1/test_runs/42/decrypt_secret?name={key}",
+		ResponsePath: "plaintext",
+	}
+	token := "abc123"
+
+	encoded := EncodeSecretsConfig(cfg, token)
+	got := DecodeSecretsConfig(encoded)
+
+	expected := []corev1.EnvVar{
+		{Name: secretSourceEnvVar, Value: "url"},
+		{Name: secretSourceURLTemplate, Value: cfg.Endpoint},
+		{Name: secretSourceURLRespPath, Value: cfg.ResponsePath},
+		{Name: secretSourceURLAuthKey, Value: "Bearer " + token},
+	}
+	assert.Equal(t, expected, got)
+}

--- a/pkg/cloud/test_runs.go
+++ b/pkg/cloud/test_runs.go
@@ -107,7 +107,7 @@ func getTestRun(client *cloudapi.Client, url string) (*TestRunData, error) {
 	return &trData, nil
 }
 
-// called by PLZworker and SetupCloudTest
+// called by PLZworker
 func GetTestRunData(client *cloudapi.Client, refID string) (*TestRunData, error) {
 	url := fmt.Sprintf("%s/loadtests/v4/test_runs(%s)?$select=id,run_status,k8s_load_zones_config,k6_runtime_config,test_run_token,secrets_config", ApiURL(client.BaseURL()), refID)
 	return getTestRun(client, url)

--- a/pkg/cloud/test_runs.go
+++ b/pkg/cloud/test_runs.go
@@ -109,7 +109,7 @@ func getTestRun(client *cloudapi.Client, url string) (*TestRunData, error) {
 
 // called by PLZworker
 func GetTestRunData(client *cloudapi.Client, refID string) (*TestRunData, error) {
-	url := fmt.Sprintf("%s/loadtests/v4/test_runs(%s)?$select=id,run_status,k8s_load_zones_config,k6_runtime_config,test_run_token,secrets_config", ApiURL(client.BaseURL()), refID)
+	url := fmt.Sprintf("%s/loadtests/v4/test_runs(%s)?$select=id,run_status,k8s_load_zones_config,k6_runtime_config,test_run_token,secrets_config", strings.TrimSuffix(client.BaseURL(), "/v1"), refID)
 	return getTestRun(client, url)
 }
 

--- a/pkg/cloud/test_runs.go
+++ b/pkg/cloud/test_runs.go
@@ -107,9 +107,9 @@ func getTestRun(client *cloudapi.Client, url string) (*TestRunData, error) {
 	return &trData, nil
 }
 
-// called by PLZworker
+// called by PLZworker and SetupCloudTest
 func GetTestRunData(client *cloudapi.Client, refID string) (*TestRunData, error) {
-	url := fmt.Sprintf("%s/loadtests/v4/test_runs(%s)?$select=id,run_status,k8s_load_zones_config,k6_runtime_config,test_run_token,secrets_config", strings.TrimSuffix(client.BaseURL(), "/v1"), refID)
+	url := fmt.Sprintf("%s/loadtests/v4/test_runs(%s)?$select=id,run_status,k8s_load_zones_config,k6_runtime_config,test_run_token,secrets_config", ApiURL(client.BaseURL()), refID)
 	return getTestRun(client, url)
 }
 

--- a/pkg/resources/jobs/runner.go
+++ b/pkg/resources/jobs/runner.go
@@ -144,6 +144,7 @@ func NewRunnerJob(k6 *v1alpha1.TestRun, index int, tokenInfo *cloud.TokenInfo) (
 				return nil, err
 			}
 			env = append(env, aggregationVars...)
+			env = append(env, cloud.DecodeSecretsConfig(k6.GetStatus().SecretsVars)...)
 		}
 
 		env = append(env, corev1.EnvVar{


### PR DESCRIPTION
https://github.com/grafana/k6-operator/issues/787

When a TestRun uses `--out cloud`, the operator creates the cloud test run via POST `/v1/tests`, and now it gets the secrets configuration from `/v1/test`, and supports secrets.

Tested here: https://admin-prod-us-east-0.grafana.net/directory-k6-cloud/admin/k6/loadtestrun/view/7416244/?_changelist_filters=q%3D2736043

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds secrets configuration (including a run-scoped token) to `TestRun` status/CRD and propagates it into runner pod environment, which is security-sensitive and could expose credentials via Kubernetes status storage/logging. Also changes cloud create-test-run response parsing, so mismatches with the cloud API contract could break cloud-output runs.
> 
> **Overview**
> Cloud-output test runs now capture a secrets configuration returned by the cloud `POST /v1/tests` response and persist it on the `TestRun` status as **new field** `status.secretsVars` (CRD/schema updated accordingly).
> 
> The controller encodes `secrets_config` + `test_run_token` into this status field during initialization, and runner job creation decodes it to inject the corresponding secret-source env vars. `CreateTestRun` was refactored to parse these additional response fields (with tests for backwards compatibility when secrets fields are absent) and new helpers/tests were added for encoding/decoding the secrets config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 240a2ad949f1a7e756ad1bdad8d0d5830ed6f38c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->