### PR TITLE
[refactor] Use test_run_token as PLZ runner K6_CLOUD_TOKEN

### DIFF
--- a/pkg/cloud/types.go
+++ b/pkg/cloud/types.go
@@ -77,7 +77,7 @@ type TestRunData struct {
 	LZConfig      `json:"k8s_load_zones_config"`
 	RunStatus     cloudapi.RunStatus `json:"run_status"`
 	RuntimeConfig cloudapi.Config    `json:"k6_runtime_config"`
-	// SecretsToken is a short-lived, test-run-scoped token for read-only access to secrets.
+	// SecretsToken is a short-lived, test-run-scoped token for test runtime auth.
 	SecretsToken  string         `json:"test_run_token,omitempty"`
 	SecretsConfig *SecretsConfig `json:"secrets_config,omitempty"`
 }

--- a/pkg/plz/worker.go
+++ b/pkg/plz/worker.go
@@ -161,7 +161,10 @@ func (w *PLZWorker) createTemplate(plz *v1alpha1.PrivateLoadZone) {
 }
 
 // complete modifies tr with data from trData, which is specific for this test run.
-func (w *PLZWorker) complete(tr *v1alpha1.TestRun, trData *cloud.TestRunData) {
+func (w *PLZWorker) complete(tr *v1alpha1.TestRun, trData *cloud.TestRunData) error {
+	if trData.TestRunId > 0 && trData.SecretsToken == "" {
+		return fmt.Errorf("test_run_token is required for PLZ test run %s", trData.TestRunID())
+	}
 	tr.Name = testrun.PLZTestName(trData.TestRunID())
 
 	initContainer := containers.NewS3InitContainer(
@@ -174,6 +177,12 @@ func (w *PLZWorker) complete(tr *v1alpha1.TestRun, trData *cloud.TestRunData) {
 		Name:  "K6_CLOUD_HOST",
 		Value: cloud.K6CloudHost(),
 	})
+	if trData.SecretsToken != "" {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  "K6_CLOUD_TOKEN",
+			Value: trData.SecretsToken,
+		})
+	}
 
 	envVars = append(envVars, cloud.AggregationEnvVars(&trData.RuntimeConfig)...)
 
@@ -189,6 +198,8 @@ func (w *PLZWorker) complete(tr *v1alpha1.TestRun, trData *cloud.TestRunData) {
 		w.plz.Name,
 		trData.TestRunID())
 	tr.Spec.TestRunID = trData.TestRunID()
+
+	return nil
 }
 
 // handle creates a new PLZ TestRun from the given test run id
@@ -214,7 +225,10 @@ func (w *PLZWorker) handle(testRunId string) {
 		w.logger.Error(err, fmt.Sprintf("Failed to retrieve test run data for `%s`", testRunId))
 		return
 	}
-	w.complete(tr, trData)
+	if err := w.complete(tr, trData); err != nil {
+		w.logger.Error(err, "Failed to prepare PLZ test run", "testRunId", testRunId)
+		return
+	}
 
 	w.logger.Info(fmt.Sprintf("PLZ test run has been prepared with image `%s` and `%d` instances",
 		tr.Spec.Runner.Image, tr.Spec.Parallelism), "testRunId", testRunId)

--- a/pkg/plz/worker_test.go
+++ b/pkg/plz/worker_test.go
@@ -125,11 +125,12 @@ func Test_complete_correctDefinitionOfTestRun(t *testing.T) {
 			corev1.ResourceCPU:    resource.MustParse("200m"),
 			corev1.ResourceMemory: resource.MustParse("1G"),
 		}
