### PR TITLE
fix: handle OOMKilled runner pods

### DIFF
--- a/internal/controller/common.go
+++ b/internal/controller/common.go
@@ -225,12 +225,18 @@ func handleRunnerOOMKilled(ctx context.Context, log logr.Logger, k6 *v1alpha1.Te
 	log.Info(msg)
 
 	if isCloudTestRun(k6) {
+		if v1alpha1.IsTrue(k6, v1alpha1.CloudTestRunAborted) {
+			return true, nil
+		}
 		if cloudClient == nil {
 			return true, errors.New("cloud client is not configured")
 		}
 		events := cloud.ErrorEvent(cloud.OOMError).WithDetail(msg).WithAbort()
-		cloud.SendTestRunEvents(cloudClient, k6.TestRunID(), log, events)
-		return true, nil
+		if err := cloud.SendTestRunEvents(cloudClient, k6.TestRunID(), log, events); err != nil {
+			return true, err
+		}
+		_, err := StopJobs(ctx, log, k6, r)
+		return true, err
 	}
 
 	v1alpha1.UpdateCondition(k6, v1alpha1.TestRunRunning, metav1.ConditionFalse)

--- a/internal/controller/common.go
+++ b/internal/controller/common.go
@@ -15,8 +15,10 @@ import (
 	"github.com/grafana/k6-operator/api/v1alpha1"
 	"github.com/grafana/k6-operator/pkg/cloud"
 	"github.com/grafana/k6-operator/pkg/testrun"
+	"go.k6.io/k6/v2/cloudapi"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -25,6 +27,7 @@ import (
 
 const (
 	errMessageTooLong = "Creation of %s takes too long: your configuration might be off. Check if %v were created successfully."
+	oomKilledReason   = "OOMKilled"
 )
 
 // It may take some time to retrieve inspect output so indicate with boolean if it's ready
@@ -191,4 +194,56 @@ func runTeardown(ctx context.Context, hostnames []string, log logr.Logger) {
 	if err := testrun.RunTeardown(ctx, hostnames); err != nil {
 		log.Error(err, "Failed to invoke teardown()")
 	}
+}
+
+func isOOMKilled(status corev1.ContainerStatus) bool {
+	return status.State.Terminated != nil && status.State.Terminated.Reason == oomKilledReason ||
+		status.LastTerminationState.Terminated != nil && status.LastTerminationState.Terminated.Reason == oomKilledReason
+}
+
+func findOOMKilledContainer(pods []corev1.Pod) (string, string, bool) {
+	for _, pod := range pods {
+		for _, statuses := range [][]corev1.ContainerStatus{pod.Status.InitContainerStatuses, pod.Status.ContainerStatuses} {
+			for _, status := range statuses {
+				if isOOMKilled(status) {
+					return pod.Name, status.Name, true
+				}
+			}
+		}
+	}
+
+	return "", "", false
+}
+
+func handleRunnerOOMKilled(ctx context.Context, log logr.Logger, k6 *v1alpha1.TestRun, r *TestRunReconciler, pods []corev1.Pod, cloudClient *cloudapi.Client) (bool, error) {
+	podName, containerName, found := findOOMKilledContainer(pods)
+	if !found {
+		return false, nil
+	}
+
+	msg := fmt.Sprintf("runner pod %s container %s was terminated with reason %s", podName, containerName, oomKilledReason)
+	log.Info(msg)
+
+	if isCloudTestRun(k6) {
+		if cloudClient == nil {
+			return true, errors.New("cloud client is not configured")
+		}
+		events := cloud.ErrorEvent(cloud.OOMError).WithDetail(msg).WithAbort()
+		cloud.SendTestRunEvents(cloudClient, k6.TestRunID(), log, events)
+		return true, nil
+	}
+
+	v1alpha1.UpdateCondition(k6, v1alpha1.TestRunRunning, metav1.ConditionFalse)
+	k6.GetStatus().Stage = "error"
+	_, err := r.UpdateStatus(ctx, k6, log)
+	return true, err
+}
+
+func checkRunnerOOMKilled(ctx context.Context, log logr.Logger, k6 *v1alpha1.TestRun, r *TestRunReconciler, cloudClient *cloudapi.Client) (bool, error) {
+	pods := &corev1.PodList{}
+	if err := r.List(ctx, pods, k6.ListOptions()); err != nil {
+		return false, err
+	}
+
+	return handleRunnerOOMKilled(ctx, log, k6, r, pods.Items, cloudClient)
 }

--- a/internal/controller/k6_finish.go
+++ b/internal/controller/k6_finish.go
@@ -20,6 +20,12 @@ func FinishJobs(ctx context.Context, log logr.Logger, k6 *v1alpha1.TestRun, r *T
 	}
 
 	log.Info("Checking if all runner pods are finished")
+	if oomKilled, err := checkRunnerOOMKilled(ctx, log, k6, r, cloudClient); err != nil {
+		log.Error(err, "Could not check runner pods for OOM termination")
+		return
+	} else if oomKilled {
+		return
+	}
 
 	selector := labels.SelectorFromSet(map[string]string{
 		"app":    "k6",

--- a/internal/controller/k6_start.go
+++ b/internal/controller/k6_start.go
@@ -47,6 +47,11 @@ func StartJobs(ctx context.Context, log logr.Logger, k6 *v1alpha1.TestRun, r *Te
 		log.Error(err, "Could not list pods")
 		return res, nil
 	}
+	if oomKilled, err := handleRunnerOOMKilled(ctx, log, k6, r, pl.Items, cloudClient); err != nil {
+		return ctrl.Result{}, err
+	} else if oomKilled {
+		return ctrl.Result{RequeueAfter: time.Second}, nil
+	}
 
 	var count int
 	for _, pod := range pl.Items {
@@ -95,14 +100,21 @@ func StartJobs(ctx context.Context, log logr.Logger, k6 *v1alpha1.TestRun, r *Te
 	// setup
 
 	if v1alpha1.IsTrue(k6, v1alpha1.CloudPLZTestRun) {
-		if err, retry := runSetup(ctx, hostnames, log); err != nil {
+		setupErr, retry := runSetup(ctx, hostnames, log)
+		if oomKilled, err := checkRunnerOOMKilled(ctx, log, k6, r, cloudClient); err != nil {
+			return ctrl.Result{}, err
+		} else if oomKilled {
+			return ctrl.Result{RequeueAfter: time.Second}, nil
+		}
+
+		if setupErr != nil {
 			if retry {
-				return ctrl.Result{}, err
+				return ctrl.Result{}, setupErr
 			}
 
-			log.Error(err, "Setup function failed, requesting abort.")
+			log.Error(setupErr, "Setup function failed, requesting abort.")
 			events := cloud.ErrorEvent(cloud.SetupError).
-				WithDetail(fmt.Sprintf("setup function failed: %v", err)).
+				WithDetail(fmt.Sprintf("setup function failed: %v", setupErr)).
 				WithAbort()
 			cloud.SendTestRunEvents(cloudClient, k6.TestRunID(), log, events)
 

--- a/internal/controller/oom_test.go
+++ b/internal/controller/oom_test.go
@@ -1,0 +1,188 @@
+package controllers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/grafana/k6-operator/api/v1alpha1"
+	"github.com/grafana/k6-operator/pkg/cloud"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"go.k6.io/k6/v2/cloudapi"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestFindOOMKilledContainer(t *testing.T) {
+	tests := []struct {
+		name string
+		pod  corev1.Pod
+		want bool
+	}{
+		{
+			name: "terminated runner",
+			pod: corev1.Pod{
+				Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{
+					Name:  "k6",
+					State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: oomKilledReason}},
+				}}},
+			},
+			want: true,
+		},
+		{
+			name: "restarted runner",
+			pod: corev1.Pod{
+				Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{
+					Name:                 "k6",
+					LastTerminationState: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: oomKilledReason}},
+				}}},
+			},
+			want: true,
+		},
+		{
+			name: "init container",
+			pod: corev1.Pod{
+				Status: corev1.PodStatus{InitContainerStatuses: []corev1.ContainerStatus{{
+					Name:  "init",
+					State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: oomKilledReason}},
+				}}},
+			},
+			want: true,
+		},
+		{
+			name: "other failure",
+			pod: corev1.Pod{
+				Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{
+					Name:  "k6",
+					State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: "Error"}},
+				}}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			podName, containerName, found := findOOMKilledContainer([]corev1.Pod{tt.pod})
+
+			require.Equal(t, tt.want, found)
+			if tt.want {
+				require.Equal(t, tt.pod.Name, podName)
+				require.NotEmpty(t, containerName)
+			}
+		})
+	}
+}
+
+func TestCheckRunnerOOMKilled(t *testing.T) {
+	for _, stage := range []v1alpha1.Stage{"created", "started"} {
+		t.Run("moves an OSS "+string(stage)+" test run to error", func(t *testing.T) {
+			k6 := newOOMTestRun(false)
+			k6.Status.Stage = stage
+			v1alpha1.UpdateCondition(k6, v1alpha1.TestRunRunning, metav1.ConditionTrue)
+			r := newOOMReconciler(t, k6, newOOMPod(k6))
+
+			found, err := checkRunnerOOMKilled(context.Background(), logr.Discard(), k6, r, nil)
+
+			require.NoError(t, err)
+			require.True(t, found)
+			updated := &v1alpha1.TestRun{}
+			require.NoError(t, r.Get(context.Background(), client.ObjectKeyFromObject(k6), updated))
+			require.Equal(t, v1alpha1.Stage("error"), updated.Status.Stage)
+			require.True(t, v1alpha1.IsFalse(updated, v1alpha1.TestRunRunning))
+		})
+	}
+
+	t.Run("requests a cloud test run abort", func(t *testing.T) {
+		k6 := newOOMTestRun(true)
+		r := newOOMReconciler(t, k6, newOOMPod(k6))
+		var received cloud.Events
+		var method, path string
+		var decodeErr error
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			method = req.Method
+			path = req.URL.Path
+			decodeErr = json.NewDecoder(req.Body).Decode(&received)
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer server.Close()
+		cloudClient := cloudapi.NewClient(logrus.New(), "", server.URL, "test", time.Second)
+
+		found, err := checkRunnerOOMKilled(context.Background(), logr.Discard(), k6, r, cloudClient)
+
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, http.MethodPost, method)
+		require.Equal(t, "/orchestrator/v1/testruns/123/events", path)
+		require.NoError(t, decodeErr)
+		require.Len(t, received, 2)
+		require.Equal(t, "TestRunErrorEvent", string(received[0].EventType))
+		require.Equal(t, cloud.OOMError, received[0].ErrorCode)
+		require.Equal(t, "runner pod sample-1 container k6 was terminated with reason OOMKilled", received[0].Detail)
+		require.Equal(t, "TestRunAbortEvent", string(received[1].EventType))
+	})
+
+	t.Run("ignores unrelated pods", func(t *testing.T) {
+		k6 := newOOMTestRun(false)
+		pod := newOOMPod(k6)
+		pod.Labels = nil
+		r := newOOMReconciler(t, k6, pod)
+
+		found, err := checkRunnerOOMKilled(context.Background(), logr.Discard(), k6, r, nil)
+
+		require.NoError(t, err)
+		require.False(t, found)
+	})
+}
+
+func newOOMTestRun(cloudRun bool) *v1alpha1.TestRun {
+	k6 := &v1alpha1.TestRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "sample", Namespace: "default"},
+		Spec:       v1alpha1.TestRunSpec{Parallelism: 1},
+		Status:     v1alpha1.TestRunStatus{Stage: "started"},
+	}
+	v1alpha1.Initialize(k6)
+	k6.Status.Stage = "started"
+	if cloudRun {
+		v1alpha1.UpdateCondition(k6, v1alpha1.CloudTestRun, metav1.ConditionTrue)
+		k6.Status.TestRunID = "123"
+	}
+	return k6
+}
+
+func newOOMPod(k6 *v1alpha1.TestRun) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sample-1",
+			Namespace: k6.Namespace,
+			Labels:    map[string]string{"app": "k6", "k6_cr": k6.Name, "runner": "true"},
+		},
+		Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{
+			Name:  "k6",
+			State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: oomKilledReason}},
+		}}},
+	}
+}
+
+func newOOMReconciler(t *testing.T, k6 *v1alpha1.TestRun, pods ...*corev1.Pod) *TestRunReconciler {
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1alpha1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	objects := []client.Object{k6.DeepCopy()}
+	for _, pod := range pods {
+		objects = append(objects, pod)
+	}
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&v1alpha1.TestRun{}).
+		WithObjects(objects...).
+		Build()
+	return &TestRunReconciler{Client: k8sClient}
+}

