### PR TITLE
fix(helm): trim generated resource names to 63 chars

### DIFF
--- a/charts/k6-operator/templates/_helpers.tpl
+++ b/charts/k6-operator/templates/_helpers.tpl
@@ -7,37 +7,31 @@ Expand the name of the chart.
 
 
 {{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+Create a default fully qualified app name, optionally appending a suffix.
+The whole name is kept within the Kubernetes 63-char name limit (DNS naming
+spec): the fullname part (not the suffix) is truncated, so the suffix is
+always preserved. This keeps names that share a fullname but differ only by
+suffix (e.g. the various Roles/RoleBindings) unique.
 If release name contains chart name it will be used as a full name.
+Usage: {{ include "k6-operator.fullname" (dict "context" $ "suffix" "-controller-manager") }}
+       {{ include "k6-operator.fullname" (dict "context" $) }}
 */}}
 {{- define "k6-operator.fullname" -}}
-{{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
-{{- end }}
-{{- end }}
-
-{{/*
-Create a resource name by appending a suffix to the fullname, keeping the whole
-name within the Kubernetes 63-char name limit (DNS naming spec).
-The fullname is already truncated to 63 chars, but appending a suffix can push
-the resulting name over the limit. The fullname part (not the suffix) is
-truncated so the suffix is always preserved; this keeps names that share a
-fullname but differ only by suffix (e.g. the various Roles/RoleBindings) unique.
-Usage: {{ include "k6-operator.fullnameWithSuffix" (dict "context" $ "suffix" "-controller-manager") }}
-*/}}
-{{- define "k6-operator.fullnameWithSuffix" -}}
-{{- $suffix := .suffix -}}
-{{- $base := include "k6-operator.fullname" .context | trunc (int (sub 63 (len $suffix))) | trimSuffix "-" -}}
-{{- printf "%s%s" $base $suffix }}
-{{- end }}
+{{- $ctx := .context -}}
+{{- $suffix := .suffix | default "" -}}
+{{- $base := "" -}}
+{{- if $ctx.Values.fullnameOverride -}}
+{{- $base = $ctx.Values.fullnameOverride -}}
+{{- else -}}
+{{- $name := default $ctx.Chart.Name $ctx.Values.nameOverride -}}
+{{- if contains $name $ctx.Release.Name -}}
+{{- $base = $ctx.Release.Name -}}
+{{- else -}}
+{{- $base = printf "%s-%s" $ctx.Release.Name $name -}}
+{{- end -}}
+{{- end -}}
+{{- printf "%s%s" ($base | trunc (int (sub 63 (len $suffix))) | trimSuffix "-") $suffix -}}
+{{- end -}}
 
 {{/*
 Create chart name and version as used by the chart label.
@@ -72,7 +66,7 @@ Create the name of the service account to use
 */}}
 {{- define "k6-operator.serviceAccountName" -}}
 {{- if .Values.manager.serviceAccount.create }}
-{{- default (include "k6-operator.fullname" .) .Values.manager.serviceAccount.name }}
+{{- default (include "k6-operator.fullname" (dict "context" .)) .Values.manager.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.manager.serviceAccount.name }}
 {{- end }}

--- a/charts/k6-operator/templates/_helpers.tpl
+++ b/charts/k6-operator/templates/_helpers.tpl
@@ -25,6 +25,21 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{/*
+Create a resource name by appending a suffix to the fullname, keeping the whole
+name within the Kubernetes 63-char name limit (DNS naming spec).
+The fullname is already truncated to 63 chars, but appending a suffix can push
+the resulting name over the limit. The fullname part (not the suffix) is
+truncated so the suffix is always preserved; this keeps names that share a
+fullname but differ only by suffix (e.g. the various Roles/RoleBindings) unique.
+Usage: {{ include "k6-operator.fullnameWithSuffix" (dict "context" $ "suffix" "-controller-manager") }}
+*/}}
+{{- define "k6-operator.fullnameWithSuffix" -}}
+{{- $suffix := .suffix -}}
+{{- $base := include "k6-operator.fullname" .context | trunc (int (sub 63 (len $suffix))) | trimSuffix "-" -}}
+{{- printf "%s%s" $base $suffix }}
+{{- end }}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "k6-operator.chart" -}}

