### PR TITLE
CI: fix publish-techdocs call

### DIFF
--- a/.github/workflows/publish-techdocs.yaml
+++ b/.github/workflows/publish-techdocs.yaml
@@ -4,17 +4,17 @@ on:
     branches:
       - main
     paths:
-      - 'docs/**'
-      - 'mkdocs.yml'
-      - 'catalog-info.yaml'
-      - '.github/workflows/publish-techdocs.yaml'
+      - "docs/**"
+      - "mkdocs.yml"
+      - "catalog-info.yaml"
+      - ".github/workflows/publish-techdocs.yaml"
 concurrency:
-  group: '${{ github.workflow }}-${{ github.ref }}'
+  group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: true
 permissions: {}
 jobs:
   publish-docs:
-    uses: grafana/shared-workflows/.github/workflows/publish-techdocs.yaml@638f24848a49edb0bd14f771b6dd37b4455f1591
+    uses: grafana/shared-workflows/.github/workflows/publish-techdocs.yaml@main
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
publish-techdocs must be called with `@main` ATM.