-		someTestRunID   = 6543
-		someRunnerImage = "grafana/k6:0.52.0"
-		someInstances   = 10
-		someArchiveURL  = "https://foo.s3.amazonaws.com"
-		someEnvVars     = map[string]string{
+		someTestRunID    = 6543
+		someRunnerImage  = "grafana/k6:0.52.0"
+		someInstances    = 10
+		someArchiveURL   = "https://foo.s3.amazonaws.com"
+		someTestRunToken = "abc123token"
+		someEnvVars      = map[string]string{
 			"ENV": "VALUE",
 			"foo": "bar",
 		}
@@ -197,6 +198,16 @@ func Test_complete_correctDefinitionOfTestRun(t *testing.T) {
 	}
 	cloudFieldsTestRun.Spec.Runner.Image = someRunnerImage
 	cloudFieldsTestRun.Spec.Parallelism = int32(someInstances)
+	cloudFieldsTestRun.Spec.Runner.Env = append([]corev1.EnvVar{
+		{
+			Name:  "K6_CLOUD_HOST",
+			Value: mainIngest,
+		},
+		{
+			Name:  "K6_CLOUD_TOKEN",
+			Value: someTestRunToken,
+		},
+	}, cloud.AggregationEnvVars(&cloudapi.Config{})...)
 
 	cloudEnvVarsTestRun = cloudFieldsTestRun // build up on top of cloud fields case
 	cloudEnvVarsTestRun.Spec.Runner.Env = append([]corev1.EnvVar{
@@ -208,7 +219,7 @@ func Test_complete_correctDefinitionOfTestRun(t *testing.T) {
 			Name:  "foo",
 			Value: "bar",
 		},
-	}, defaultTestRun.Spec.Runner.Env...)
+	}, cloudFieldsTestRun.Spec.Runner.Env...)
 
 	podTemplateTolerationsTestRun = requiredFieldsTestRun
 	podTemplateTolerationsTestRun.Spec.Runner.Tolerations = someTolerations
@@ -234,7 +245,6 @@ func Test_complete_correctDefinitionOfTestRun(t *testing.T) {
 		Endpoint:     "https://api.k6.io/provisioning/v1/test_runs/6543/decrypt_secret?name={key}",
 		ResponsePath: "plaintext",
 	}