--- a/charts/k6-operator/templates/deployment.yaml
+++ b/charts/k6-operator/templates/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "k6-operator.fullnameWithSuffix" (dict "context" $ "suffix" "-controller-manager") }}
+  name: {{ include "k6-operator.fullname" (dict "context" $ "suffix" "-controller-manager") }}
   namespace: {{- include "k6-operator.namespace" . }}
   labels:
     control-plane: "controller-manager"

--- a/charts/k6-operator/templates/deployment.yaml
+++ b/charts/k6-operator/templates/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "k6-operator.fullname" . }}-controller-manager
+  name: {{ include "k6-operator.fullnameWithSuffix" (dict "context" $ "suffix" "-controller-manager") }}
   namespace: {{- include "k6-operator.namespace" . }}
   labels:
     control-plane: "controller-manager"

--- a/charts/k6-operator/templates/leaderRole.yaml
+++ b/charts/k6-operator/templates/leaderRole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ include "k6-operator.fullname" . }}-leader-election-role
+  name: {{ include "k6-operator.fullnameWithSuffix" (dict "context" $ "suffix" "-leader-election-role") }}
   namespace: {{- include "k6-operator.namespace" . }}
   labels:
     app.kubernetes.io/component: controller

--- a/charts/k6-operator/templates/leaderRole.yaml
+++ b/charts/k6-operator/templates/leaderRole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ include "k6-operator.fullnameWithSuffix" (dict "context" $ "suffix" "-leader-election-role") }}
+  name: {{ include "k6-operator.fullname" (dict "context" $ "suffix" "-leader-election-role") }}
   namespace: {{- include "k6-operator.namespace" . }}
   labels:
     app.kubernetes.io/component: controller

--- a/charts/k6-operator/templates/leaderRoleBinding.yaml
+++ b/charts/k6-operator/templates/leaderRoleBinding.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "k6-operator.fullnameWithSuffix" (dict "context" $ "suffix" "-leader-election-rolebinding") }}
+  name: {{ include "k6-operator.fullname" (dict "context" $ "suffix" "-leader-election-rolebinding") }}
   namespace: {{- include "k6-operator.namespace" . }}
   labels:
     app.kubernetes.io/component: controller
@@ -12,7 +12,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ include "k6-operator.fullnameWithSuffix" (dict "context" $ "suffix" "-leader-election-role") }}
+  name: {{ include "k6-operator.fullname" (dict "context" $ "suffix" "-leader-election-role") }}
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.manager.serviceAccount.name }}

--- a/charts/k6-operator/templates/leaderRoleBinding.yaml
+++ b/charts/k6-operator/templates/leaderRoleBinding.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "k6-operator.fullname" . }}-leader-election-rolebinding
+  name: {{ include "k6-operator.fullnameWithSuffix" (dict "context" $ "suffix" "-leader-election-rolebinding") }}
   namespace: {{- include "k6-operator.namespace" . }}
   labels:
     app.kubernetes.io/component: controller
@@ -12,7 +12,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ include "k6-operator.fullname" . }}-leader-election-role
+  name: {{ include "k6-operator.fullnameWithSuffix" (dict "context" $ "suffix" "-leader-election-role") }}
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.manager.serviceAccount.name }}

--- a/charts/k6-operator/templates/namespace.yaml
+++ b/charts/k6-operator/templates/namespace.yaml
@@ -4,7 +4,7 @@ kind: Namespace
 metadata:
   name: {{- include "k6-operator.namespace" . }}
   labels:
-    app.kubernetes.io/name: {{ include "k6-operator.fullname" . }}
+    app.kubernetes.io/name: {{ include "k6-operator.fullname" (dict "context" .) }}
     control-plane: "controller-manager"
     {{- with .Values.customLabels }}
       {{- toYaml . | nindent 4 }}

--- a/charts/k6-operator/templates/role.yaml
+++ b/charts/k6-operator/templates/role.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 kind: Role
 {{- end }}
 metadata:
-  name: {{ include "k6-operator.fullnameWithSuffix" (dict "context" $ "suffix" "-manager-role") }}
+  name: {{ include "k6-operator.fullname" (dict "context" $ "suffix" "-manager-role") }}
   {{- if .Values.rbac.namespaced }}
   namespace: {{- include "k6-operator.namespace" . }}
   {{- end }}
@@ -163,7 +163,7 @@ kind: ClusterRole
 kind: Role
 {{- end }}
 metadata:
