### PR TITLE
Get rid off shared cloud client in TestRun logic

### DIFF
--- a/internal/controller/k6_create.go
+++ b/internal/controller/k6_create.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/k6-operator/api/v1alpha1"
 	"github.com/grafana/k6-operator/pkg/cloud"
 	"github.com/grafana/k6-operator/pkg/resources/jobs"
+	"go.k6.io/k6/v2/cloudapi"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -17,7 +18,7 @@ import (
 )
 
 // CreateJobs creates jobs that will spawn k6 pods for distributed test
-func CreateJobs(ctx context.Context, log logr.Logger, k6 *v1alpha1.TestRun, r *TestRunReconciler) (ctrl.Result, error) {
+func CreateJobs(ctx context.Context, log logr.Logger, k6 *v1alpha1.TestRun, r *TestRunReconciler, cloudClient *cloudapi.Client) (ctrl.Result, error) {
 	// needed for cloud tests
 	tokenInfo := cloud.NewTokenInfo(k6.GetSpec().Token, k6.NamespacedName().Namespace)
 
@@ -43,7 +44,7 @@ func CreateJobs(ctx context.Context, log logr.Logger, k6 *v1alpha1.TestRun, r *T
 			events := cloud.ErrorEvent(cloud.K6OperatorStartError).
 				WithDetail(fmt.Sprintf("Failed to create runner jobs: %v", err)).
 				WithAbort()
-			cloud.SendTestRunEvents(r.k6CloudClient, k6.TestRunID(), log, events)
+			cloud.SendTestRunEvents(cloudClient, k6.TestRunID(), log, events)
 		}
 
 		return res, err

--- a/internal/controller/k6_finish.go
+++ b/internal/controller/k6_finish.go
@@ -7,13 +7,14 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/grafana/k6-operator/api/v1alpha1"
 	"github.com/grafana/k6-operator/pkg/cloud"
+	"go.k6.io/k6/v2/cloudapi"
 	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // FinishJobs checks if the runners pods have finished execution.
-func FinishJobs(ctx context.Context, log logr.Logger, k6 *v1alpha1.TestRun, r *TestRunReconciler) (allFinished bool) {
+func FinishJobs(ctx context.Context, log logr.Logger, k6 *v1alpha1.TestRun, r *TestRunReconciler, cloudClient *cloudapi.Client) (allFinished bool) {
 	if len(k6.GetStatus().TestRunID) > 0 {
 		log = log.WithValues("testRunId", k6.GetStatus().TestRunID)
 	}
@@ -57,7 +58,7 @@ func FinishJobs(ctx context.Context, log logr.Logger, k6 *v1alpha1.TestRun, r *T
 		events := cloud.ErrorEvent(cloud.K6OperatorRunnerError).
 			WithDetail(msg).
 			WithAbort()
-		cloud.SendTestRunEvents(r.k6CloudClient, k6.TestRunID(), log, events)
+		cloud.SendTestRunEvents(cloudClient, k6.TestRunID(), log, events)
 	}
 
 	if finished < k6.GetSpec().Parallelism {

--- a/internal/controller/k6_initialize.go
+++ b/internal/controller/k6_initialize.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/grafana/k6-operator/pkg/types"
+	"go.k6.io/k6/v2/cloudapi"
 
 	"github.com/go-logr/logr"
 	"github.com/grafana/k6-operator/api/v1alpha1"
@@ -45,7 +46,7 @@ func InitializeJobs(ctx context.Context, log logr.Logger, k6 *v1alpha1.TestRun, 
 	return res, nil
 }
 
-func RunValidations(ctx context.Context, log logr.Logger, k6 *v1alpha1.TestRun, r *TestRunReconciler) (
+func RunValidations(ctx context.Context, log logr.Logger, k6 *v1alpha1.TestRun, r *TestRunReconciler, cloudClient *cloudapi.Client) (
 	res ctrl.Result, ready bool, err error,
 ) {
 	// initializer is a quick job so check in frequently
@@ -63,7 +64,7 @@ func RunValidations(ctx context.Context, log logr.Logger, k6 *v1alpha1.TestRun, 
 			events := cloud.ErrorEvent(cloud.K6OperatorStartError).
 				WithDetail(fmt.Sprintf("Failed to inspect the test script: %v", err)).
 				WithAbort()
-			cloud.SendTestRunEvents(r.k6CloudClient, k6.TestRunID(), log, events)
+			cloud.SendTestRunEvents(cloudClient, k6.TestRunID(), log, events)
 		} else {
 			// if there is any error, we have to reflect it on the TestRun manifest
 			k6.GetStatus().Stage = "error"
@@ -126,7 +127,7 @@ func RunValidations(ctx context.Context, log logr.Logger, k6 *v1alpha1.TestRun, 
 
 // SetupCloudTest inspects the output of initializer and creates a new
 // test run. It is meant to be used only in cloud output mode.
-func SetupCloudTest(ctx context.Context, log logr.Logger, k6 *v1alpha1.TestRun, r *TestRunReconciler) (res ctrl.Result, err error) {
+func SetupCloudTest(ctx context.Context, log logr.Logger, k6 *v1alpha1.TestRun, r *TestRunReconciler, cloudClient *cloudapi.Client) (res ctrl.Result, err error) {
 	res = ctrl.Result{RequeueAfter: time.Second * 5}
 
 	inspectOutput, inspectReady, err := inspectTestRun(ctx, log, k6, r.Client)
@@ -138,20 +139,6 @@ func SetupCloudTest(ctx context.Context, log logr.Logger, k6 *v1alpha1.TestRun, 
 	if !inspectReady {
 		return res, nil
 	}
-
-	tokenInfo := cloud.NewTokenInfo(k6.GetSpec().Token, k6.NamespacedName().Namespace)
-	err = tokenInfo.Load(ctx, log, r.Client)
-	if err != nil {
-		// An error here means a very likely mis-configuration of the token.
-		// Consider updating status to error to let a user know quicker?
-		log.Error(err, "A problem while getting token.")
-		return ctrl.Result{}, nil
-	}
-	if !tokenInfo.Ready {
-		return res, nil
-	}
-
-	host := getEnvVar(k6.GetSpec().Runner.Env, "K6_CLOUD_HOST")
 
 	if v1alpha1.IsFalse(k6, v1alpha1.CloudTestRunCreated) {
 
@@ -169,7 +156,7 @@ func SetupCloudTest(ctx context.Context, log logr.Logger, k6 *v1alpha1.TestRun, 
 			inspectOutput.SetTestName(script.Filename)
 		}
 
-		if testRunData, err := cloud.CreateTestRun(inspectOutput, k6.GetSpec().Parallelism, host, tokenInfo.Value(), log); err != nil {
+		if testRunData, err := cloud.CreateTestRun(inspectOutput, k6.GetSpec().Parallelism, cloudClient, log); err != nil {
 			log.Error(err, "Failed to create a new cloud test run.")
 			return res, nil
 		} else {

--- a/internal/controller/k6_start.go
+++ b/internal/controller/k6_start.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/k6-operator/api/v1alpha1"
 	"github.com/grafana/k6-operator/pkg/cloud"
 	"github.com/grafana/k6-operator/pkg/resources/jobs"
+	"go.k6.io/k6/v2/cloudapi"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -29,7 +30,7 @@ func isServiceReady(log logr.Logger, service *v1.Service) bool {
 }
 
 // StartJobs in the Ready phase using a curl container
-func StartJobs(ctx context.Context, log logr.Logger, k6 *v1alpha1.TestRun, r *TestRunReconciler) (res ctrl.Result, err error) {
+func StartJobs(ctx context.Context, log logr.Logger, k6 *v1alpha1.TestRun, r *TestRunReconciler, cloudClient *cloudapi.Client) (res ctrl.Result, err error) {
 	// It may take some time to get Services up, so check in frequently
 	res = ctrl.Result{RequeueAfter: time.Second}
 
@@ -71,7 +72,7 @@ func StartJobs(ctx context.Context, log logr.Logger, k6 *v1alpha1.TestRun, r *Te
 					events := cloud.ErrorEvent(cloud.K6OperatorStartError).
 						WithDetail(msg).
 						WithAbort()
-					cloud.SendTestRunEvents(r.k6CloudClient, k6.TestRunID(), log, events)
+					cloud.SendTestRunEvents(cloudClient, k6.TestRunID(), log, events)
 				}
 			}
 		}
@@ -103,7 +104,7 @@ func StartJobs(ctx context.Context, log logr.Logger, k6 *v1alpha1.TestRun, r *Te
 			events := cloud.ErrorEvent(cloud.SetupError).
 				WithDetail(fmt.Sprintf("setup function failed: %v", err)).
 				WithAbort()
-			cloud.SendTestRunEvents(r.k6CloudClient, k6.TestRunID(), log, events)
+			cloud.SendTestRunEvents(cloudClient, k6.TestRunID(), log, events)
 
 			return ctrl.Result{Requeue: false}, nil
 		}

--- a/internal/controller/testrun_controller.go
+++ b/internal/controller/testrun_controller.go
@@ -52,10 +52,6 @@ type TestRunReconciler struct {
 	Log      logr.Logger
 	Scheme   *runtime.Scheme
 	Recorder record.EventRecorder
-
-	// Note: here we assume that all users of the operator are allowed to use
-	// the same token / cloud client.
-	k6CloudClient *cloudapi.Client
 }
 
 // Reconcile takes a K6 object and takes the appropriate action in the cluster
@@ -99,10 +95,14 @@ func isCloudTestRun(k6 *v1alpha1.TestRun) bool {
 }
 
 func (r *TestRunReconciler) reconcile(ctx context.Context, req ctrl.Request, log logr.Logger, k6 *v1alpha1.TestRun) (ctrl.Result, error) {
-	var err error
+	var (
+		err         error
+		cloudClient *cloudapi.Client
+	)
 	if isCloudTestRun(k6) {
 		// bootstrap the client
-		found, err := r.createClient(ctx, k6, log)
+		var found bool
+		cloudClient, found, err = r.createClient(ctx, k6, log)
 		if err != nil {
 			log.Error(err, "A problem while getting token.")
 			return ctrl.Result{}, err
@@ -120,7 +120,7 @@ func (r *TestRunReconciler) reconcile(ctx context.Context, req ctrl.Request, log
 
 	if isCloudTestRun(k6) && v1alpha1.IsFalse(k6, v1alpha1.CloudTestRunAborted) {
 		// check in with the BE for status
-		if r.ShouldAbort(ctx, k6, log) {
+		if r.ShouldAbort(ctx, k6, cloudClient, log) {
 			log.Info("Received an abort signal from the k6 Cloud: stopping the test.")
 			return StopJobs(ctx, log, k6, r)
 		}
@@ -176,7 +176,7 @@ func (r *TestRunReconciler) reconcile(ctx context.Context, req ctrl.Request, log
 		return ctrl.Result{}, nil
 
 	case "initialization":
-		res, ready, err := RunValidations(ctx, log, k6, r)
+		res, ready, err := RunValidations(ctx, log, k6, r, cloudClient)
 		if err != nil || !ready {
 			if t, ok := v1alpha1.LastUpdate(k6, v1alpha1.TestRunRunning); !ok {
 				// this should never happen
@@ -191,7 +191,7 @@ func (r *TestRunReconciler) reconcile(ctx context.Context, req ctrl.Request, log
 						events := cloud.ErrorEvent(cloud.K6OperatorStartError).
 							WithDetail(msg).
 							WithAbort()
-						cloud.SendTestRunEvents(r.k6CloudClient, k6.TestRunID(), log, events)
+						cloud.SendTestRunEvents(cloudClient, k6.TestRunID(), log, events)
 					}
 				}
 			}
@@ -216,7 +216,7 @@ func (r *TestRunReconciler) reconcile(ctx context.Context, req ctrl.Request, log
 		if v1alpha1.IsTrue(k6, v1alpha1.CloudTestRun) {
 
 			if v1alpha1.IsFalse(k6, v1alpha1.CloudTestRunCreated) {
-				return SetupCloudTest(ctx, log, k6, r)
+				return SetupCloudTest(ctx, log, k6, r, cloudClient)
 
 			} else {
 				// if test run was created, then only changing status is left
@@ -233,10 +233,10 @@ func (r *TestRunReconciler) reconcile(ctx context.Context, req ctrl.Request, log
 		return ctrl.Result{}, nil
 
 	case "initialized":
-		return CreateJobs(ctx, log, k6, r)
+		return CreateJobs(ctx, log, k6, r, cloudClient)
 
 	case "created":
-		return StartJobs(ctx, log, k6, r)
+		return StartJobs(ctx, log, k6, r, cloudClient)
 
 	case "started":
 		if v1alpha1.IsTrue(k6, v1alpha1.CloudTestRun) && v1alpha1.IsTrue(k6, v1alpha1.CloudTestRunFinalized) {
@@ -277,13 +277,13 @@ func (r *TestRunReconciler) reconcile(ctx context.Context, req ctrl.Request, log
 					return ctrl.Result{RequeueAfter: time.Second * 15}, nil
 				}
 			}
-		} else if !FinishJobs(ctx, log, k6, r) {
+		} else if !FinishJobs(ctx, log, k6, r, cloudClient) {
 			// wait for the test to finish
 
 			// TODO: confirm if this check is needed given the check in the beginning of reconcile
 			if v1alpha1.IsTrue(k6, v1alpha1.CloudTestRun) && v1alpha1.IsFalse(k6, v1alpha1.CloudTestRunAborted) {
 				// check in with the BE for status
-				if r.ShouldAbort(ctx, k6, log) {
+				if r.ShouldAbort(ctx, k6, cloudClient, log) {
 					log.Info("Received an abort signal from the k6 Cloud: stopping the test.")
 					return StopJobs(ctx, log, k6, r)
 				}
@@ -346,7 +346,7 @@ func (r *TestRunReconciler) reconcile(ctx context.Context, req ctrl.Request, log
 				return ctrl.Result{RequeueAfter: time.Second * 2}, nil
 			}
 
-			if err = cloud.FinishTestRun(r.k6CloudClient, k6.GetStatus().TestRunID); err != nil {
+			if err = cloud.FinishTestRun(cloudClient, k6.GetStatus().TestRunID); err != nil {
 				log.Error(err, "Failed to finalize the test run with cloud output")
 				return ctrl.Result{}, nil
 			} else {
@@ -455,14 +455,14 @@ func (r *TestRunReconciler) UpdateStatus(ctx context.Context, k6 *v1alpha1.TestR
 
 // ShouldAbort retrieves the status of test run from the Cloud and whether it should
 // cause a forced stop. It is meant to be used only by PLZ test runs.
-func (r *TestRunReconciler) ShouldAbort(ctx context.Context, k6 *v1alpha1.TestRun, log logr.Logger) bool {
+func (r *TestRunReconciler) ShouldAbort(ctx context.Context, k6 *v1alpha1.TestRun, cloudClient *cloudapi.Client, log logr.Logger) bool {
 	// sanity check
 	if len(k6.TestRunID()) == 0 {
 		// log.Error(errors.New("empty test run ID"), "Trying to get state of test run with empty test run ID")
 		return false
 	}
 
-	status, err := cloud.GetTestRunState(r.k6CloudClient, k6.TestRunID(), log)
+	status, err := cloud.GetTestRunState(cloudClient, k6.TestRunID(), log)
 	if err != nil {
 		return false
 	}
@@ -470,23 +470,19 @@ func (r *TestRunReconciler) ShouldAbort(ctx context.Context, k6 *v1alpha1.TestRu
 	return status.Aborted()
 }
 
-func (r *TestRunReconciler) createClient(ctx context.Context, k6 *v1alpha1.TestRun, log logr.Logger) (bool, error) {
-	if r.k6CloudClient == nil {
-		tokenInfo := cloud.NewTokenInfo(k6.GetSpec().Token, k6.NamespacedName().Namespace)
-		err := tokenInfo.Load(ctx, log, r.Client)
+func (r *TestRunReconciler) createClient(ctx context.Context, k6 *v1alpha1.TestRun, log logr.Logger) (*cloudapi.Client, bool, error) {
+	tokenInfo := cloud.NewTokenInfo(k6.GetSpec().Token, k6.NamespacedName().Namespace)
+	err := tokenInfo.Load(ctx, log, r.Client)
 
-		if err != nil {
-			log.Error(err, "A problem while getting token.")
-			return false, err
-		}
-		if !tokenInfo.Ready {
-			return false, nil
-		}
-
-		host := getEnvVar(k6.GetSpec().Runner.Env, "K6_CLOUD_HOST")
-
-		r.k6CloudClient = cloud.NewClient(log, tokenInfo.Value(), host)
+	if err != nil {
+		log.Error(err, "A problem while getting token.")
+		return nil, false, err
+	}
+	if !tokenInfo.Ready {
+		return nil, false, nil
 	}
 
-	return true, nil
+	host := getEnvVar(k6.GetSpec().Runner.Env, "K6_CLOUD_HOST")
+
+	return cloud.NewClient(log, tokenInfo.Value(), host), true, nil
 }

--- a/pkg/cloud/cloud_output.go
+++ b/pkg/cloud/cloud_output.go
@@ -11,9 +11,6 @@ import (
 	null "gopkg.in/guregu/null.v3"
 )
 
-// TODO: refactor this!
-var client *cloudapi.Client
-
 type TestRun struct {
 	Name              string              `json:"name"`
 	ProjectID         int64               `json:"project_id,omitempty"`
@@ -46,7 +43,7 @@ func NewClient(logger logr.Logger, token, host string) *cloudapi.Client {
 	return cloudapi.NewClient(logrusLogger, token, host, "1.2.3", time.Duration(time.Minute))
 }
 
-func CreateTestRun(opts InspectOutput, instances int32, host, token string, log logr.Logger) (*cloudapi.CreateTestRunResponse, error) {
+func CreateTestRun(opts InspectOutput, instances int32, client *cloudapi.Client, log logr.Logger) (*cloudapi.CreateTestRunResponse, error) {
 	cloudConfig := cloudapi.NewConfig()
 
 	if opts.ProjectID() > 0 {
@@ -60,14 +57,6 @@ func CreateTestRun(opts InspectOutput, instances int32, host, token string, log 
 		}
 	}
 
-	if len(host) == 0 {
-		host = cloudConfig.Host.String
-	}
-
-	if client == nil {
-		client = NewClient(log, token, host)
-	}
-
 	tr := TestRun{
 		Name:              opts.TestName(),
 		ProjectID:         cloudConfig.ProjectID.Int64,
@@ -77,13 +66,13 @@ func CreateTestRun(opts InspectOutput, instances int32, host, token string, log 
 		ProcessThresholds: true,
 		Instances:         instances,
 	}
-	return createTestRun(client, host, &tr)
+	return createTestRun(client, &tr)
 }
 
 // We cannot use cloudapi.TestRun struct and cloudapi.Client.CreateTestRun call because they're not aware of
 // process_thresholds argument; so let's use custom struct and function instead
-func createTestRun(client *cloudapi.Client, host string, testRun *TestRun) (*cloudapi.CreateTestRunResponse, error) {
-	url := host + "/v1/tests"
+func createTestRun(client *cloudapi.Client, testRun *TestRun) (*cloudapi.CreateTestRunResponse, error) {
+	url := client.BaseURL() + "/tests"
 	req, err := client.NewRequest("POST", url, testRun)
 	if err != nil {
 		return nil, err
@@ -103,13 +92,7 @@ func createTestRun(client *cloudapi.Client, host string, testRun *TestRun) (*clo
 }
 
 func FinishTestRun(c *cloudapi.Client, refID string) error {
-	if c != nil {
-		return c.TestFinished(refID, cloudapi.ThresholdResult(
-			map[string]map[string]bool{},
-		), false, cloudapi.RunStatusFinished)
-	}
-
-	return client.TestFinished(refID, cloudapi.ThresholdResult(
+	return c.TestFinished(refID, cloudapi.ThresholdResult(
 		map[string]map[string]bool{},
 	), false, cloudapi.RunStatusFinished)
 }


### PR DESCRIPTION
Prerequisite for https://github.com/grafana/k6-operator/issues/823