### PR TITLE
Hardening memory and concurrency

### DIFF
--- a/internal/controller/k6_start.go
+++ b/internal/controller/k6_start.go
@@ -23,6 +23,7 @@ func isServiceReady(log logr.Logger, service *v1.Service) bool {
 		log.Error(err, fmt.Sprintf("failed to get status from %v", service.Name))
 		return false
 	}
+	defer resp.Body.Close() //nolint:errcheck
 
 	return resp.StatusCode < 400
 }

--- a/internal/controller/k6_stopped_jobs.go
+++ b/internal/controller/k6_stopped_jobs.go
@@ -22,6 +22,7 @@ func isJobRunning(log logr.Logger, service *v1.Service) bool {
 	if err != nil {
 		return false
 	}
+	defer resp.Body.Close() //nolint:errcheck
 
 	// Response has been received so assume the job is running.
 
@@ -29,8 +30,6 @@ func isJobRunning(log logr.Logger, service *v1.Service) bool {
 		log.Error(err, fmt.Sprintf("status from from runner job %v is %d", service.Name, resp.StatusCode))
 		return true
 	}
-
-	defer resp.Body.Close() //nolint:errcheck
 
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/pkg/cloud/conn/poller.go
+++ b/pkg/cloud/conn/poller.go
@@ -11,6 +11,7 @@ type Poller struct {
 
 	mu      sync.Mutex
 	running bool
+	ctx     context.Context
 	cancel  context.CancelFunc
 
 	OnInterval func()
@@ -34,6 +35,19 @@ func (poller *Poller) IsPolling() bool {
 	return poller.running
 }
 
+// Context returns the context owned by the poller. When poller stops,
+// it cancels the context. Use it to abort / cancel processes downstream.
+func (poller *Poller) Context() context.Context {
+	poller.mu.Lock()
+	defer poller.mu.Unlock()
+
+	if poller.ctx == nil {
+		return context.Background()
+	}
+
+	return poller.ctx
+}
+
 func (poller *Poller) Start() {
 	poller.mu.Lock()
 	defer poller.mu.Unlock()
@@ -42,8 +56,10 @@ func (poller *Poller) Start() {
 		return
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	poller.cancel = cancel
+	// At the moment of writing, context.Background() is intentional here.
+	// The only upstream context we can use here instead is the manager's one,
+	// but wiring it up will complicate impl. with little benefit.
+	poller.ctx, poller.cancel = context.WithCancel(context.Background())
 	poller.running = true
 
 	ticker := time.NewTicker(poller.interval)
@@ -51,7 +67,7 @@ func (poller *Poller) Start() {
 	go func() {
 		for {
 			select {
-			case <-ctx.Done():
+			case <-poller.ctx.Done():
 				ticker.Stop()
 				poller.OnDone()
 				return
@@ -63,9 +79,9 @@ func (poller *Poller) Start() {
 	}()
 }
 
-// Stop signals the poller to stop. It is non-blocking and idempotent: cancelling
+// Stop signals the poller to stop. Non-blocking and idempotent: cancelling
 // the context returns immediately even if OnInterval is currently executing (or
-// stuck), so callers such as the reconciler are never wedged by a slow handler.
+// stuck), so callers (reconciler) don't get stuck stuck by a handler.
 func (poller *Poller) Stop() {
 	poller.mu.Lock()
 	defer poller.mu.Unlock()

--- a/pkg/cloud/conn/poller.go
+++ b/pkg/cloud/conn/poller.go
@@ -1,13 +1,17 @@
 package conn
 
 import (
+	"context"
+	"sync"
 	"time"
 )
 
 type Poller struct {
 	interval time.Duration
-	running  bool
-	done     chan bool
+
+	mu      sync.Mutex
+	running bool
+	cancel  context.CancelFunc
 
 	OnInterval func()
 	OnDone     func()
@@ -16,8 +20,6 @@ type Poller struct {
 func NewPoller(interval time.Duration) *Poller {
 	return &Poller{
 		interval: interval,
-		running:  false,
-		done:     make(chan bool),
 
 		// by default, poller does nothing
 		OnInterval: func() {},
@@ -25,17 +27,31 @@ func NewPoller(interval time.Duration) *Poller {
 	}
 }
 
-func (poller Poller) IsPolling() bool {
+func (poller *Poller) IsPolling() bool {
+	poller.mu.Lock()
+	defer poller.mu.Unlock()
+
 	return poller.running
 }
 
 func (poller *Poller) Start() {
+	poller.mu.Lock()
+	defer poller.mu.Unlock()
+
+	if poller.running {
+		return
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	poller.cancel = cancel
+	poller.running = true
+
 	ticker := time.NewTicker(poller.interval)
 
 	go func() {
 		for {
 			select {
-			case <-poller.done:
+			case <-ctx.Done():
 				ticker.Stop()
 				poller.OnDone()
 				return
@@ -45,14 +61,19 @@ func (poller *Poller) Start() {
 			}
 		}
 	}()
-
-	poller.running = true
 }
 
+// Stop signals the poller to stop. It is non-blocking and idempotent: cancelling
+// the context returns immediately even if OnInterval is currently executing (or
+// stuck), so callers such as the reconciler are never wedged by a slow handler.
 func (poller *Poller) Stop() {
-	if poller.IsPolling() {
-		poller.done <- true
+	poller.mu.Lock()
+	defer poller.mu.Unlock()
 
-		poller.running = false
+	if !poller.running {
+		return
 	}
+
+	poller.cancel()
+	poller.running = false
 }

--- a/pkg/cloud/conn/poller_test.go
+++ b/pkg/cloud/conn/poller_test.go
@@ -87,3 +87,22 @@ func Test_PollerStop_OnDeadlock(t *testing.T) {
 			"Both the poller and the handler goroutines leak and the reconciler stalls.")
 	}
 }
+
+func Test_PollerContext_CancelledOnStop(t *testing.T) {
+	poller := NewPoller(time.Millisecond * 10)
+	poller.Start()
+
+	ctx := poller.Context()
+	if ctx.Err() != nil {
+		t.Fatal("Context should be active while the poller is running")
+	}
+
+	poller.Stop()
+
+	select {
+	case <-ctx.Done():
+		// All OK: Stop() cancelled the context.
+	case <-time.After(time.Second * 2):
+		t.Fatal("Poller context was not cancelled after Stop()")
+	}
+}

--- a/pkg/cloud/conn/poller_test.go
+++ b/pkg/cloud/conn/poller_test.go
@@ -1,19 +1,25 @@
 package conn
 
 import (
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
 
-func Test_PollerStops(t *testing.T) {
-	var x int
+// The happy path test that checks that poller executes and
+// finishes cleanly when OnInterval callback behaves well.
+func Test_PollerStop(t *testing.T) {
+	var x atomic.Int32
+
+	ranOnce := make(chan struct{}) // a signal that poller can be stopped
 
 	poller := NewPoller(time.Millisecond * 100)
 	poller.OnInterval = func() {
-		// sleep for 200ms before changing the var so that each polling loop
-		// takes twice longer than the ticker itself
-		time.Sleep(time.Millisecond * 200)
-		x++
+		// run the handler a couple of times before stopping the poller
+		if x.Add(1) == 2 {
+			close(ranOnce)
+		}
 	}
 
 	pollerStopped := make(chan struct{})
@@ -21,9 +27,8 @@ func Test_PollerStops(t *testing.T) {
 	poller.Start()
 
 	go func() {
-		// If we stop after 300ms, then there should be ~ 2
-		// polling loops done in total.
-		time.Sleep(time.Millisecond * 300)
+		// blocks until OnInterval signals it's run for a bit
+		<-ranOnce
 		poller.Stop()
 		pollerStopped <- struct{}{}
 	}()
@@ -34,11 +39,51 @@ func Test_PollerStops(t *testing.T) {
 			t.Error("Poller is running even though pollerStopped was marked: something may be off with the test.")
 		}
 
-		if x == 0 {
+		if x.Load() == 0 {
 			t.Error("Poller stopped correctly, but var's value hasn't been increased")
 		}
 
 	case <-time.After(time.Second * 10):
-		t.Errorf("Poller failed to stop after 5 seconds. Poller status: %v", poller.IsPolling())
+		t.Errorf("Poller failed to stop after 10 seconds. Poller status: %v", poller.IsPolling())
+	}
+}
+
+// The un-happy path test which checks that the poller can successfully
+// stop even on a faulty handler in OnInterval callback. This prevents
+// the leaking of goroutines and stuck reconciler.
+func Test_PollerStop_OnDeadlock(t *testing.T) {
+	poller := NewPoller(time.Millisecond * 10)
+
+	var once sync.Once
+	startedHandler := make(chan struct{}) // a signal that the stuck handler has started executing
+	blockHandler := make(chan struct{})   // simulates a stuck handler
+	defer close(blockHandler)             // cleanup
+
+	poller.OnInterval = func() {
+		// Mimic `testRunsCh <- testRunId` blocking on a consumer that never reads.
+		once.Do(func() { close(startedHandler) })
+		<-blockHandler
+	}
+
+	poller.Start()
+
+	// We need to call poller.Stop() only after OnInterval() got into stuck state.
+	// To ensure that, blocking here until OnInterval() closes the channel and therefore,
+	// signals that it started executing.
+	<-startedHandler
+
+	stopReturned := make(chan struct{})
+	go func() {
+		// try to stop the poller
+		poller.Stop()
+		close(stopReturned)
+	}()
+
+	select {
+	case <-stopReturned:
+		// All OK: Stop() managed to complete despite OnInterval() call hanging.
+	case <-time.After(time.Second * 2):
+		t.Fatal("Poller failed to stop because OnInterval callback is blocked. " +
+			"Both the poller and the handler goroutines leak and the reconciler stalls.")
 	}
 }

--- a/pkg/cloud/test_runs.go
+++ b/pkg/cloud/test_runs.go
@@ -60,8 +60,13 @@ func NewTestRunPoller(host, token, plzName string, logger logr.Logger) *TestRunP
 		} else {
 			logger.Info(fmt.Sprintf("Retrieved test runs: %+v", list))
 
+			ctx := testRunPoller.Context()
 			for _, testRunId := range list {
-				testRunsCh <- testRunId
+				select {
+				case testRunsCh <- testRunId:
+				case <-ctx.Done():
+					return
+				}
 			}
 		}
 	}

--- a/pkg/plz/worker.go
+++ b/pkg/plz/worker.go
@@ -71,13 +71,14 @@ func (w *PLZWorker) Deregister(ctx context.Context) {
 func (w *PLZWorker) StartFactory() {
 	if w.poller != nil && !w.poller.IsPolling() {
 		w.poller.Start()
+		ctx := w.poller.Context()
 		go func() {
 			w.logger.Info("Started factory for PLZ test runs.")
 
+			// poller closes the channel and cancels context on Stop()
 			for testRunId := range w.poller.GetTestRuns() {
-				w.handle(testRunId)
+				w.handle(ctx, testRunId)
 			}
-			// TODO: a potential leak
 		}()
 		w.logger.Info("Started polling k6 Cloud for new test runs.")
 	}
@@ -191,9 +192,9 @@ func (w *PLZWorker) complete(tr *v1alpha1.TestRun, trData *cloud.TestRunData) {
 	tr.Spec.TestRunID = trData.TestRunID()
 }
 
-// handle creates a new PLZ TestRun from the given test run id
-// TODO: pass proper context!
-func (w *PLZWorker) handle(testRunId string) {
+// handle creates a new PLZ TestRun from the given test run id. The context is
+// cancelled when the poller stops, so in-flight k8s calls abort on shutdown.
+func (w *PLZWorker) handle(ctx context.Context, testRunId string) {
 	tr := w.template.Create()
 
 	// First check if such a test already exists
@@ -202,7 +203,7 @@ func (w *PLZWorker) handle(testRunId string) {
 		Namespace: tr.Namespace,
 	}
 
-	if err := w.k8sClient.Get(context.Background(), namespacedName, tr); err == nil || !errors.IsNotFound(err) {
+	if err := w.k8sClient.Get(ctx, namespacedName, tr); err == nil || !errors.IsNotFound(err) {
 		w.logger.Info(fmt.Sprintf("Test run `%s` has already been started.", testRunId))
 		return
 	}
@@ -223,7 +224,7 @@ func (w *PLZWorker) handle(testRunId string) {
 		w.logger.Error(err, "Failed to set controller reference for the PLZ test run", "testRunId", testRunId)
 	}
 
-	if err := w.k8sClient.Create(context.Background(), tr); err != nil {
+	if err := w.k8sClient.Create(ctx, tr); err != nil {
 		w.logger.Error(err, "Failed to create PLZ test run", "testRunId", testRunId)
 	}
 


### PR DESCRIPTION
A few hardening fixes here:
- fixing missing / drifted away HTTP `body.Close()` calls;
- hardening the PLZ poller against misbehaving handler calls: that solves a potential data race; 
    - e.g. issues on GCk6 or k8s can delay healthy processing of the test run: that shouldn't hang the poller or finalization
- introducing centralized context in the PLZ poller and using that to cancel all the calls in the handler properly.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PLZ shutdown and in-flight TestRun creation behavior during deregistration; incorrect cancellation could skip or abort k8s work, though scope is limited to the poller/PLZ path.
> 
> **Overview**
> **HTTP cleanup:** k6 runner readiness checks now **`defer resp.Body.Close()`** immediately after a successful `http.Get` in **`isServiceReady`** and **`isJobRunning`**, including moving the close in the stopped-jobs path so the body is always released even when status or JSON parsing fails.
> 
> **PLZ poller concurrency:** **`conn.Poller`** no longer stops via a blocking **`done` channel send**. It uses a **mutex**, **pointer receivers**, a **`context.Context`** created on **`Start`**, and **`Stop`** that **cancels the context** and returns immediately (idempotent, safe if **`OnInterval`** is stuck). Callers can use **`Context()`** to abort downstream work when the poller stops.
> 
> **Downstream wiring:** The cloud **test run poller** sends IDs to its channel with a **select** against **`ctx.Done()`** so shutdown does not block on a full or slow consumer. **`PLZWorker.handle`** takes that context for **`Get`/`Create`** on TestRun CRs instead of **`context.Background`**, and tests cover normal stop, stop while the interval handler deadlocks, and context cancellation on stop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48ddd3d5915f60e92a3088381f7159ae5652e72e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->