### PR TITLE
chore: allow floating patch version of Go in GH workflows

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -14,7 +14,8 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.x"
+          check-latest: true
           cache: false
       - name: lint
         uses: golangci/golangci-lint-action@36fe29c8f9dc696b104db0f7d49d1a87d2bbcd5b

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -17,6 +17,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.x"
+          check-latest: true
       - run: |
           go run golang.org/x/vuln/cmd/govulncheck@v1.3.0 ./...

--- a/.github/workflows/helm-schema.yaml
+++ b/.github/workflows/helm-schema.yaml
@@ -28,7 +28,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.x"
+          check-latest: true
           cache: false
 
       - name: Generate Helm values schema

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -8,7 +8,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.25.11, 1.26.4]
+        go-version: ["1.25.x", "1.26.x"]
         k8s_version: [1.27.1, 1.30.0, 1.34.1]
         os: [ubuntu-x64]
     runs-on: ${{ matrix.os }}
@@ -17,6 +17,7 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: ${{ matrix.go-version }}
+          check-latest: true
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:


### PR DESCRIPTION
govulncheck CI is annoyingly failing every 2 weeks because of Golang CVE which are regular and just as regularly fixed. Switching to floating patch version of Go in Github workflows. 

The bump in go.mod remains separate: patch of toolchain by renovate, minor / major update - manual.