### PR TITLE
chore: update Helm release HA to use GH token broker

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -1,4 +1,3 @@
-
 name: Helm release
 permissions: {}
 
@@ -8,7 +7,7 @@ on:
     branches:
       - main
     paths:
-      - 'charts/k6-operator/Chart.yaml'
+      - "charts/k6-operator/Chart.yaml"
 
 jobs:
   generate-chart-schema:
@@ -68,5 +67,4 @@ jobs:
       cr_configfile: charts/cr.yaml
       ct_configfile: charts/ct.yaml
       helm_tag_prefix: helm
-    secrets:
-      vault_repo_secret_name: github-app
+      github_app: k6-operator-helm-release-app


### PR DESCRIPTION
Ref. PR in helm-charts: https://github.com/grafana/helm-charts/pull/4164