### PR TITLE
fix: avoid recreating start and stop jobs

### DIFF
--- a/internal/controller/job_helper.go
+++ b/internal/controller/job_helper.go
@@ -1,0 +1,29 @@
+package controllers
+
+import (
+	"context"
+
+	batchv1 "k8s.io/api/batch/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func createJobIfNotExists(ctx context.Context, k8sClient client.Client, job *batchv1.Job) (bool, error) {
+	err := k8sClient.Get(ctx, client.ObjectKeyFromObject(job), &batchv1.Job{})
+	if err == nil {
+		return false, nil
+	}
+	if !apierrors.IsNotFound(err) {
+		return false, err
+	}
+
+	err = k8sClient.Create(ctx, job)
+	if apierrors.IsAlreadyExists(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}

--- a/internal/controller/job_helper_test.go
+++ b/internal/controller/job_helper_test.go
@@ -1,0 +1,49 @@
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestCreateJobIfNotExists(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, batchv1.AddToScheme(scheme))
+
+	t.Run("creates a missing job", func(t *testing.T) {
+		k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+		job := &batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-starter",
+				Namespace: "default",
+			},
+		}
+
+		created, err := createJobIfNotExists(context.Background(), k8sClient, job)
+
+		require.NoError(t, err)
+		require.True(t, created)
+		require.NoError(t, k8sClient.Get(context.Background(), client.ObjectKeyFromObject(job), &batchv1.Job{}))
+	})
+
+	t.Run("keeps an existing job", func(t *testing.T) {
+		existing := &batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-stopper",
+				Namespace: "default",
+			},
+		}
+		k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
+
+		created, err := createJobIfNotExists(context.Background(), k8sClient, existing.DeepCopy())
+
+		require.NoError(t, err)
+		require.False(t, created)
+	})
+}

--- a/internal/controller/k6_start.go
+++ b/internal/controller/k6_start.go
@@ -118,14 +118,17 @@ func StartJobs(ctx context.Context, log logr.Logger, k6 *v1alpha1.TestRun, r *Te
 		log.Error(err, "Failed to set controller reference for the start job")
 	}
 
-	// TODO: add a check for existence of starter job
-
-	if err = r.Create(ctx, starter); err != nil {
+	created, err := createJobIfNotExists(ctx, r.Client, starter)
+	if err != nil {
 		log.Error(err, "Failed to launch k6 test starter")
 		return res, nil
 	}
 
-	log.Info("Created starter job")
+	if created {
+		log.Info("Created starter job")
+	} else {
+		log.Info("Starter job already exists")
+	}
 
 	log.Info("Changing stage of TestRun status to started")
 	k6.GetStatus().Stage = "started"

--- a/internal/controller/k6_stop.go
+++ b/internal/controller/k6_stop.go
@@ -48,14 +48,17 @@ func StopJobs(ctx context.Context, log logr.Logger, k6 *v1alpha1.TestRun, r *Tes
 		log.Error(err, "Failed to set controller reference for the stop job")
 	}
 
-	// TODO: add a check for existence of stop job
-
-	if err = r.Create(ctx, stopJob); err != nil {
+	created, err := createJobIfNotExists(ctx, r.Client, stopJob)
+	if err != nil {
 		log.Error(err, "Failed to launch k6 test stop job.")
 		return res, nil
 	}
 
-	log.Info("Created stop job")
+	if created {
+		log.Info("Created stop job")
+	} else {
+		log.Info("Stop job already exists")
+	}
 
 	log.Info("Changing stage of TestRun status to stopped")
 	k6.GetStatus().Stage = "stopped"


### PR DESCRIPTION
Fixes #310

## Problem

Reconciliation can reach start or stop job creation again before the TestRun status update has caught up. Creating the same job again then reports an `AlreadyExists` error.

## Change

Check for an existing job before creation and continue the status transition when it is already present. An `AlreadyExists` response from a concurrent creation is handled the same way.

## Verification

- `go test ./internal/controller -run '^TestCreateJobIfNotExists$' -count=10`
- `go test ./... -run '^TestCreateJobIfNotExists$' -count=1`
- `go vet ./internal/controller`
