### PR TITLE
Pass ephemeral test run token as `K6_CLOUD_TOKEN` for PLZ tests

### DIFF
--- a/internal/controller/k6_create.go
+++ b/internal/controller/k6_create.go
@@ -20,26 +20,26 @@ import (
 // CreateJobs creates jobs that will spawn k6 pods for distributed test
 func CreateJobs(ctx context.Context, log logr.Logger, k6 *v1alpha1.TestRun, r *TestRunReconciler, cloudClient *cloudapi.Client) (ctrl.Result, error) {
 	// needed for cloud tests
-	tokenInfo := cloud.NewTokenInfo(k6.GetSpec().Token, k6.NamespacedName().Namespace)
+	sti := cloud.NewSecretTokenInfo(k6.GetSpec().Token, k6.NamespacedName().Namespace)
 
 	if v1alpha1.IsTrue(k6, v1alpha1.CloudTestRun) && v1alpha1.IsTrue(k6, v1alpha1.CloudTestRunCreated) {
 		log = log.WithValues("testRunId", k6.GetStatus().TestRunID)
 
-		err := tokenInfo.Load(ctx, log, r.Client)
+		err := sti.Load(ctx, log, r.Client)
 		if err != nil {
 			// An error here means a very likely mis-configuration of the token.
 			// TODO: update status to error to let a user know quicker
 			log.Error(err, "A problem while getting token.")
 			return ctrl.Result{}, nil
 		}
-		if !tokenInfo.Ready {
+		if !sti.Ready {
 			return ctrl.Result{RequeueAfter: time.Second * 5}, nil
 		}
 	}
 
 	log.Info("Creating test jobs")
 
-	if res, recheck, err := createJobSpecs(ctx, log, k6, r, tokenInfo); err != nil {
+	if res, recheck, err := createJobSpecs(ctx, log, k6, r, sti); err != nil {
 		if v1alpha1.IsTrue(k6, v1alpha1.CloudTestRun) {
 			events := cloud.ErrorEvent(cloud.K6OperatorStartError).
 				WithDetail(fmt.Sprintf("Failed to create runner jobs: %v", err)).
@@ -63,7 +63,7 @@ func CreateJobs(ctx context.Context, log logr.Logger, k6 *v1alpha1.TestRun, r *T
 	return ctrl.Result{}, nil
 }
 
-func createJobSpecs(ctx context.Context, log logr.Logger, k6 *v1alpha1.TestRun, r *TestRunReconciler, tokenInfo *cloud.TokenInfo) (ctrl.Result, bool, error) {
+func createJobSpecs(ctx context.Context, log logr.Logger, k6 *v1alpha1.TestRun, r *TestRunReconciler, sti *cloud.SecretTokenInfo) (ctrl.Result, bool, error) {
 	found := &batchv1.Job{}
 	namespacedName := types.NamespacedName{
 		Name:      fmt.Sprintf("%s-1", k6.NamespacedName().Name),
@@ -90,14 +90,14 @@ func createJobSpecs(ctx context.Context, log logr.Logger, k6 *v1alpha1.TestRun, 
 	}
 
 	for i := 1; i <= int(k6.GetSpec().Parallelism); i++ {
-		if err := launchTest(ctx, k6, i, log, r, tokenInfo); err != nil {
+		if err := launchTest(ctx, k6, i, log, r, sti); err != nil {
 			return ctrl.Result{}, false, err
 		}
 	}
 	return ctrl.Result{}, false, nil
 }
 
-func launchTest(ctx context.Context, k6 *v1alpha1.TestRun, index int, log logr.Logger, r *TestRunReconciler, tokenInfo *cloud.TokenInfo) error {
+func launchTest(ctx context.Context, k6 *v1alpha1.TestRun, index int, log logr.Logger, r *TestRunReconciler, sti *cloud.SecretTokenInfo) error {
 	var job *batchv1.Job
 	var service *corev1.Service
 	var err error
@@ -105,7 +105,7 @@ func launchTest(ctx context.Context, k6 *v1alpha1.TestRun, index int, log logr.L
 	msg := fmt.Sprintf("Launching k6 test #%d", index)
 	log.Info(msg)
 
-	if job, err = jobs.NewRunnerJob(k6, index, tokenInfo); err != nil {
+	if job, err = jobs.NewRunnerJob(k6, index, sti); err != nil {
 		log.Error(err, "Failed to generate k6 test job")
 		return err
 	}

--- a/internal/controller/plz_controller.go
+++ b/internal/controller/plz_controller.go
@@ -219,16 +219,16 @@ func (r *PrivateLoadZoneReconciler) UpdateStatus(
 func (r *PrivateLoadZoneReconciler) loadToken(ctx context.Context, tokenName, ns string, logger logr.Logger) (
 	token string, proceed bool, result ctrl.Result) {
 
-	tokenInfo := cloud.NewTokenInfo(tokenName, ns)
-	err := tokenInfo.Load(ctx, logger, r.Client)
+	sti := cloud.NewSecretTokenInfo(tokenName, ns)
+	err := sti.Load(ctx, logger, r.Client)
 
 	if err != nil {
 		// An error here means a very likely mis-configuration of the token.
 		logger.Error(err, "A problem while getting token.")
 		return "", false, ctrl.Result{}
 	}
-	if !tokenInfo.Ready {
+	if !sti.Ready {
 		return "", false, ctrl.Result{RequeueAfter: time.Second * 5}
 	}
-	return tokenInfo.Value(), true, ctrl.Result{}
+	return sti.Value(), true, ctrl.Result{}
 }

--- a/internal/controller/testrun_controller.go
+++ b/internal/controller/testrun_controller.go
@@ -471,18 +471,18 @@ func (r *TestRunReconciler) ShouldAbort(ctx context.Context, k6 *v1alpha1.TestRu
 }
 
 func (r *TestRunReconciler) createClient(ctx context.Context, k6 *v1alpha1.TestRun, log logr.Logger) (*cloudapi.Client, bool, error) {
-	tokenInfo := cloud.NewTokenInfo(k6.GetSpec().Token, k6.NamespacedName().Namespace)
-	err := tokenInfo.Load(ctx, log, r.Client)
+	sti := cloud.NewSecretTokenInfo(k6.GetSpec().Token, k6.NamespacedName().Namespace)
+	err := sti.Load(ctx, log, r.Client)
 
 	if err != nil {
 		log.Error(err, "A problem while getting token.")
 		return nil, false, err
 	}
-	if !tokenInfo.Ready {
+	if !sti.Ready {
 		return nil, false, nil
 	}
 
 	host := getEnvVar(k6.GetSpec().Runner.Env, "K6_CLOUD_HOST")
 
-	return cloud.NewClient(log, tokenInfo.Value(), host), true, nil
+	return cloud.NewClient(log, sti.Value(), host), true, nil
 }

--- a/pkg/cloud/apitypes.go
+++ b/pkg/cloud/apitypes.go
@@ -12,8 +12,8 @@ import (
 // GCk6 can set only a limited number of env vars to k6 process:
 // these are known and whitelisted with this "const" map.
 var reservedGCk6EnvVars = map[string]struct{}{
+	"K6_CLOUD_TOKEN": struct{}{},
 	// Future candidates:
-	// "K6_CLOUD_TOKEN": struct{}{},
 	// K6_LOG_OUTPUT, K6_TRACES_OUTPUT, K6_BROWSER_ENABLED_MSG, K6_CLOUD_TRACES_ENABLED, K6_BROWSER_SCREENSHOTS_OUTPUT
 }
 

--- a/pkg/cloud/token.go
+++ b/pkg/cloud/token.go
@@ -12,8 +12,9 @@ import (
 )
 
 // k6-operator has to handle authentication tokens for Cloud tests.
-// This struct contains key utilities to encapsulate that logic.
-type TokenInfo struct {
+// This struct contains key utilities to encapsulate that logic when
+// the token is stored in Kubernetes Secret.
+type SecretTokenInfo struct {
 	value string
 
 	secretName      string
@@ -35,25 +36,25 @@ const (
 	tokenLabelValue = "token"
 )
 
-func NewTokenInfo(name, namespace string) *TokenInfo {
-	return &TokenInfo{
+func NewSecretTokenInfo(name, namespace string) *SecretTokenInfo {
+	return &SecretTokenInfo{
 		secretName:      name,
 		secretNamespace: namespace,
 	}
 }
 
-func (ti TokenInfo) SecretName() string {
+func (ti SecretTokenInfo) SecretName() string {
 	return ti.secretName
 }
 
-func (ti TokenInfo) Value() string {
+func (ti SecretTokenInfo) Value() string {
 	return ti.value
 }
 
-// Load attempts to load the Secret and populate TokenInfo.
+// Load attempts to load the Secret and populate SecretTokenInfo.
 // returnErr means a non-recoverable error and requires the caller to take action or
 // propagate it further.
-func (ti *TokenInfo) Load(ctx context.Context, log logr.Logger, c k8sClient.Client) (returnErr error) {
+func (ti *SecretTokenInfo) Load(ctx context.Context, log logr.Logger, c k8sClient.Client) (returnErr error) {
 	var (
 		secrets corev1.SecretList
 		secret  corev1.Secret
@@ -116,7 +117,7 @@ func (ti *TokenInfo) Load(ctx context.Context, log logr.Logger, c k8sClient.Clie
 
 // InjectValue: this is only for unit tests!
 // If you see it elsewhere, it's likely a bug or an attack.
-func (ti *TokenInfo) InjectValue(v string) *TokenInfo {
+func (ti *SecretTokenInfo) InjectValue(v string) *SecretTokenInfo {
 	ti.value = v
 	return ti
 }

--- a/pkg/resources/jobs/runner.go
+++ b/pkg/resources/jobs/runner.go
@@ -17,39 +17,39 @@ import (
 
 // NewRunnerJob creates a new k6 job from a CRD
 // secretName is the name of the Secret with Cloud token, which must be in the same namespace.
-func NewRunnerJob(k6 *v1alpha1.TestRun, index int, tokenInfo *cloud.TokenInfo) (*batchv1.Job, error) {
-	name := fmt.Sprintf("%s-%d", k6.NamespacedName().Name, index)
+func NewRunnerJob(tr *v1alpha1.TestRun, index int, sti *cloud.SecretTokenInfo) (*batchv1.Job, error) {
+	name := fmt.Sprintf("%s-%d", tr.NamespacedName().Name, index)
 	postCommand := []string{"k6", "run"}
 
-	command, istioEnabled := newIstioCommand(k6.GetSpec().Scuttle.Enabled, postCommand)
+	command, istioEnabled := newIstioCommand(tr.GetSpec().Scuttle.Enabled, postCommand)
 
 	quiet := true
-	if k6.GetSpec().Quiet != "" {
-		quiet, _ = strconv.ParseBool(k6.GetSpec().Quiet)
+	if tr.GetSpec().Quiet != "" {
+		quiet, _ = strconv.ParseBool(tr.GetSpec().Quiet)
 	}
 
 	if quiet {
 		command = append(command, "--quiet")
 	}
 
-	if k6.GetSpec().Parallelism > 1 {
+	if tr.GetSpec().Parallelism > 1 {
 		var args []string
 		var err error
 
-		if args, err = segmentation.NewCommandFragments(index, int(k6.GetSpec().Parallelism)); err != nil {
+		if args, err = segmentation.NewCommandFragments(index, int(tr.GetSpec().Parallelism)); err != nil {
 			return nil, err
 
 		}
 		command = append(command, args...)
 	}
 
-	script, err := k6.GetSpec().ParseScript()
+	script, err := tr.GetSpec().ParseScript()
 	if err != nil {
 		return nil, err
 	}
 
-	if k6.GetSpec().Arguments != "" {
-		args := strings.Split(k6.GetSpec().Arguments, " ")
+	if tr.GetSpec().Arguments != "" {
+		args := strings.Split(tr.GetSpec().Arguments, " ")
 		command = append(command, args...)
 	}
 
@@ -59,8 +59,8 @@ func NewRunnerJob(k6 *v1alpha1.TestRun, index int, tokenInfo *cloud.TokenInfo) (
 		"--address=0.0.0.0:6565")
 
 	paused := true
-	if k6.GetSpec().Paused != "" {
-		paused, _ = strconv.ParseBool(k6.GetSpec().Paused)
+	if tr.GetSpec().Paused != "" {
+		paused, _ = strconv.ParseBool(tr.GetSpec().Paused)
 	}
 
 	if paused {
@@ -71,14 +71,14 @@ func NewRunnerJob(k6 *v1alpha1.TestRun, index int, tokenInfo *cloud.TokenInfo) (
 	command = append(command, "--tag", fmt.Sprintf("instance_id=%d", index))
 
 	// Add a testrun name tag: in case metrics are stored, they need to be distinguished by test run name
-	command = append(command, "--tag", fmt.Sprintf("testrun_name=%s", k6.NamespacedName().Name))
+	command = append(command, "--tag", fmt.Sprintf("testrun_name=%s", tr.NamespacedName().Name))
 
-	if v1alpha1.IsTrue(k6, v1alpha1.CloudPLZTestRun) {
+	if v1alpha1.IsTrue(tr, v1alpha1.CloudPLZTestRun) {
 		command = append(command, "--no-setup", "--no-teardown", "--linger")
 	}
 
 	// For PLZ tests, we add a reserved env var containing instance ID.
-	if len(k6.TestRunID()) > 0 && v1alpha1.IsTrue(k6, v1alpha1.CloudPLZTestRun) {
+	if len(tr.TestRunID()) > 0 && v1alpha1.IsTrue(tr, v1alpha1.CloudPLZTestRun) {
 		command = append(command, "-e", fmt.Sprintf(`%s=%d`, cloud.IIDCloudExecVar, index))
 	}
 
@@ -90,19 +90,19 @@ func NewRunnerJob(k6 *v1alpha1.TestRun, index int, tokenInfo *cloud.TokenInfo) (
 	)
 
 	image := "grafana/k6:latest"
-	if k6.GetSpec().Runner.Image != "" {
-		image = k6.GetSpec().Runner.Image
+	if tr.GetSpec().Runner.Image != "" {
+		image = tr.GetSpec().Runner.Image
 	}
 
 	runnerAnnotations := make(map[string]string)
-	if k6.GetSpec().Runner.Metadata.Annotations != nil {
-		runnerAnnotations = k6.GetSpec().Runner.Metadata.Annotations
+	if tr.GetSpec().Runner.Metadata.Annotations != nil {
+		runnerAnnotations = tr.GetSpec().Runner.Metadata.Annotations
 	}
 
-	runnerLabels := newLabels(k6.NamespacedName().Name)
+	runnerLabels := newLabels(tr.NamespacedName().Name)
 	runnerLabels["runner"] = "true"
-	if k6.GetSpec().Runner.Metadata.Labels != nil {
-		for k, v := range k6.GetSpec().Runner.Metadata.Labels { // Order not specified
+	if tr.GetSpec().Runner.Metadata.Labels != nil {
+		for k, v := range tr.GetSpec().Runner.Metadata.Labels { // Order not specified
 			if _, ok := runnerLabels[k]; !ok {
 				runnerLabels[k] = v
 			}
@@ -110,69 +110,42 @@ func NewRunnerJob(k6 *v1alpha1.TestRun, index int, tokenInfo *cloud.TokenInfo) (
 	}
 
 	serviceAccountName := "default"
-	if k6.GetSpec().Runner.ServiceAccountName != "" {
-		serviceAccountName = k6.GetSpec().Runner.ServiceAccountName
+	if tr.GetSpec().Runner.ServiceAccountName != "" {
+		serviceAccountName = tr.GetSpec().Runner.ServiceAccountName
 	}
 
 	automountServiceAccountToken := true
-	if k6.GetSpec().Runner.AutomountServiceAccountToken != "" {
-		automountServiceAccountToken, _ = strconv.ParseBool(k6.GetSpec().Runner.AutomountServiceAccountToken)
+	if tr.GetSpec().Runner.AutomountServiceAccountToken != "" {
+		automountServiceAccountToken, _ = strconv.ParseBool(tr.GetSpec().Runner.AutomountServiceAccountToken)
 	}
 
 	ports := []corev1.ContainerPort{{ContainerPort: 6565}}
-	ports = append(ports, k6.GetSpec().Ports...)
+	ports = append(ports, tr.GetSpec().Ports...)
 
-	env := newIstioEnvVar(k6.GetSpec().Scuttle, istioEnabled)
+	env := newIstioEnvVar(tr.GetSpec().Scuttle, istioEnabled)
 
-	// this is a cloud test run: either cloud output or PLZ
-	if len(k6.TestRunID()) > 0 {
-		// cloud output case
-		tokenVar := corev1.EnvVar{
-			Name:  "K6_CLOUD_TOKEN",
-			Value: tokenInfo.Value(),
-		}
-
-		if v1alpha1.IsTrue(k6, v1alpha1.CloudPLZTestRun) {
-			tokenVar = corev1.EnvVar{
-				Name: "K6_CLOUD_TOKEN",
-				ValueFrom: &corev1.EnvVarSource{
-					SecretKeyRef: &corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{Name: tokenInfo.SecretName()},
-						Key:                  "token",
-					},
-				},
-			}
-		} else {
-			// cloud output case
-			aggregationVars, err := cloud.DecodeAggregationConfig(k6.GetStatus().AggregationVars)
-			if err != nil {
-				return nil, err
-			}
-			env = append(env, aggregationVars...)
-		}
-
-		env = append(env, corev1.EnvVar{
-			Name:  "K6_CLOUD_PUSH_REF_ID",
-			Value: k6.TestRunID(),
-		}, tokenVar)
+	cloudEnvVars, err := getCloudEnvVars(tr, sti)
+	if err != nil {
+		return nil, err
 	}
+	env = append(env, cloudEnvVars...)
 
-	env = append(env, k6.GetSpec().Runner.Env...)
+	env = append(env, tr.GetSpec().Runner.Env...)
 
 	volumes := script.Volume()
-	volumes = append(volumes, k6.GetSpec().Runner.Volumes...)
+	volumes = append(volumes, tr.GetSpec().Runner.Volumes...)
 
 	volumeMounts := script.VolumeMount()
-	volumeMounts = append(volumeMounts, k6.GetSpec().Runner.VolumeMounts...)
+	volumeMounts = append(volumeMounts, tr.GetSpec().Runner.VolumeMounts...)
 
-	if k6.GetSpec().Runner.SchedulerName != "" {
-		schedulerName = k6.GetSpec().Runner.SchedulerName
+	if tr.GetSpec().Runner.SchedulerName != "" {
+		schedulerName = tr.GetSpec().Runner.SchedulerName
 	}
 
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
-			Namespace:   k6.NamespacedName().Namespace,
+			Namespace:   tr.NamespacedName().Namespace,
 			Labels:      runnerLabels,
 			Annotations: runnerAnnotations,
 		},
@@ -189,54 +162,54 @@ func NewRunnerJob(k6 *v1alpha1.TestRun, index int, tokenInfo *cloud.TokenInfo) (
 					Hostname:                     name,
 					RestartPolicy:                corev1.RestartPolicyNever,
 					SchedulerName:                schedulerName,
-					Affinity:                     k6.GetSpec().Runner.Affinity,
-					NodeSelector:                 k6.GetSpec().Runner.NodeSelector,
-					Tolerations:                  k6.GetSpec().Runner.Tolerations,
-					TopologySpreadConstraints:    k6.GetSpec().Runner.TopologySpreadConstraints,
-					SecurityContext:              &k6.GetSpec().Runner.SecurityContext,
-					ImagePullSecrets:             k6.GetSpec().Runner.ImagePullSecrets,
-					InitContainers:               getInitContainers(&k6.GetSpec().Runner, script),
+					Affinity:                     tr.GetSpec().Runner.Affinity,
+					NodeSelector:                 tr.GetSpec().Runner.NodeSelector,
+					Tolerations:                  tr.GetSpec().Runner.Tolerations,
+					TopologySpreadConstraints:    tr.GetSpec().Runner.TopologySpreadConstraints,
+					SecurityContext:              &tr.GetSpec().Runner.SecurityContext,
+					ImagePullSecrets:             tr.GetSpec().Runner.ImagePullSecrets,
+					InitContainers:               getInitContainers(&tr.GetSpec().Runner, script),
 					Containers: []corev1.Container{{
 						Image:           image,
-						ImagePullPolicy: k6.GetSpec().Runner.ImagePullPolicy,
+						ImagePullPolicy: tr.GetSpec().Runner.ImagePullPolicy,
 						Name:            "k6",
 						Command:         command,
 						Env:             env,
-						Resources:       k6.GetSpec().Runner.Resources,
+						Resources:       tr.GetSpec().Runner.Resources,
 						VolumeMounts:    volumeMounts,
 						Ports:           ports,
-						EnvFrom:         k6.GetSpec().Runner.EnvFrom,
-						LivenessProbe:   generateProbe(k6.GetSpec().Runner.LivenessProbe),
-						ReadinessProbe:  generateProbe(k6.GetSpec().Runner.ReadinessProbe),
-						SecurityContext: &k6.GetSpec().Runner.ContainerSecurityContext,
+						EnvFrom:         tr.GetSpec().Runner.EnvFrom,
+						LivenessProbe:   generateProbe(tr.GetSpec().Runner.LivenessProbe),
+						ReadinessProbe:  generateProbe(tr.GetSpec().Runner.ReadinessProbe),
+						SecurityContext: &tr.GetSpec().Runner.ContainerSecurityContext,
 					}},
 					Volumes:           volumes,
-					PriorityClassName: k6.GetSpec().Runner.PriorityClassName,
+					PriorityClassName: tr.GetSpec().Runner.PriorityClassName,
 				},
 			},
 		},
 	}
 
-	if k6.GetSpec().Separate {
+	if tr.GetSpec().Separate {
 		job.Spec.Template.Spec.Affinity = newAntiAffinity()
 	}
 
 	return job, nil
 }
 
-func NewRunnerService(k6 *v1alpha1.TestRun, index int) (*corev1.Service, error) {
-	serviceName := fmt.Sprintf("%s-%s-%d", k6.NamespacedName().Name, "service", index)
-	runnerName := fmt.Sprintf("%s-%d", k6.NamespacedName().Name, index)
+func NewRunnerService(tr *v1alpha1.TestRun, index int) (*corev1.Service, error) {
+	serviceName := fmt.Sprintf("%s-%s-%d", tr.NamespacedName().Name, "service", index)
+	runnerName := fmt.Sprintf("%s-%d", tr.NamespacedName().Name, index)
 
 	runnerAnnotations := make(map[string]string)
-	if k6.GetSpec().Runner.Metadata.Annotations != nil {
-		runnerAnnotations = k6.GetSpec().Runner.Metadata.Annotations
+	if tr.GetSpec().Runner.Metadata.Annotations != nil {
+		runnerAnnotations = tr.GetSpec().Runner.Metadata.Annotations
 	}
 
-	runnerLabels := newLabels(k6.NamespacedName().Name)
+	runnerLabels := newLabels(tr.NamespacedName().Name)
 	runnerLabels["runner"] = "true"
-	if k6.GetSpec().Runner.Metadata.Labels != nil {
-		for k, v := range k6.GetSpec().Runner.Metadata.Labels { // Order not specified
+	if tr.GetSpec().Runner.Metadata.Labels != nil {
+		for k, v := range tr.GetSpec().Runner.Metadata.Labels { // Order not specified
 			if _, ok := runnerLabels[k]; !ok {
 				runnerLabels[k] = v
 			}
@@ -252,7 +225,7 @@ func NewRunnerService(k6 *v1alpha1.TestRun, index int) (*corev1.Service, error) 
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        serviceName,
-			Namespace:   k6.NamespacedName().Namespace,
+			Namespace:   tr.NamespacedName().Namespace,
 			Labels:      runnerLabels,
 			Annotations: runnerAnnotations,
 		},
@@ -310,4 +283,53 @@ func generateProbe(configuredProbe *corev1.Probe) *corev1.Probe {
 			},
 		},
 	}
+}
+
+// TODO: these are to be moved to an internal API package once it's up (separate PR & work, see #616)
+func getCloudEnvVars(tr *v1alpha1.TestRun, sti *cloud.SecretTokenInfo) ([]corev1.EnvVar, error) {
+	ev := make([]corev1.EnvVar, 0)
+
+	// non-cloud mode - no-op
+	if len(tr.TestRunID()) <= 0 {
+		return ev, nil
+	}
+
+	ev = append(ev, tokenEnvVar(tr, sti)...)
+
+	// Add aggregation vars for cloud output mode;
+	// PLZ mode already has them.
+	if !v1alpha1.IsTrue(tr, v1alpha1.CloudPLZTestRun) {
+		aggregationVars, err := cloud.DecodeAggregationConfig(tr.GetStatus().AggregationVars)
+		if err != nil {
+			return nil, err
+		}
+		ev = append(ev, aggregationVars...)
+	}
+
+	ev = append(ev, corev1.EnvVar{
+		Name:  "K6_CLOUD_PUSH_REF_ID",
+		Value: tr.TestRunID(),
+	})
+
+	return ev, nil
+}
+
+// assumes tr is a cloud test run
+func tokenEnvVar(tr *v1alpha1.TestRun, sti *cloud.SecretTokenInfo) []corev1.EnvVar {
+	// cloud output mode
+	// old auth path, with `--out cloud`
+	if !v1alpha1.IsTrue(tr, v1alpha1.CloudPLZTestRun) {
+		return []corev1.EnvVar{{
+			Name:  "K6_CLOUD_TOKEN",
+			Value: sti.Value(),
+		}}
+	}
+
+	return nil
+
+	// PLZ mode is a no-op because ephemeral `K6_CLOUD_TOKEN` is set in test run data
+
+	// new auth path, with `--local-execution`
+	//   K6_CLOUD_TEST_RUN_TOKEN for all modes
+	// Future TODO, see https://github.com/grafana/k6-operator/issues/668
 }

--- a/pkg/resources/jobs/runner_test.go
+++ b/pkg/resources/jobs/runner_test.go
@@ -165,7 +165,7 @@ func Test_NewRunnerJob(t *testing.T) {
 	tests := []struct {
 		name             string
 		script           *types.Script
-		tokenInfo        *cloud.TokenInfo
+		sti              *cloud.SecretTokenInfo
 		setupTestRun     func(*v1alpha1.TestRun)
 		setupExpectedJob func(*batchv1.Job)
 	}{
@@ -250,8 +250,8 @@ func Test_NewRunnerJob(t *testing.T) {
 			},
 		},
 		{
-			name:      "cloud output mode",
-			tokenInfo: cloud.NewTokenInfo("", "").InjectValue("token"),
+			name: "cloud output mode",
+			sti:  cloud.NewSecretTokenInfo("", "").InjectValue("token"),
 			setupTestRun: func(k6 *v1alpha1.TestRun) {
 				k6.Spec.Arguments = "--out cloud"
 				k6.Spec.Runner.Metadata.Labels = nil
@@ -265,9 +265,11 @@ func Test_NewRunnerJob(t *testing.T) {
 					"k6", "run", "--quiet", "--out", "cloud", "/test/test.js", "--address=0.0.0.0:6565", "--paused",
 					"--tag", "instance_id=1", "--tag", "testrun_name=test",
 				}
-				j.Spec.Template.Spec.Containers[0].Env = append(aggregationEnvVars,
-					corev1.EnvVar{Name: "K6_CLOUD_PUSH_REF_ID", Value: "testrunid"},
-					corev1.EnvVar{Name: "K6_CLOUD_TOKEN", Value: "token"},
+				j.Spec.Template.Spec.Containers[0].Env = append(
+					[]corev1.EnvVar{{Name: "K6_CLOUD_TOKEN", Value: "token"}},
+					append(aggregationEnvVars,
+						corev1.EnvVar{Name: "K6_CLOUD_PUSH_REF_ID", Value: "testrunid"},
+					)...,
 				)
 			},
 		},
@@ -431,8 +433,8 @@ func Test_NewRunnerJob(t *testing.T) {
 			},
 		},
 		{
-			name:      "PLZ test run",
-			tokenInfo: cloud.NewTokenInfo("plz-token-secret", "test"),
+			name: "PLZ test run",
+			sti:  cloud.NewSecretTokenInfo("plz-token-secret", "test"),
 			setupTestRun: func(k6 *v1alpha1.TestRun) {
 				k6.Spec.TestRunID = "plz-run-123"
 				k6.Spec.Runner.EnvFrom = envFromConfigMap("env")
@@ -455,16 +457,8 @@ func Test_NewRunnerJob(t *testing.T) {
 					"-e", "K6_CLOUDRUN_INSTANCE_ID=1",
 				}
 				j.Spec.Template.Spec.Containers[0].Env = []corev1.EnvVar{
+					// This is the only env var set in this package for PLZ now
 					{Name: "K6_CLOUD_PUSH_REF_ID", Value: "plz-run-123"},
-					{
-						Name: "K6_CLOUD_TOKEN",
-						ValueFrom: &corev1.EnvVarSource{
-							SecretKeyRef: &corev1.SecretKeySelector{
-								LocalObjectReference: corev1.LocalObjectReference{Name: "plz-token-secret"},
-								Key:                  "token",
-							},
-						},
-					},
 				}
 			},
 		},
@@ -487,12 +481,12 @@ func Test_NewRunnerJob(t *testing.T) {
 				tt.setupExpectedJob(expected)
 			}
 
-			tokenInfo := tt.tokenInfo
-			if tokenInfo == nil {
-				tokenInfo = cloud.NewTokenInfo("", "")
+			sti := tt.sti
+			if sti == nil {
+				sti = cloud.NewSecretTokenInfo("", "")
 			}
 
-			job, err := NewRunnerJob(k6, 1, tokenInfo)
+			job, err := NewRunnerJob(k6, 1, sti)
 			if err != nil {
 				t.Fatalf("NewRunnerJob errored: %v", err)
 			}


### PR DESCRIPTION
Fixes: https://github.com/grafana/k6-operator/issues/823

A small refactoring included on the way, to improve readability and as a prep for #616 (creating an internal TestRun type) and #668 (support for new k6 command and new auth), plus:

- `cloud.TokenInfo` -> `cloud.SecretTokenInfo`, because we now can have more than one source of the token (k8s Secret vs GCk6)
- legacy var renaming: `k6` -> `tr`

Note: cloud output mode remains as it was before. The remake of cloud output logic will come in / after the https://github.com/grafana/k6-operator/issues/668. However, there is an expectation that a user of cloud output is not setting `K6_CLOUD_TOKEN` env var to runners: that probably won't work. (This wasn't supported prior to this PR either, it just becomes more explicit now.)

