### PR TITLE
Refactoring initializer command to account for more error cases

### DIFF
--- a/e2e/basic-testrun-1/test.js
+++ b/e2e/basic-testrun-1/test.js
@@ -11,7 +11,7 @@ const PARENT = "./"
 const env = new Environment({
   name: "basic-testrun-1",
   implementation: "vcluster",
-  initFolder: PARENT + "manifests", // initial folder with everything that wil be loaded at init
+  initFolder: PARENT + "manifests", // initial folder with everything that will be loaded at init
 })
 
 export function setup() {

--- a/e2e/initializer-missing-k6-logs/log-checker.yaml
+++ b/e2e/initializer-missing-k6-logs/log-checker.yaml
@@ -1,0 +1,31 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: initializer-log-checker
+spec:
+  backoffLimit: 0
+  template:
+    spec:
+      serviceAccountName: initializer-log-checker
+      restartPolicy: Never
+      containers:
+      - name: kubectl
+        image: alpine/k8s:1.31.0
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -eu
+
+          selector='app=k6,k6_cr=k6-missing-k6,job-name=k6-missing-k6-initializer'
+          pod="$(kubectl get pod -l "${selector}" -o jsonpath='{.items[0].metadata.name}')"
+          phase="$(kubectl get pod "${pod}" -o jsonpath='{.status.phase}')"
+
+          if [ "${phase}" != "Failed" ]; then
+            echo "initializer pod should fail; phase=${phase}"
+            exit 1
+          fi
+
+          logs="$(kubectl logs "${pod}" -c k6)"
+          printf '%s\n' "${logs}"
+          printf '%s\n' "${logs}" | grep -F 'k6 executable not found in PATH; initializer image must contain k6'

--- a/e2e/initializer-missing-k6-logs/manifests/configmap.yaml
+++ b/e2e/initializer-missing-k6-logs/manifests/configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test
+data:
+  test.js: |
+    export const options = {
+      vus: 1,
+      duration: "1s",
+    };
+
+    export default function () {}

--- a/e2e/initializer-missing-k6-logs/manifests/kustomization.yaml
+++ b/e2e/initializer-missing-k6-logs/manifests/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../latest/
+- configmap.yaml
+- rbac.yaml

--- a/e2e/initializer-missing-k6-logs/manifests/rbac.yaml
+++ b/e2e/initializer-missing-k6-logs/manifests/rbac.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: initializer-log-checker
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: initializer-log-checker
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["pods/log"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: initializer-log-checker
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: initializer-log-checker
+subjects:
+- kind: ServiceAccount
+  name: initializer-log-checker

--- a/e2e/initializer-missing-k6-logs/test.js
+++ b/e2e/initializer-missing-k6-logs/test.js
@@ -1,0 +1,59 @@
+import { Environment } from 'k6/x/environment';
+import { sleep } from 'k6';
+import { expect } from '../assertions.js';
+
+export const options = {
+  setupTimeout: '60s',
+};
+
+const PARENT = "./"
+const TEST_NAME = "k6-missing-k6"
+
+const env = new Environment({
+  name: "initializer-missing-k6-logs",
+  implementation: "vcluster",
+  initFolder: PARENT + "manifests",
+})
+
+export function setup() {
+  console.log("init returns", env.init());
+  sleep(0.5);
+}
+
+export default function () {
+  let err = env.apply(PARENT + "testrun.yaml");
+  console.log("apply testrun returns", err)
+  expect(err, "apply testrun returns").toBeNull();
+
+  err = env.wait({
+    kind: "TestRun",
+    name: TEST_NAME,
+    namespace: "default",
+    status_key: "stage",
+    status_value: "error",
+  }, {
+    timeout: "3m",
+    interval: "10s",
+  });
+  expect(err, "testrun should reach error stage").toBeNull();
+
+  err = env.apply(PARENT + "log-checker.yaml");
+  console.log("apply log checker returns", err)
+  expect(err, "apply log checker returns").toBeNull();
+
+  err = env.wait({
+    kind: "Job",
+    name: "initializer-log-checker",
+    namespace: "default",
+    condition_type: "Complete",
+    value: "True",
+  }, {
+    timeout: "3m",
+    interval: "10s",
+  });
+  expect(err, "initializer logs should show missing k6").toBeNull();
+}
+
+export function teardown() {
+  console.log("delete returns", env.delete());
+}

--- a/e2e/initializer-missing-k6-logs/testrun.yaml
+++ b/e2e/initializer-missing-k6-logs/testrun.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: k6.io/v1alpha1
+kind: TestRun
+metadata:
+  name: k6-missing-k6
+spec:
+  parallelism: 1
+  script:
+    configMap:
+      name: "test"
+      file: "test.js"
+  initializer:
+    image: busybox:1.36

--- a/e2e/tests.yaml
+++ b/e2e/tests.yaml
@@ -104,6 +104,12 @@ tests:
       - "internal/controller/k6_initialize.go"
       - "pkg/resources/jobs/initializer.go"
 
+  - name: initializer-missing-k6-logs
+    source_patterns:
+      - "internal/controller/k6_initialize.go"
+      - "internal/controller/common.go"
+      - "pkg/resources/jobs/initializer.go"
+
   # - name: volume-claim
   # - name: kyverno
   # - name: custom-domain

--- a/pkg/resources/jobs/initializer.go
+++ b/pkg/resources/jobs/initializer.go
@@ -10,6 +10,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const initializerMissingK6Message = `level=error msg="k6 executable not found in PATH; initializer image must contain k6"`
+
 // NewInitializerJob builds a template used to initializefor creating a starter job
 func NewInitializerJob(k6 *v1alpha1.TestRun, argLine string) (*batchv1.Job, error) {
 	script, err := k6.GetSpec().ParseScript()
@@ -67,25 +69,7 @@ func NewInitializerJob(k6 *v1alpha1.TestRun, argLine string) (*batchv1.Job, erro
 		archiveName = fmt.Sprintf("/tmp/%s.archived.tar", script.Filename)
 	)
 	istioCommand, istioEnabled := newIstioCommand(k6.GetSpec().Scuttle.Enabled, []string{"sh", "-c"})
-	command := append(istioCommand, fmt.Sprintf(
-		// There can be several scenarios from k6 command here:
-		// a) script is correct and `k6 inspect` outputs JSON
-		// b) script is partially incorrect and `k6` outputs a warning log message and
-		// then a JSON
-		// c) script is incorrect and `k6` outputs an error log message
-		// Warnings at this point are not necessary (warning messages will re-appear in
-		// runner's logs and the user can see them there) so we need a pure JSON here
-		// without any additional messages in cases a) and b). In case c), output should
-		// contain error message and the Job is to exit with non-zero code.
-		//
-		// Due to some pecularities of k6 logging, to achieve the above behaviour,
-		// we need to use a workaround to store all log messages in temp file while
-		// printing JSON as usual. Then parse temp file only for errors, ignoring
-		// any other log messages.
-		// Related: https://github.com/grafana/k6-docs/issues/877
-		"mkdir -p $(dirname %s) && k6 archive %s%s -O %s %s 2> /tmp/k6logs && k6 inspect --execution-requirements %s 2> /tmp/k6logs ; ! cat /tmp/k6logs | grep 'level.*error'",
-		archiveName, scriptName, envVarString, archiveName, argLine,
-		archiveName))
+	command := append(istioCommand, newInitializerCommand(scriptName, archiveName, envVarString, argLine))
 
 	env := append(newIstioEnvVar(k6.GetSpec().Scuttle, istioEnabled), k6.GetSpec().Initializer.Env...)
 
@@ -148,4 +132,57 @@ func NewInitializerJob(k6 *v1alpha1.TestRun, argLine string) (*batchv1.Job, erro
 	}
 
 	return job, nil
+}
+
+func newInitializerCommand(scriptName, archiveName, envVarString, argLine string) string {
+	// There can be several scenarios from k6 command here:
+	// a) script is correct and `k6 inspect` outputs JSON;
+	// b) script is partially incorrect and `k6` outputs a warning log message and
+	// then a JSON;
+	// c) script is incorrect and `k6` outputs an error log message;
+	// d) k6 binary is missing;
+	// e) k6 binary exists but is corrupted or otherwise unexecutable.
+	//
+	// Warnings at this point are not necessary (warning messages will re-appear in
+	// runner's logs and the user can see them there) so we need a pure JSON here,
+	// without any additional messages in cases a) and b). In cases c) - e), output
+	// should contain an error message and the Job is to exit with non-zero code.
+	//
+	// Due to some peculiarities of k6 logging, to achieve the above behaviour,
+	// we need to use a workaround to store all log messages in temp file while
+	// printing JSON as usual. Then parse temp file only for errors, ignoring
+	// any other log messages.
+	// Related: https://github.com/grafana/k6-docs/issues/877
+
+	return fmt.Sprintf(
+		`if ! command -v k6 >/dev/null 2>&1; then
+  echo '%[1]s' >&2
+  exit 127
+fi
+
+logs=/tmp/k6logs
+
+if ! mkdir -p "$(dirname %[3]s)"; then
+  exit 1
+fi
+
+if ! k6 archive %[2]s%[4]s -O %[3]s %[5]s 2> "${logs}"; then
+  cat "${logs}"
+  exit 1
+fi
+
+if ! k6 inspect --execution-requirements %[3]s 2> "${logs}"; then
+  cat "${logs}"
+  exit 1
+fi
+
+if grep 'level.*error' "${logs}"; then
+  exit 1
+fi`,
+		initializerMissingK6Message,
+		scriptName,
+		archiveName,
+		envVarString,
+		argLine,
+	)
 }

--- a/pkg/resources/jobs/initializer_test.go
+++ b/pkg/resources/jobs/initializer_test.go
@@ -102,7 +102,12 @@ func defaultExpectedJobForInitializer() *batchv1.Job {
 							Name:            "k6",
 							Command: []string{
 								"sh", "-c",
-								"mkdir -p $(dirname /tmp/test.js.archived.tar) && k6 archive /test/test.js -O /tmp/test.js.archived.tar --out cloud 2> /tmp/k6logs && k6 inspect --execution-requirements /tmp/test.js.archived.tar 2> /tmp/k6logs ; ! cat /tmp/k6logs | grep 'level.*error'",
+								newInitializerCommand(
+									"/test/test.js",
+									"/tmp/test.js.archived.tar",
+									"",
+									"--out cloud",
+								),
 							},
 							Env: []corev1.EnvVar{},
 							EnvFrom: []corev1.EnvFromSource{
@@ -126,6 +131,7 @@ func defaultExpectedJobForInitializer() *batchv1.Job {
 		},
 	}
 }
+
 func Test_NewInitializerJob(t *testing.T) {
 	tests := []struct {
 		name             string
@@ -177,7 +183,6 @@ func Test_NewInitializerJob(t *testing.T) {
 			if diff != nil {
 				t.Errorf("NewInitializerJob difference: %v", diff)
 			}
-
 		})
 	}
 }


### PR DESCRIPTION
As described [here](https://github.com/grafana/k6-operator/issues/435#issuecomment-4502312165), the missing k6 binary in the image is a case that is currently hidden by initializer logic. This PR fixes that.

Additionally, if k6 binary exists but is corrupted for some reason, `k6 archive` will produce a non-zero exit code and with this change, the initializer is now explicitly tracking that as well.

All in all, this PR should fix the case of k6 missing binary but also https://github.com/grafana/k6-operator/issues/435 too. (We didn't get a reproducible scenario in that issue, but I assume it was something causing non-zero exit code from `k6 archive` without useful logs.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the initializer Job command on the TestRun init path; behavior on success should match, but failure modes and exit codes differ from the previous shell pipeline.
> 
> **Overview**
> Refactors the initializer container’s shell script into **`newInitializerCommand`**, with clearer failure handling than the old chained one-liner.
> 
> The initializer now **checks for `k6` on PATH** before running and emits a fixed **`level=error`** message when the custom image has no k6 binary. **`k6 archive`** and **`k6 inspect`** failures are handled explicitly: non-zero exits dump captured logs and fail the job, instead of relying only on grepping `/tmp/k6logs` after a combined command.
> 
> Adds an **e2e scenario** (`initializer-missing-k6-logs`) that uses a **`busybox`** initializer image, expects the TestRun to reach **`error`**, and verifies initializer pod logs contain the missing-k6 message. **`e2e/tests.yaml`** registers that test against initializer-related source paths. Unit tests assert the job command via **`newInitializerCommand`**. Also fixes a comment typo in **`basic-testrun-1`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50fa04e2ff4e3fd37d495b23ee5c667dec86cd28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->