### PR TITLE
Forbid renovate large jumps in go `toolchain`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,6 +21,23 @@
             ]
         },
         {
+            "description": "Do not bump Go toolchain minor/major versions",
+            "matchManagers": [
+                "gomod"
+            ],
+            "matchDatasources": [
+                "golang-version"
+            ],
+            "matchDepTypes": [
+                "toolchain"
+            ],
+            "matchUpdateTypes": [
+                "minor",
+                "major"
+            ],
+            "enabled": false
+        },
+        {
             "description": "No indirect dependencies",
             "matchManagers": [
                 "gomod"


### PR DESCRIPTION
This came up in PR: https://github.com/grafana/k6-operator/pull/780/changes

Rationale. The project aims to verify the support for minimum Go version in CI matrix:
https://github.com/grafana/k6-operator/blob/main/.github/workflows/unit-test.yaml#L11

ATM, I don't have confidence that bumping minor version of `toolchain` directive won't break testing or, more precisely, hide it: e.g. perform only testing with Go 1.26 and not with 1.25. It'd be nice to confirm this some time. Until then, let's avoid automatic updates of minor version for `toolchain` directive just in case.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes Renovate configuration to stop automated minor/major bumps of the Go `toolchain`, with no runtime or build logic changes.
> 
> **Overview**
> Prevents Renovate from creating PRs that *minor/major* bump the Go `toolchain` directive by adding a `packageRules` entry that disables `golang-version` updates for `toolchain` when the update type is `minor` or `major`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8da6070256cb6d1302611dd7ea4c3009a0b88c38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->