-	someTestRunToken := "abc123token"
 
 	secretsWithTokenTestRun = cloudFieldsTestRun
 	secretsWithTokenTestRun.Spec.Runner.Env = append(
@@ -251,6 +261,7 @@ func Test_complete_correctDefinitionOfTestRun(t *testing.T) {
 		cloudData *cloud.TestRunData
 		ingestUrl string
 		expected  *v1alpha1.TestRun
+		wantErr   bool
 	}{
 		{
 			name:      "empty input gets a zero-values TestRun",
@@ -303,7 +314,8 @@ func Test_complete_correctDefinitionOfTestRun(t *testing.T) {
 				},
 			},
 			cloudData: &cloud.TestRunData{
-				TestRunId: someTestRunID,
+				TestRunId:    someTestRunID,
+				SecretsToken: someTestRunToken,
 				LZConfig: cloud.LZConfig{
 					RunnerImage:   someRunnerImage,
 					InstanceCount: someInstances,
@@ -324,7 +336,8 @@ func Test_complete_correctDefinitionOfTestRun(t *testing.T) {
 				},
 			},
 			cloudData: &cloud.TestRunData{
-				TestRunId: someTestRunID,
+				TestRunId:    someTestRunID,
+				SecretsToken: someTestRunToken,
 				LZConfig: cloud.LZConfig{
 					RunnerImage:   someRunnerImage,
 					InstanceCount: someInstances,
@@ -334,6 +347,27 @@ func Test_complete_correctDefinitionOfTestRun(t *testing.T) {
 			},
 			ingestUrl: mainIngest,
 			expected:  &cloudEnvVarsTestRun,
+		},
+		{
+			name: "cloud fields without test run token",
+			plz: &v1alpha1.PrivateLoadZone{
+				Spec: v1alpha1.PrivateLoadZoneSpec{
+					Token: someToken,
+					Resources: corev1.ResourceRequirements{
+						Limits: resourceLimits,
+					},
+				},
+			},
+			cloudData: &cloud.TestRunData{
+				TestRunId: someTestRunID,
+				LZConfig: cloud.LZConfig{
+					RunnerImage:   someRunnerImage,
+					InstanceCount: someInstances,
+					ArchiveURL:    someArchiveURL,
+				},
+			},
+			ingestUrl: mainIngest,
+			wantErr:   true,
 		},
 		{
 			name: "podTemplate with tolerations",
@@ -457,7 +491,16 @@ func Test_complete_correctDefinitionOfTestRun(t *testing.T) {
 			worker := NewPLZWorker(testCase.plz, "token", c, logr.Logger{})
 
 			tr := worker.template.Create()
-			worker.complete(tr, testCase.cloudData)
+			err := worker.complete(tr, testCase.cloudData)
+			if testCase.wantErr {
+				if err == nil {
+					t.Fatal("worker.complete expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("worker.complete returned unexpected error: %v", err)
+			}
 
 			if diff := deep.Equal(tr, testCase.expected); diff != nil {
 				t.Errorf("worker.complete returned unexpected data, diff: %s", diff)

--- a/pkg/resources/jobs/runner.go
+++ b/pkg/resources/jobs/runner.go
@@ -122,21 +122,22 @@ func NewRunnerJob(k6 *v1alpha1.TestRun, index int, tokenInfo *cloud.TokenInfo) (
 
 	// this is a cloud test run: either cloud output or PLZ
 	if len(k6.TestRunID()) > 0 {
-		// cloud output case
-		tokenVar := corev1.EnvVar{
-			Name:  "K6_CLOUD_TOKEN",
-			Value: tokenInfo.Value(),
-		}
+		envVars := []corev1.EnvVar{{
+			Name:  "K6_CLOUD_PUSH_REF_ID",
+			Value: k6.TestRunID(),
+		}}
 
 		if v1alpha1.IsTrue(k6, v1alpha1.CloudPLZTestRun) {
-			tokenVar = corev1.EnvVar{
-				Name: "K6_CLOUD_TOKEN",
-				ValueFrom: &corev1.EnvVarSource{
-					SecretKeyRef: &corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{Name: tokenInfo.SecretName()},
-						Key:                  "token",
+			if !hasEnvVar(k6.GetSpec().Runner.Env, "K6_CLOUD_TOKEN") {
+				envVars = append(envVars, corev1.EnvVar{
+					Name: "K6_CLOUD_TOKEN",
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: tokenInfo.SecretName()},
+							Key:                  "token",
+						},
 					},
-				},
+				})
 			}
 		} else {
 			// cloud output case
@@ -145,12 +146,13 @@ func NewRunnerJob(k6 *v1alpha1.TestRun, index int, tokenInfo *cloud.TokenInfo) (
 				return nil, err
 			}
 			env = append(env, aggregationVars...)
+			envVars = append(envVars, corev1.EnvVar{
+				Name:  "K6_CLOUD_TOKEN",
+				Value: tokenInfo.Value(),
+			})
 		}
 
-		env = append(env, corev1.EnvVar{
-			Name:  "K6_CLOUD_PUSH_REF_ID",
-			Value: k6.TestRunID(),
-		}, tokenVar)
+		env = append(env, envVars...)
 	}
 
 	env = append(env, k6.GetSpec().Runner.Env...)
@@ -219,6 +221,16 @@ func NewRunnerJob(k6 *v1alpha1.TestRun, index int, tokenInfo *cloud.TokenInfo) (
 	}
 
 	return job, nil
+}
+
+func hasEnvVar(envVars []corev1.EnvVar, name string) bool {
+	for _, envVar := range envVars {
+		if envVar.Name == name {
+			return true
+		}
+	}
+
+	return false
 }
 
 func NewRunnerService(k6 *v1alpha1.TestRun, index int) (*corev1.Service, error) {

--- a/pkg/resources/jobs/runner_test.go
+++ b/pkg/resources/jobs/runner_test.go
@@ -469,6 +469,33 @@ func Test_NewRunnerJob(t *testing.T) {
 				}
 			},
 		},
+		{
+			name:      "PLZ test run with test run token env",
+			tokenInfo: cloud.NewTokenInfo("plz-token-secret", "test"),
+			setupTestRun: func(k6 *v1alpha1.TestRun) {
+				k6.Spec.TestRunID = "plz-run-123"
+				k6.Spec.Runner.Env = []corev1.EnvVar{
+					{Name: "K6_CLOUD_TOKEN", Value: "test-run-token"},
+				}
+				k6.Status.Conditions = []metav1.Condition{
+					{
+						Type:               v1alpha1.CloudPLZTestRun,
+						Status:             metav1.ConditionTrue,
+						LastTransitionTime: metav1.Now(),
+					},
+				}
+			},
+			setupExpectedJob: func(j *batchv1.Job) {
+				j.Spec.Template.Spec.Containers[0].Command = append(
+					j.Spec.Template.Spec.Containers[0].Command,
+					"--no-setup", "--no-teardown", "--linger",
+				)
+				j.Spec.Template.Spec.Containers[0].Env = []corev1.EnvVar{
+					{Name: "K6_CLOUD_PUSH_REF_ID", Value: "plz-run-123"},
+					{Name: "K6_CLOUD_TOKEN", Value: "test-run-token"},
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
- Wires backend test_run_token into PLZ runner env as K6_CLOUD_TOKEN.
-  Fails PLZ test-run setup early when test_run_token is missing.
-  Keeps existing non-PLZ/cloud-output token behavior unchanged.