### PR TITLE
Remove drift between jobs around `terminationGracePeriodSeconds`

### DIFF
--- a/pkg/resources/jobs/runner.go
+++ b/pkg/resources/jobs/runner.go
@@ -80,7 +80,6 @@ func NewRunnerJob(k6 *v1alpha1.TestRun, index int, tokenInfo *cloud.TokenInfo) (
 	command = script.UpdateCommand(command)
 
 	var (
-		zero          int64 = 0
 		zero32        int32 = 0
 		schedulerName       = corev1.DefaultSchedulerName
 	)
@@ -206,9 +205,8 @@ func NewRunnerJob(k6 *v1alpha1.TestRun, index int, tokenInfo *cloud.TokenInfo) (
 						ReadinessProbe:  generateProbe(k6.GetSpec().Runner.ReadinessProbe),
 						SecurityContext: &k6.GetSpec().Runner.ContainerSecurityContext,
 					}},
-					TerminationGracePeriodSeconds: &zero,
-					Volumes:                       volumes,
-					PriorityClassName:             k6.GetSpec().Runner.PriorityClassName,
+					Volumes:           volumes,
+					PriorityClassName: k6.GetSpec().Runner.PriorityClassName,
 				},
 			},
 		},

--- a/pkg/resources/jobs/runner_test.go
+++ b/pkg/resources/jobs/runner_test.go
@@ -81,7 +81,6 @@ func defaultTestRun() *v1alpha1.TestRun {
 }
 
 func defaultExpectedJob(script *types.Script) *batchv1.Job {
-	var zero int64 = 0
 	automountServiceAccountToken := true
 
 	jobLabels := defaultLabels()
@@ -143,8 +142,7 @@ func defaultExpectedJob(script *types.Script) *batchv1.Job {
 						},
 						SecurityContext: &corev1.SecurityContext{},
 					}},
-					TerminationGracePeriodSeconds: &zero,
-					Volumes:                       script.Volume(),
+					Volumes: script.Volume(),
 				},
 			},
 		},


### PR DESCRIPTION
Issue: https://github.com/grafana/k6-operator/issues/604

Default value for `terminationGracePeriodSeconds` in Kubernetes in 30s.