### PR TITLE
Add a deprecation warning for `.spec.scuttle`

### DIFF
--- a/api/v1alpha1/testrun_types.go
+++ b/api/v1alpha1/testrun_types.go
@@ -127,6 +127,9 @@ type TestRunSpec struct {
 	Paused string `json:"paused,omitempty"`
 
 	// Configuration for Envoy proxy.
+	// Deprecated: we'll be removing support for Envoy.
+	// See https://github.com/grafana/k6-operator/issues/195#issuecomment-3062174234 for details.
+	// +optional
 	Scuttle K6Scuttle `json:"scuttle,omitempty"`
 
 	Cleanup Cleanup `json:"cleanup,omitempty"`
@@ -213,10 +216,15 @@ func init() {
 	SchemeBuilder.Register(&TestRun{}, &TestRunList{})
 }
 
-func (k6 *TestRunSpec) Validate() error {
+func (k6 *TestRunSpec) Validate() (warnings []string, err error) {
+	// Check for deprecated fields.
+	if len(k6.Scuttle.Enabled) > 0 {
+		warnings = append(warnings, "`.spec.scuttle` is deprecated and will be removed in the future. See https://grafana.com/docs/k6/latest/set-up/set-up-distributed-k6/usage/istio/ on how to set up Istio.")
+	}
+
 	// Currently, we validate "manually" only arguments field.
-	_, err := types.ParseCLI(k6.Arguments)
-	return err
+	_, err = types.ParseCLI(k6.Arguments)
+	return
 }
 
 // Parse extracts Script data bits from K6 spec and performs basic validation

--- a/charts/k6-operator/templates/role.yaml
+++ b/charts/k6-operator/templates/role.yaml
@@ -19,6 +19,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - get

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -111,9 +111,10 @@ func main() {
 	_ = mgr.AddReadyzCheck("ready", healthz.Ping)
 
 	if err = (&controllers.TestRunReconciler{
-		Client: mgr.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("TestRun"),
-		Scheme: mgr.GetScheme(),
+		Client:   mgr.GetClient(),
+		Log:      ctrl.Log.WithName("controllers").WithName("TestRun"),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("testrun-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "TestRun")
 		os.Exit(1)

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - pods
   - pods/log
   - secrets

--- a/internal/controller/testrun_controller.go
+++ b/internal/controller/testrun_controller.go
@@ -21,15 +21,16 @@ import (
 	"time"
 
 	"go.k6.io/k6/v2/cloudapi"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 
 	"github.com/go-logr/logr"
 	"github.com/grafana/k6-operator/api/v1alpha1"
 	"github.com/grafana/k6-operator/pkg/cloud"
 	k6types "github.com/grafana/k6-operator/pkg/types"
 	batchv1 "k8s.io/api/batch/v1"
-	v1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -48,8 +49,9 @@ const (
 // TestRunReconciler reconciles a K6 object
 type TestRunReconciler struct {
 	client.Client
-	Log    logr.Logger
-	Scheme *runtime.Scheme
+	Log      logr.Logger
+	Scheme   *runtime.Scheme
+	Recorder record.EventRecorder
 
 	// Note: here we assume that all users of the operator are allowed to use
 	// the same token / cloud client.
@@ -65,6 +67,7 @@ type TestRunReconciler struct {
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;create;update
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 func (r *TestRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := r.Log.WithValues("namespace", req.Namespace, "name", req.Name, "reconcileID", controller.ReconcileIDFromContext(ctx))
@@ -127,7 +130,12 @@ func (r *TestRunReconciler) reconcile(ctx context.Context, req ctrl.Request, log
 	case "":
 		log.Info("Initialize test")
 
-		if err := k6.GetSpec().Validate(); err != nil {
+		warnings, err := k6.GetSpec().Validate()
+		for _, w := range warnings {
+			log.Info(w)
+			r.Recorder.Event(k6, corev1.EventTypeWarning, "DeprecatedField", w)
+		}
+		if err != nil {
 			log.Error(err, "Invalid TestRun")
 			log.Info("Changing stage of TestRun status to error")
 			k6.GetStatus().Stage = "error"
@@ -378,10 +386,10 @@ func (r *TestRunReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.TestRun{}).
 		Owns(&batchv1.Job{}).
-		Watches(&v1.Pod{},
+		Watches(&corev1.Pod{},
 			handler.EnqueueRequestsFromMapFunc(
 				func(ctx context.Context, object client.Object) []reconcile.Request {
-					pod := object.(*v1.Pod)
+					pod := object.(*corev1.Pod)
 					k6CrName, ok := pod.GetLabels()[k6CrLabelName]
 					if !ok {
 						return nil
@@ -394,7 +402,7 @@ func (r *TestRunReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				}),
 			builder.WithPredicates(predicate.NewPredicateFuncs(
 				func(object client.Object) bool {
-					pod := object.(*v1.Pod)
+					pod := object.(*corev1.Pod)
 					_, ok := pod.GetLabels()[k6CrLabelName]
 					return ok
 				}))).


### PR DESCRIPTION
As described in https://github.com/grafana/k6-operator/issues/195#issuecomment-3062174234, we're going to deprecate the `.spec.scuttle` field as it's possible to setup Envoy / Istio with cleaner approaches on modern clusters.

This PR doesn't change logic yet but adds deprecation warnings in logs and events:
```
  Warning  DeprecatedField  31s   testrun-controller  `.spec.scuttle` is deprecated and will be removed in the future. See https://grafana.com/docs/k6/latest/set-up/set-up-distributed-k6/usage/istio/ on how to set up Istio.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability and documentation only—no change to Scuttle/Envoy logic or test execution paths.
> 
> **Overview**
> Documents **`.spec.scuttle`** (Envoy/Scuttle) as deprecated on the API type and surfaces that to users without changing runtime behavior yet.
> 
> **`TestRunSpec.Validate`** now returns **warnings** alongside validation errors. When **`spec.scuttle.enabled`** is set, a warning points users to Istio setup docs. On the empty-stage init path, the reconciler logs each warning and emits a **`DeprecatedField`** **Warning** event on the **TestRun** via a new **`EventRecorder`**, with RBAC extended so the controller can **create/patch** **events** (Helm role and **`config/rbac/role.yaml`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30f313edc8e05e8a60f28b64067dcbf825aa8f44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->