### PR TITLE
Update GA runners to ubuntu-x64

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   golangci:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -14,7 +14,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
           cache: false
       - name: lint
         uses: golangci/golangci-lint-action@36fe29c8f9dc696b104db0f7d49d1a87d2bbcd5b

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -17,6 +17,6 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
       - run: |
           go run golang.org/x/vuln/cmd/govulncheck@v1.3.0 ./...

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   govulncheck:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-x64
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   generate-chart-schema:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-x64
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/helm-schema.yaml
+++ b/.github/workflows/helm-schema.yaml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   schema:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-x64
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/helm-schema.yaml
+++ b/.github/workflows/helm-schema.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
           cache: false
 
       - name: Generate Helm values schema

--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-x64
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -15,7 +15,7 @@ on:
 jobs:
   build:
     name: "Build images"
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-x64
     permissions:
       packages: write
     steps:
@@ -79,7 +79,7 @@ jobs:
   bundle:
     name: "Generate bundle"
     if: startsWith(github.ref_name, 'v')
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-x64
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -55,8 +55,6 @@ jobs:
           context: .
           push: true
           file: Dockerfile.controller
-          build-args: |
-            GO_BUILDER_IMG=golang:1.26.3-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d
           platforms: linux/amd64,linux/arm64
           tags: ghcr.io/grafana/k6-operator:latest,ghcr.io/grafana/k6-operator:controller-${{env.IMAGETAG}}
       - name: "Build:dockerimage"

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -65,8 +65,6 @@ jobs:
           context: .
           file: Dockerfile.controller
           push: true
-          build-args: |
-            GO_BUILDER_IMG=golang:1.26.3-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d
           tags: |
             ghcr.io/grafana/k6-operator:${{ github.sha }}
 

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   changes:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-x64
     permissions:
       contents: read
     outputs:
@@ -40,7 +40,7 @@ jobs:
               - 'charts/**'
 
   docker:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-x64
     permissions:
       packages: write
     steps:
@@ -73,7 +73,7 @@ jobs:
   kind-kustomize:
     needs: ["changes", "docker"]
     if: needs.changes.outputs.go-or-manifests == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-x64
     steps:
       - name: "Checkout"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -110,7 +110,7 @@ jobs:
   kind-helm:
     needs: ["changes", "docker"]
     if: needs.changes.outputs.charts == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-x64
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -8,7 +8,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.25.10, 1.26.3]
+        go-version: [1.25.11, 1.26.4]
         k8s_version: [1.27.1, 1.30.0, 1.34.1]
         os: [ubuntu-x64]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         go-version: [1.25.10, 1.26.3]
         k8s_version: [1.27.1, 1.30.0, 1.34.1]
-        os: [ubuntu-24.04]
+        os: [ubuntu-x64]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Go

--- a/.github/workflows/yamllint.yaml
+++ b/.github/workflows/yamllint.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   lintAllTheThings:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI and build-pipeline configuration only; no application or runtime behavior changes.
> 
> **Overview**
> Standardizes GitHub Actions jobs on **`ubuntu-x64`** instead of **`ubuntu-24.04`** across lint, test, Helm, release, smoke, and vuln-check workflows.
> 
> Bumps Go in CI from **1.26.3 → 1.26.4** (and unit-test matrix **1.25.10 → 1.25.11**, **1.26.3 → 1.26.4**). **Release** and **smoke-test** controller image builds no longer pass a **`GO_BUILDER_IMG`** build-arg, so the **`Dockerfile.controller`** base image pin drives the builder version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 008ecb1942c42c199a06da9ac178a13819b07efd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->