-  name: {{ include "k6-operator.fullnameWithSuffix" (dict "context" $ "suffix" "-metrics-auth-role") }}
+  name: {{ include "k6-operator.fullname" (dict "context" $ "suffix" "-metrics-auth-role") }}
   {{- if .Values.rbac.namespaced }}
   namespace: {{- include "k6-operator.namespace" . }}
   {{- end }}
@@ -190,7 +190,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "k6-operator.fullnameWithSuffix" (dict "context" $ "suffix" "-metrics-reader") }}
+  name: {{ include "k6-operator.fullname" (dict "context" $ "suffix" "-metrics-reader") }}
   labels:
     {{- include "k6-operator.labels" . | nindent 4 }}
     {{- include "k6-operator.customLabels" . | default "" | nindent 4 }}

--- a/charts/k6-operator/templates/role.yaml
+++ b/charts/k6-operator/templates/role.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 kind: Role
 {{- end }}
 metadata:
-  name: {{ include "k6-operator.fullname" . }}-manager-role
+  name: {{ include "k6-operator.fullnameWithSuffix" (dict "context" $ "suffix" "-manager-role") }}
   {{- if .Values.rbac.namespaced }}
   namespace: {{- include "k6-operator.namespace" . }}
   {{- end }}
@@ -163,7 +163,7 @@ kind: ClusterRole
 kind: Role
 {{- end }}
 metadata:
-  name: {{ include "k6-operator.fullname" . }}-metrics-auth-role
+  name: {{ include "k6-operator.fullnameWithSuffix" (dict "context" $ "suffix" "-metrics-auth-role") }}
   {{- if .Values.rbac.namespaced }}
   namespace: {{- include "k6-operator.namespace" . }}
   {{- end }}
@@ -190,7 +190,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "k6-operator.fullname" . }}-metrics-reader
+  name: {{ include "k6-operator.fullnameWithSuffix" (dict "context" $ "suffix" "-metrics-reader") }}
   labels:
     {{- include "k6-operator.labels" . | nindent 4 }}
     {{- include "k6-operator.customLabels" . | default "" | nindent 4 }}

--- a/charts/k6-operator/templates/roleBinding.yaml
+++ b/charts/k6-operator/templates/roleBinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 kind: RoleBinding
 {{- end }}
 metadata:
-  name: {{ include "k6-operator.fullname" . }}-manager-rolebinding
+  name: {{ include "k6-operator.fullnameWithSuffix" (dict "context" $ "suffix" "-manager-rolebinding") }}
   {{- if .Values.rbac.namespaced }}
   namespace: {{- include "k6-operator.namespace" . }}
   {{- end }}
@@ -22,7 +22,7 @@ roleRef:
   {{- else }}
   kind: Role
   {{- end }}
-  name: {{ include "k6-operator.fullname" . }}-manager-role
+  name: {{ include "k6-operator.fullnameWithSuffix" (dict "context" $ "suffix" "-manager-role") }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "k6-operator.serviceAccountName" . }}
@@ -35,7 +35,7 @@ kind: ClusterRoleBinding
 kind: RoleBinding
 {{- end }}
 metadata:
-  name: {{ include "k6-operator.fullname" . }}-metrics-auth-rolebinding
+  name: {{ include "k6-operator.fullnameWithSuffix" (dict "context" $ "suffix" "-metrics-auth-rolebinding") }}
   {{- if .Values.rbac.namespaced }}
   namespace: {{- include "k6-operator.namespace" . }}
   {{- end }}
@@ -50,7 +50,7 @@ roleRef:
   {{- else }}
   kind: Role
   {{- end }}
-  name: {{ include "k6-operator.fullname" . }}-metrics-auth-role
+  name: {{ include "k6-operator.fullnameWithSuffix" (dict "context" $ "suffix" "-metrics-auth-role") }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "k6-operator.serviceAccountName" . }}

--- a/charts/k6-operator/templates/roleBinding.yaml
+++ b/charts/k6-operator/templates/roleBinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 kind: RoleBinding
 {{- end }}
 metadata:
-  name: {{ include "k6-operator.fullnameWithSuffix" (dict "context" $ "suffix" "-manager-rolebinding") }}
+  name: {{ include "k6-operator.fullname" (dict "context" $ "suffix" "-manager-rolebinding") }}
   {{- if .Values.rbac.namespaced }}
   namespace: {{- include "k6-operator.namespace" . }}
   {{- end }}
@@ -22,7 +22,7 @@ roleRef:
   {{- else }}
   kind: Role
   {{- end }}
