### PR TITLE
E2E: switch to `expect()` instead of `fail()` in k6 tests

### DIFF
--- a/e2e/assertions.js
+++ b/e2e/assertions.js
@@ -1,0 +1,1 @@
+export { expect } from 'https://jslib.k6.io/k6-testing/0.6.1/index.js';

--- a/e2e/basic-testrun-1/test.js
+++ b/e2e/basic-testrun-1/test.js
@@ -1,5 +1,6 @@
 import { Environment } from 'k6/x/environment';
-import { sleep, fail } from 'k6';
+import { sleep } from 'k6';
+import { expect } from '../assertions.js';
 
 export const options = {
   setupTimeout: '60s',
@@ -35,9 +36,7 @@ export default function () {
     interval: "1m",
   });
 
-  if (err != null) {
-    fail("wait returns" + err);
-  }
+  expect(err, "wait returns").toBeNull();
 }
 
 export function teardown() {

--- a/e2e/basic-testrun-4/test.js
+++ b/e2e/basic-testrun-4/test.js
@@ -1,5 +1,6 @@
 import { Environment } from 'k6/x/environment';
-import { sleep, fail } from 'k6';
+import { sleep } from 'k6';
+import { expect } from '../assertions.js';
 
 export const options = {
   setupTimeout: '60s',
@@ -35,9 +36,7 @@ export default function () {
     interval: "10s",
   });
 
-  if (err != null) {
-    fail("wait for started returns" + err);
-  }
+  expect(err, "wait for started returns").toBeNull();
 
   let allPods = env.getN("pods", {
     "namespace": "fancy-testing", //tr.namespace()
@@ -53,9 +52,8 @@ export default function () {
   });
 
   // there should be N runners pods + initializer + starter
-  if (runnerPods != 4 || allPods != runnerPods + 2) {
-    fail("wrong number of pods:" + runnerPods + "/" + allPods);
-  }
+  expect(runnerPods, "runner pod count").toBe(4);
+  expect(allPods, "total pod count").toBe(runnerPods + 2);
 
   err = env.wait({
     kind: "TestRun",
@@ -70,9 +68,7 @@ export default function () {
 
   // TODO: add check for status of the pods
 
-  if (err != null) {
-    fail("wait for finished returns" + err);
-  }
+  expect(err, "wait for finished returns").toBeNull();
 }
 
 export function teardown() {

--- a/e2e/error-stage/test.js
+++ b/e2e/error-stage/test.js
@@ -1,5 +1,6 @@
 import { Environment } from 'k6/x/environment';
-import { sleep, fail } from 'k6';
+import { sleep } from 'k6';
+import { expect } from '../assertions.js';
 
 export const options = {
   setupTimeout: '60s',
@@ -36,9 +37,7 @@ export default function () {
     interval: "1m",
   });
 
-  if (err != null) {
-    fail("wait returns" + err);
-  }
+  expect(err, "wait returns").toBeNull();
 }
 
 export function teardown() {

--- a/e2e/init-container-volume/test.js
+++ b/e2e/init-container-volume/test.js
@@ -1,5 +1,6 @@
 import { Environment } from 'k6/x/environment';
-import { sleep, fail } from 'k6';
+import { sleep } from 'k6';
+import { expect } from '../assertions.js';
 
 export const options = {
     setupTimeout: '60s',
@@ -41,9 +42,7 @@ export default function () {
         interval: "1m",
     });
 
-    if (err != null) {
-        fail("wait returns" + err);
-    }
+    expect(err, "wait returns").toBeNull();
 
     let allPods = env.getN("pods", {
         "namespace": "default", //tr.namespace()
@@ -52,9 +51,7 @@ export default function () {
     });
 
     // there should be N runners pods + initializer + starter
-    if (allPods != 2 + 2) {
-        fail("wrong number of pods:" + allPods + " instead of " + 4);
-    }
+    expect(allPods, "total pod count").toBe(2 + 2);
 }
 
 export function teardown() {

--- a/e2e/initializer-disabled/test.js
+++ b/e2e/initializer-disabled/test.js
@@ -1,5 +1,6 @@
 import { Environment } from 'k6/x/environment';
-import { sleep, fail } from 'k6';
+import { sleep } from 'k6';
+import { expect } from '../assertions.js';
 
 export const options = {
   setupTimeout: '60s',
@@ -34,9 +35,7 @@ export default function () {
     interval: "1m",
   });
 
-  if (err != null) {
-    fail("wait returns " + err);
-  }
+  expect(err, "wait returns").toBeNull();
 
   // Check total pod count
   // With initializer disabled: runner + starter = 2 pods (initializer should be skippd)
@@ -47,10 +46,7 @@ export default function () {
   });
 
   const expectedPods = 2;
-  if (allPods != expectedPods) {
-    fail("wrong number of pods: " + allPods + " instead of " + expectedPods +
-         " (initializer should not exist when disabled)");
-  }
+  expect(allPods, "initializer should not exist when disabled").toBe(expectedPods);
 
   console.log("SUCCESS: No initializer pod created, total pods: " + allPods);
 }

--- a/e2e/invalid-arguments/test.js
+++ b/e2e/invalid-arguments/test.js
@@ -1,5 +1,6 @@
 import { Environment } from 'k6/x/environment';
-import { sleep, fail } from 'k6';
+import { sleep } from 'k6';
+import { expect } from '../assertions.js';
 
 export const options = {
   setupTimeout: '60s',
@@ -36,9 +37,7 @@ export default function () {
     interval: "1m",
   });
 
-  if (err != null) {
-    fail("wait returns" + err);
-  }
+  expect(err, "wait returns").toBeNull();
 }
 
 export function teardown() {

--- a/e2e/multifile/test.js
+++ b/e2e/multifile/test.js
@@ -1,5 +1,6 @@
 import { Environment } from 'k6/x/environment';
-import { sleep, fail } from 'k6';
+import { sleep } from 'k6';
+import { expect } from '../assertions.js';
 
 export const options = {
     setupTimeout: '60s',
@@ -34,9 +35,7 @@ export default function () {
         timeout: "2m",
         interval: "1s",
     });
-    if (err != null) {
-        fail("wait returns" + err);
-    }
+    expect(err, "wait returns").toBeNull();
 
     let allPods = env.getN("pods", {
         "namespace": "default", // tr.namespace()
@@ -45,9 +44,7 @@ export default function () {
     });
 
     // there should be N runners pods + initializer + starter
-    if (allPods != 3 + 2) {
-        fail("wrong number of pods:" + allPods + " instead of " + 5);
-    }
+    expect(allPods, "total pod count").toBe(3 + 2);
 }
 
 export function teardown() {

--- a/e2e/testrun-archive/test.js
+++ b/e2e/testrun-archive/test.js
@@ -1,5 +1,6 @@
 import { Environment } from 'k6/x/environment';
-import { sleep, fail } from 'k6';
+import { sleep } from 'k6';
+import { expect } from '../assertions.js';
 
 export const options = {
   setupTimeout: '60s',
@@ -37,9 +38,7 @@ export default function () {
     interval: "1m",
   });
 
-  if (err != null) {
-    fail("wait returns" + err);
-  }
+  expect(err, "wait returns").toBeNull();
 }
 
 export function teardown() {

--- a/e2e/testrun-cleanup/test.js
+++ b/e2e/testrun-cleanup/test.js
@@ -1,5 +1,6 @@
 import { Environment } from 'k6/x/environment';
-import { sleep, fail } from 'k6';
+import { sleep } from 'k6';
+import { expect } from '../assertions.js';
 
 export const options = {
   setupTimeout: '60s',
@@ -34,9 +35,7 @@ export default function () {
   });
 
   // there should be at least initializer pod by now
-  if (allPods < 1) {
-    fail("wrong number of pods: " + allPods);
-  }
+  expect(allPods, "pod count after bootstrap").toBeGreaterThanOrEqual(1);
 
   err = env.wait({
     kind: "TestRun",
@@ -52,9 +51,7 @@ export default function () {
   // Either wait() will "catch" TestRun at finished stage or
   // TestRun will be deleted some time between wait checks. Both
   // of those are valid in this case.
-  if (err != null && err != "context deadline exceeded") {
-    fail("unexpected error from wait(): " + err);
-  }
+  expect(err == null || err == "context deadline exceeded", "wait should finish or time out after cleanup").toBeTruthy();
 
   // there should be no pods at this point
 
@@ -64,9 +61,7 @@ export default function () {
     "k6_cr": "k6-sample", //tr.name()
   });
 
-  if (allPods != 0) {
-    fail("pods were not deleted, there are " + allPods + " pods");
-  }
+  expect(allPods, "pod count after cleanup").toBe(0);
 }
 
 export function teardown() {

--- a/e2e/testrun-cloud-output/test.js
+++ b/e2e/testrun-cloud-output/test.js
@@ -1,5 +1,6 @@
 import { Environment } from 'k6/x/environment';
-import { sleep, fail } from 'k6';
+import { sleep } from 'k6';
+import { expect } from '../assertions.js';
 
 export const options = {
   setupTimeout: '60s',
@@ -35,9 +36,7 @@ export default function () {
     interval: "10s",
   });
 
-  if (err != null) {
-    fail("wait for started returns" + err);
-  }
+  expect(err, "wait for started returns").toBeNull();
 
   let allPods = env.getN("pods", {
     "namespace": "k6-tests", //tr.namespace()
@@ -53,9 +52,8 @@ export default function () {
   });
 
   // there should be N runners pods + initializer + starter
-  if (runnerPods != 4 || allPods != runnerPods + 2) {
-    fail("wrong number of pods:" + runnerPods + "/" + allPods);
-  }
+  expect(runnerPods, "runner pod count").toBe(4);
+  expect(allPods, "total pod count").toBe(runnerPods + 2);
 
   err = env.wait({
     kind: "TestRun",
@@ -70,9 +68,7 @@ export default function () {
 
   // TODO: add check for status of the pods
 
-  if (err != null) {
-    fail("wait for finished returns" + err);
-  }
+  expect(err, "wait for finished returns").toBeNull();
 }
 
 export function teardown() {

--- a/e2e/testrun-simultaneous-cloud-output/test.js
+++ b/e2e/testrun-simultaneous-cloud-output/test.js
@@ -1,5 +1,6 @@
 import { Environment } from 'k6/x/environment';
-import { sleep, fail } from 'k6';
+import { sleep } from 'k6';
+import { expect } from '../assertions.js';
 
 import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.2.0/index.js';
 
@@ -58,9 +59,7 @@ function wait_for_first(env) {
     interval: "1m",
   });
 
-  if (err != null) {
-    fail("wait for t-2-runners returns" + err);
-  }
+  expect(err, "wait for t-2-runners returns").toBeNull();
 
   let allPods = env.getN("pods", {
     "namespace": "k6-tests", //tr.namespace()
@@ -69,9 +68,7 @@ function wait_for_first(env) {
   });
 
   // there should be N runners pods + initializer + starter
-  if (allPods != 2 + 2) {
-    fail("wrong number of pods:" + allPods + " instead of " + 4);
-  }
+  expect(allPods, "pod count for t-2-runners").toBe(2 + 2);
 }
 
 function wait_for_second(env) {
@@ -86,9 +83,7 @@ function wait_for_second(env) {
     interval: "1m",
   });
 
-  if (err != null) {
-    fail("wait for t-3-runners returns" + err);
-  }
+  expect(err, "wait for t-3-runners returns").toBeNull();
 
   let allPods = env.getN("pods", {
     "namespace": "k6-tests", //tr.namespace()
@@ -97,7 +92,5 @@ function wait_for_second(env) {
   });
 
   // there should be N runners pods + initializer + starter
-  if (allPods != 3 + 2) {
-    fail("wrong number of pods:" + allPods + " instead of " + 5);
-  }
+  expect(allPods, "pod count for t-3-runners").toBe(3 + 2);
 }

--- a/e2e/testrun-simultaneous/test.js
+++ b/e2e/testrun-simultaneous/test.js
@@ -1,5 +1,6 @@
 import { Environment } from 'k6/x/environment';
-import { sleep, fail } from 'k6';
+import { sleep } from 'k6';
+import { expect } from '../assertions.js';
 
 import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.2.0/index.js';
 
@@ -58,9 +59,7 @@ function wait_for_first(env) {
     interval: "1m",
   });
 
-  if (err != null) {
-    fail("wait for t-2-runners returns" + err);
-  }
+  expect(err, "wait for t-2-runners returns").toBeNull();
 
   let allPods = env.getN("pods", {
     "namespace": "default", //tr.namespace()
@@ -69,9 +68,7 @@ function wait_for_first(env) {
   });
 
   // there should be N runners pods + initializer + starter
-  if (allPods != 2 + 2) {
-    fail("wrong number of pods:" + allPods + " instead of " + 4);
-  }
+  expect(allPods, "pod count for t-2-runners").toBe(2 + 2);
 }
 
 function wait_for_second(env) {
@@ -86,9 +83,7 @@ function wait_for_second(env) {
     interval: "1m",
   });
 
-  if (err != null) {
-    fail("wait for t-3-runners returns" + err);
-  }
+  expect(err, "wait for t-3-runners returns").toBeNull();
 
   let allPods = env.getN("pods", {
     "namespace": "default", //tr.namespace()
@@ -97,7 +92,5 @@ function wait_for_second(env) {
   });
 
   // there should be N runners pods + initializer + starter
-  if (allPods != 3 + 2) {
-    fail("wrong number of pods:" + allPods + " instead of " + 5);
-  }
+  expect(allPods, "pod count for t-3-runners").toBe(3 + 2);
 }

--- a/e2e/testrun-watch-namespace/test.js
+++ b/e2e/testrun-watch-namespace/test.js
@@ -1,5 +1,6 @@
 import { Environment } from 'k6/x/environment';
-import { sleep, fail } from 'k6';
+import { sleep } from 'k6';
+import { expect } from '../assertions.js';
 
 export const options = {
   setupTimeout: '60s',
@@ -39,9 +40,7 @@ export default function () {
     interval: "1m",
   });
 
-  if (err != null) {
-    fail("wait for k6-sample in some-ns returns" + err);
-  }
+  expect(err, "wait for k6-sample in some-ns returns").toBeNull();
 
   err = env.wait({
     kind: "TestRun",
@@ -57,7 +56,7 @@ export default function () {
   // Uncomment this, once this issue is done:
   // https://github.com/grafana/xk6-environment/issues/17
   // if (err !== null) {
-  //   fail("wait for k6-sample in default returns" + err);
+  //   expect(err, "wait for k6-sample in default returns").toBeNull();
   // }
 }
 

--- a/e2e/testrun-watch-namespaces/test.js
+++ b/e2e/testrun-watch-namespaces/test.js
@@ -1,5 +1,6 @@
 import { Environment } from 'k6/x/environment';
-import { sleep, fail } from 'k6';
+import { sleep } from 'k6';
+import { expect } from '../assertions.js';
 
 export const options = {
   setupTimeout: '60s',
@@ -42,9 +43,7 @@ export default function () {
     interval: "1m",
   });
 
-  if (err != null) {
-    fail("wait for k6-sample in some-ns returns" + err);
-  }
+  expect(err, "wait for k6-sample in some-ns returns").toBeNull();
 
   err = env.wait({
     kind: "TestRun",
@@ -57,9 +56,7 @@ export default function () {
     interval: "1m",
   });
 
-  if (err != null) {
-    fail("wait for k6-sample in some-other-ns returns" + err);
-  }
+  expect(err, "wait for k6-sample in some-other-ns returns").toBeNull();
 
   err = env.wait({
     kind: "TestRun",
@@ -75,7 +72,7 @@ export default function () {
   // Uncomment this, once this issue is done:
   // https://github.com/grafana/xk6-environment/issues/17
   // if (err !== null) {
-  //   fail("wait for k6-sample in default returns" + err);
+  //   expect(err, "wait for k6-sample in default returns").toBeNull();
   // }
 }
 


### PR DESCRIPTION
Unlike `fail()`, `expect()` guarantees the call to `teardown` in case of failure. This is esp. important in tests based on xk6-environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to E2E test assertions and imports, with no impact to production logic. Main risk is behavioral differences in assertion handling that could alter test pass/fail conditions or error messages.
> 
> **Overview**
> Switches k6 E2E tests from imperative `fail()` checks to `expect()` assertions so failures still run `teardown()` (important for `xk6-environment` cleanup).
> 
> Adds a shared `e2e/assertions.js` re-export of `expect` and updates all affected tests to import it, converting error/null checks and pod-count validations to `toBe*()`/`toBeNull()`/`toBeTruthy()` matchers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5739bdffd6c87e18cf61a9feca626bf974ae2ff3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->