--- a/internal/controller/oom_test.go
+++ b/internal/controller/oom_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"go.k6.io/k6/v2/cloudapi"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -100,13 +101,15 @@ func TestCheckRunnerOOMKilled(t *testing.T) {
 		})
 	}
 
-	t.Run("requests a cloud test run abort", func(t *testing.T) {
+	t.Run("requests a cloud test run abort once", func(t *testing.T) {
 		k6 := newOOMTestRun(true)
 		r := newOOMReconciler(t, k6, newOOMPod(k6))
 		var received cloud.Events
 		var method, path string
 		var decodeErr error
+		requestCount := 0
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			requestCount++
 			method = req.Method
 			path = req.URL.Path
 			decodeErr = json.NewDecoder(req.Body).Decode(&received)
@@ -127,6 +130,36 @@ func TestCheckRunnerOOMKilled(t *testing.T) {
 		require.Equal(t, cloud.OOMError, received[0].ErrorCode)
 		require.Equal(t, "runner pod sample-1 container k6 was terminated with reason OOMKilled", received[0].Detail)
 		require.Equal(t, "TestRunAbortEvent", string(received[1].EventType))
+		updated := &v1alpha1.TestRun{}
+		require.NoError(t, r.Get(context.Background(), client.ObjectKeyFromObject(k6), updated))
+		require.Equal(t, v1alpha1.Stage("stopped"), updated.Status.Stage)
+		require.True(t, v1alpha1.IsFalse(updated, v1alpha1.TestRunRunning))
+		require.True(t, v1alpha1.IsTrue(updated, v1alpha1.CloudTestRunAborted))
+
+		found, err = checkRunnerOOMKilled(context.Background(), logr.Discard(), updated, r, cloudClient)
+
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, 1, requestCount)
+	})
+
+	t.Run("retries when cloud event delivery fails", func(t *testing.T) {
+		k6 := newOOMTestRun(true)
+		r := newOOMReconciler(t, k6, newOOMPod(k6))
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer server.Close()
+		cloudClient := cloudapi.NewClient(logrus.New(), "", server.URL, "test", time.Second)
+
+		found, err := checkRunnerOOMKilled(context.Background(), logr.Discard(), k6, r, cloudClient)
+
+		require.Error(t, err)
+		require.True(t, found)
+		updated := &v1alpha1.TestRun{}
+		require.NoError(t, r.Get(context.Background(), client.ObjectKeyFromObject(k6), updated))
+		require.Equal(t, v1alpha1.Stage("started"), updated.Status.Stage)
+		require.False(t, v1alpha1.IsTrue(updated, v1alpha1.CloudTestRunAborted))
 	})
 
 	t.Run("ignores unrelated pods", func(t *testing.T) {
@@ -175,6 +208,7 @@ func newOOMReconciler(t *testing.T, k6 *v1alpha1.TestRun, pods ...*corev1.Pod) *
 	scheme := runtime.NewScheme()
 	require.NoError(t, v1alpha1.AddToScheme(scheme))
 	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, batchv1.AddToScheme(scheme))
 	objects := []client.Object{k6.DeepCopy()}
 	for _, pod := range pods {
 		objects = append(objects, pod)
@@ -184,5 +218,5 @@ func newOOMReconciler(t *testing.T, k6 *v1alpha1.TestRun, pods ...*corev1.Pod) *
 		WithStatusSubresource(&v1alpha1.TestRun{}).
 		WithObjects(objects...).
 		Build()
-	return &TestRunReconciler{Client: k8sClient}
+	return &TestRunReconciler{Client: k8sClient, Scheme: scheme}
 }

--- a/internal/controller/testrun_controller.go
+++ b/internal/controller/testrun_controller.go
@@ -251,6 +251,11 @@ func (r *TestRunReconciler) reconcile(ctx context.Context, req ctrl.Request, log
 		}
 
 		if v1alpha1.IsTrue(k6, v1alpha1.CloudPLZTestRun) {
+			if oomKilled, err := checkRunnerOOMKilled(ctx, log, k6, r, cloudClient); err != nil {
+				return ctrl.Result{}, err
+			} else if oomKilled {
+				return ctrl.Result{RequeueAfter: time.Second}, nil
+			}
 			runningTime, _ := v1alpha1.LastUpdate(k6, v1alpha1.TestRunRunning)
 
 			if v1alpha1.IsFalse(k6, v1alpha1.TeardownExecuted) {
@@ -267,6 +272,11 @@ func (r *TestRunReconciler) reconcile(ctx context.Context, req ctrl.Request, log
 						return ctrl.Result{}, nil
 					}
 					runTeardown(ctx, hostnames, log)
+					if oomKilled, err := checkRunnerOOMKilled(ctx, log, k6, r, cloudClient); err != nil {
+						return ctrl.Result{}, err
+					} else if oomKilled {
+						return ctrl.Result{RequeueAfter: time.Second}, nil
+					}
 					v1alpha1.UpdateCondition(k6, v1alpha1.TeardownExecuted, metav1.ConditionTrue)
 
 					_, err = r.UpdateStatus(ctx, k6, log)

--- a/pkg/cloud/test_runs.go
+++ b/pkg/cloud/test_runs.go
@@ -139,9 +139,9 @@ func GetTestRunState(client *cloudapi.Client, refID string, logger logr.Logger) 
 
 // called by TestRun controller
 // If there's an error, it'll be logged.
-func SendTestRunEvents(client *cloudapi.Client, refID string, logger logr.Logger, events *Events) {
+func SendTestRunEvents(client *cloudapi.Client, refID string, logger logr.Logger, events *Events) error {
 	if len(*events) == 0 {
-		return
+		return nil
 	}
 
 	host := strings.TrimSuffix(client.BaseURL(), "/v1")
@@ -152,7 +152,7 @@ func SendTestRunEvents(client *cloudapi.Client, refID string, logger logr.Logger
 
 	if err != nil {
 		logger.Error(err, fmt.Sprintf("Failed to create events HTTP request %+v", events))
-		return
+		return err
 	}
 
 	logger.Info(fmt.Sprintf("Sending events to k6 Cloud %+v", *events))
@@ -160,5 +160,8 @@ func SendTestRunEvents(client *cloudapi.Client, refID string, logger logr.Logger
 	// status code is checked in Do
 	if err = client.Do(req, nil); err != nil {
 		logger.Error(err, fmt.Sprintf("Failed to send events %+v", events))
+		return err
 	}
+
+	return nil
 }


### PR DESCRIPTION
Detects OOMKilled runner and init containers, including previous termination states.

OSS test runs move to the error stage. Cloud test runs send the OOM error and abort events. The check runs during startup and the setup, runner-finish, and teardown paths.

Tests: focused OOM tests, non-e2e unit tests, and non-e2e go vet.

Closes #251