-  name: {{ include "k6-operator.fullnameWithSuffix" (dict "context" $ "suffix" "-manager-role") }}
+  name: {{ include "k6-operator.fullname" (dict "context" $ "suffix" "-manager-role") }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "k6-operator.serviceAccountName" . }}
@@ -35,7 +35,7 @@ kind: ClusterRoleBinding
 kind: RoleBinding
 {{- end }}
 metadata:
-  name: {{ include "k6-operator.fullnameWithSuffix" (dict "context" $ "suffix" "-metrics-auth-rolebinding") }}
+  name: {{ include "k6-operator.fullname" (dict "context" $ "suffix" "-metrics-auth-rolebinding") }}
   {{- if .Values.rbac.namespaced }}
   namespace: {{- include "k6-operator.namespace" . }}
   {{- end }}
@@ -50,7 +50,7 @@ roleRef:
   {{- else }}
   kind: Role
   {{- end }}
-  name: {{ include "k6-operator.fullnameWithSuffix" (dict "context" $ "suffix" "-metrics-auth-role") }}
+  name: {{ include "k6-operator.fullname" (dict "context" $ "suffix" "-metrics-auth-role") }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "k6-operator.serviceAccountName" . }}

--- a/charts/k6-operator/templates/service.yaml
+++ b/charts/k6-operator/templates/service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "k6-operator.fullname" . }}-controller-manager-metrics-service
+  name: {{ include "k6-operator.fullnameWithSuffix" (dict "context" $ "suffix" "-controller-manager-metrics-service") }}
   namespace: {{- include "k6-operator.namespace" . }}
   labels:
     control-plane: "controller-manager"

--- a/charts/k6-operator/templates/service.yaml
+++ b/charts/k6-operator/templates/service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "k6-operator.fullnameWithSuffix" (dict "context" $ "suffix" "-controller-manager-metrics-service") }}
+  name: {{ include "k6-operator.fullname" (dict "context" $ "suffix" "-controller-manager-metrics-service") }}
   namespace: {{- include "k6-operator.namespace" . }}
   labels:
     control-plane: "controller-manager"


### PR DESCRIPTION
Fixes #660

## Problem

The `k6-operator.fullname` helper is already truncated to 63 chars, but the templates append a suffix to it (e.g. `-controller-manager-metrics-service`, 35 chars). When the release/fullname is long enough, the final resource name exceeds the Kubernetes 63-char name limit and `helm install` fails:

```
Invalid value: "synthetics-dev-usw2-01-k6-operator-controller-manager-metrics-service": must be no more than 63 characters
```

Today the only workaround is setting a very short `fullnameOverride`. As noted in the issue, the chart should handle this automatically.

## Change

- Rework `k6-operator.fullname` to take an optional `suffix` via a dict argument: `include "k6-operator.fullname" (dict "context" $ "suffix" "-manager-role")`.
- The fullname part (not the suffix) is truncated to `63 - len(suffix)`, so the whole name always fits in 63 chars while the suffix is always preserved. Keeping the suffix is what distinguishes the otherwise identical Role/RoleBinding names, so truncating it away would collapse several RBAC objects onto one name.
- Use the helper for every resource name that builds on the fullname: service, deployment, the roles/cluster-roles and their (cluster-)role-bindings, and the leader-election role/binding. Role / RoleBinding pairs use the same helper + the same suffix, so their `roleRef` names stay consistent with the role definitions even when truncation kicks in.
- Per review feedback, this is a single helper (no separate `fullnameWithSuffix`); the non-suffix call sites (`serviceAccountName`, namespace label) use the same dict form without a suffix.

## Verification

Rendered the chart with the reproducing values from the issue (`fullnameOverride=synthetics-dev-usw2-012345678`, `service.enabled=true`):

- Previously-overflowing service name (65 chars) is now exactly 63 chars with the suffix intact; **all** generated names are ≤ 63.
- Every `roleRef` name still matches a defined role name (verified under a stress release name long enough to force role-name truncation too).
- `helm template` with the default release name produces an **identical** manifest to `main` (no regression for existing installs).
- `helm lint` passes.

No chart version bump (left to maintainers), and `values.yaml` is unchanged so no docs/schema regeneration is needed.

## Note for release notes

When the release name (or `fullnameOverride`) is long enough that truncation applies, the rendered resource names change on upgrade (e.g. the Deployment is recreated under the new, truncated name). Default release names are unaffected. Users who reference these resource names in monitoring/alerting should update them.
