### PR TITLE
refactor: collect default values at the top of job builders

### DIFF
--- a/pkg/resources/jobs/runner.go
+++ b/pkg/resources/jobs/runner.go
@@ -85,21 +85,24 @@ func NewRunnerJob(k6 *v1alpha1.TestRun, index int, tokenInfo *cloud.TokenInfo) (
 	command = script.UpdateCommand(command)
 
 	var (
-		zero32        int32 = 0
-		schedulerName       = corev1.DefaultSchedulerName
+		zero32                       int32 = 0
+		image                              = "grafana/k6:latest"
+		runnerAnnotations                  = make(map[string]string)
+		runnerLabels                       = newLabels(k6.NamespacedName().Name)
+		serviceAccountName                 = "default"
+		automountServiceAccountToken       = true
+		ports                              = append([]corev1.ContainerPort{{ContainerPort: 6565}}, k6.GetSpec().Ports...)
+		schedulerName                      = corev1.DefaultSchedulerName
 	)
 
-	image := "grafana/k6:latest"
 	if k6.GetSpec().Runner.Image != "" {
 		image = k6.GetSpec().Runner.Image
 	}
 
-	runnerAnnotations := make(map[string]string)
 	if k6.GetSpec().Runner.Metadata.Annotations != nil {
 		runnerAnnotations = k6.GetSpec().Runner.Metadata.Annotations
 	}
 
-	runnerLabels := newLabels(k6.NamespacedName().Name)
 	runnerLabels["runner"] = "true"
 	if k6.GetSpec().Runner.Metadata.Labels != nil {
 		for k, v := range k6.GetSpec().Runner.Metadata.Labels { // Order not specified
@@ -109,18 +112,13 @@ func NewRunnerJob(k6 *v1alpha1.TestRun, index int, tokenInfo *cloud.TokenInfo) (
 		}
 	}
 
-	serviceAccountName := "default"
 	if k6.GetSpec().Runner.ServiceAccountName != "" {
 		serviceAccountName = k6.GetSpec().Runner.ServiceAccountName
 	}
 
-	automountServiceAccountToken := true
 	if k6.GetSpec().Runner.AutomountServiceAccountToken != "" {
 		automountServiceAccountToken, _ = strconv.ParseBool(k6.GetSpec().Runner.AutomountServiceAccountToken)
 	}
-
-	ports := []corev1.ContainerPort{{ContainerPort: 6565}}
-	ports = append(ports, k6.GetSpec().Ports...)
 
 	env := newIstioEnvVar(k6.GetSpec().Scuttle, istioEnabled)
 

--- a/pkg/resources/jobs/starter.go
+++ b/pkg/resources/jobs/starter.go
@@ -16,20 +16,33 @@ import (
 func NewStarterJob(k6 *v1alpha1.TestRun, hostname []string) *batchv1.Job {
 
 	var (
-		schedulerName = corev1.DefaultSchedulerName
+		starterImage                 = "ghcr.io/grafana/k6-operator:latest-starter"
+		starterAnnotations           = make(map[string]string)
+		starterLabels                = newLabels(k6.NamespacedName().Name)
+		serviceAccountName           = "default"
+		automountServiceAccountToken = true
+		schedulerName                = corev1.DefaultSchedulerName
+		// Default resource requests and limits to use as a fallback
+		resourceRequirements = corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    *resource.NewMilliQuantity(50, resource.DecimalSI),
+				corev1.ResourceMemory: *resource.NewQuantity(2097152, resource.BinarySI),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    *resource.NewMilliQuantity(100, resource.DecimalSI),
+				corev1.ResourceMemory: *resource.NewQuantity(209715200, resource.BinarySI),
+			},
+		}
 	)
 
-	starterAnnotations := make(map[string]string)
 	if k6.GetSpec().Starter.Metadata.Annotations != nil {
 		starterAnnotations = k6.GetSpec().Starter.Metadata.Annotations
 	}
 
-	starterImage := "ghcr.io/grafana/k6-operator:latest-starter"
 	if k6.GetSpec().Starter.Image != "" {
 		starterImage = k6.GetSpec().Starter.Image
 	}
 
-	starterLabels := newLabels(k6.NamespacedName().Name)
 	if k6.GetSpec().Starter.Metadata.Labels != nil {
 		for k, v := range k6.GetSpec().Starter.Metadata.Labels { // Order not specified
 			if _, ok := starterLabels[k]; !ok {
@@ -37,29 +50,15 @@ func NewStarterJob(k6 *v1alpha1.TestRun, hostname []string) *batchv1.Job {
 			}
 		}
 	}
-	serviceAccountName := "default"
 	if k6.GetSpec().Starter.ServiceAccountName != "" {
 		serviceAccountName = k6.GetSpec().Starter.ServiceAccountName
 	}
-	automountServiceAccountToken := true
 	if k6.GetSpec().Starter.AutomountServiceAccountToken != "" {
 		automountServiceAccountToken, _ = strconv.ParseBool(k6.GetSpec().Starter.AutomountServiceAccountToken)
 	}
 
 	command, istioEnabled := newIstioCommand(k6.GetSpec().Scuttle.Enabled, []string{"sh", "-c"})
 	env := newIstioEnvVar(k6.GetSpec().Scuttle, istioEnabled)
-
-	// Default resource requests and limits to use as a fallback
-	resourceRequirements := corev1.ResourceRequirements{
-		Requests: corev1.ResourceList{
-			corev1.ResourceCPU:    *resource.NewMilliQuantity(50, resource.DecimalSI),
-			corev1.ResourceMemory: *resource.NewQuantity(2097152, resource.BinarySI),
-		},
-		Limits: corev1.ResourceList{
-			corev1.ResourceCPU:    *resource.NewMilliQuantity(100, resource.DecimalSI),
-			corev1.ResourceMemory: *resource.NewQuantity(209715200, resource.BinarySI),
-		},
-	}
 
 	// User specified resource requirements
 	if len(k6.GetSpec().Starter.Resources.Requests) > 0 || len(k6.GetSpec().Starter.Resources.Limits) > 0 {


### PR DESCRIPTION
Closes #784

## What

`NewInitializerJob` declares all of its default values in a single `var` block at the top of the function:

https://github.com/grafana/k6-operator/blob/ffca562/pkg/resources/jobs/initializer.go#L22-L30

`NewRunnerJob` and `NewStarterJob` follow the same "default -> override -> pass to `PodSpec`" shape, but scatter their defaults across the function body: `runner.go` had 2 of 8 in the `var` block, `starter.go` had 1 of 7. This PR moves the scattered ones into the existing `var` blocks, in the same order as `initializer.go`, so all job builders read the same way.

`stopper.go` needs no change: `NewStopJob` builds on top of `NewStarterJob`, so it inherits the cleanup.

## Notes for review

- **Behaviour is unchanged.** Only declaration sites move; the override branches stay where they were.
- **The unit tests are untouched on purpose.** They compare the whole generated `Job` object, so any difference in the resulting `PodSpec` would fail them - which makes them the regression check for this change.
- Variables are not renamed (e.g. `starterAnnotations` is left as is rather than becoming `annotations`), to keep the diff limited to movement.
- `ports` in `runner.go` is now built with the single-line `append` form used in `initializer.go`, instead of a literal followed by a separate `append`.
- `var zero32 int32` is deliberately left alone: `initializer.go` and `starter.go` both declare it on its own just before the `Job` literal, so it is already consistent there.

Moving declarations earlier changes when they are evaluated, so I checked that nothing in between has side effects:
- `newLabels()` only returns a map literal.
- `k6.GetSpec().Ports` is read exactly once in `runner.go` and never written.
- `ports` starts from a fresh slice literal, so no backing array is shared with `k6.GetSpec().Ports`.

## Verification

- `go test ./pkg/resources/jobs/...` - ok, 45 tests pass
- `go test -race` over all packages except `e2e` - all pass
- `make lint` (golangci-lint with the kube-api-linter plugin, `./...`) - 0 issues
- `gofmt` / `go vet` / `go build ./...` - clean