### PR TITLE
Add a `.spec.args` to TestRun CRD and switch PLZ to using it (2/3)

### DIFF
--- a/api/v1alpha1/testrun_types.go
+++ b/api/v1alpha1/testrun_types.go
@@ -16,7 +16,10 @@ package v1alpha1
 
 import (
 	"errors"
+	"fmt"
 	"path/filepath"
+	"slices"
+	"strings"
 
 	"github.com/grafana/k6-operator/pkg/types"
 	corev1 "k8s.io/api/core/v1"
@@ -100,8 +103,14 @@ type TestRunSpec struct {
 	// using the podAntiAffinity rule.
 	Separate bool `json:"separate,omitempty"`
 
-	// Arguments to pass to the k6 process.
+	// Arguments to pass to the k6 process, as a space-separated string.
+	// Prefer `args` for values that contain spaces or quotes.
 	Arguments string `json:"arguments,omitempty"`
+
+	// Args contains exact argv elements passed to k6.
+	// A non-empty Args overrides Arguments.
+	// +listType=atomic
+	Args []string `json:"args,omitempty"`
 
 	// Port to configure on all k6 containers.
 	// Port 6565 is always configured for k6 processes.
@@ -226,9 +235,39 @@ func (k6 *TestRunSpec) Validate() (warnings []string, err error) {
 		warnings = append(warnings, "`.spec.scuttle` is deprecated and will be removed in the future. See https://grafana.com/docs/k6/latest/set-up/set-up-distributed-k6/usage/istio/ on how to set up Istio.")
 	}
 
-	// Currently, we validate "manually" only arguments field.
-	_, err = types.ParseCLI(k6.Arguments)
+	// An empty argument here is likely a misconfiguration.
+	// Fail early instead of propagating this to the initializer pod.
+	if i := slices.Index(k6.Args, ""); i >= 0 {
+		return warnings, fmt.Errorf("`.spec.args` contains an empty element at index %d", i)
+	}
+
+	// Currently, we validate "manually" only the k6 arguments.
+	_, err = types.ParseCLI(k6.Argv())
 	return
+}
+
+// Argv returns the exact argv elements to be passed to k6.
+// A non-empty Args takes precedence over Arguments. Otherwise,
+// Arguments is split on spaces.
+func (k6 *TestRunSpec) Argv() []string {
+	if len(k6.Args) > 0 {
+		return slices.Clone(k6.Args)
+	}
+
+	if len(k6.Arguments) == 0 {
+		return nil
+	}
+
+	argv := make([]string, 0, strings.Count(k6.Arguments, " ")+1)
+	for _, arg := range strings.Split(k6.Arguments, " ") {
+		if arg = strings.TrimSpace(arg); len(arg) > 0 {
+			argv = append(argv, arg)
+		}
+	}
+	if len(argv) == 0 {
+		return nil
+	}
+	return argv
 }
 
 // Parse extracts Script data bits from K6 spec and performs basic validation

--- a/api/v1alpha1/testrun_types.go
+++ b/api/v1alpha1/testrun_types.go
@@ -17,6 +17,8 @@ package v1alpha1
 import (
 	"errors"
 	"path/filepath"
+	"slices"
+	"strings"
 
 	"github.com/grafana/k6-operator/pkg/types"
 	corev1 "k8s.io/api/core/v1"
@@ -100,8 +102,14 @@ type TestRunSpec struct {
 	// using the podAntiAffinity rule.
 	Separate bool `json:"separate,omitempty"`
 
-	// Arguments to pass to the k6 process.
+	// Arguments to pass to the k6 process, as a space-separated string.
+	// Prefer `args` for values that contain spaces or quotes.
 	Arguments string `json:"arguments,omitempty"`
+
+	// Args contains exact argv elements passed to k6.
+	// A non-empty Args overrides Arguments.
+	// +listType=atomic
+	Args []string `json:"args,omitempty"`
 
 	// Port to configure on all k6 containers.
 	// Port 6565 is always configured for k6 processes.
@@ -226,9 +234,39 @@ func (k6 *TestRunSpec) Validate() (warnings []string, err error) {
 		warnings = append(warnings, "`.spec.scuttle` is deprecated and will be removed in the future. See https://grafana.com/docs/k6/latest/set-up/set-up-distributed-k6/usage/istio/ on how to set up Istio.")
 	}
 
-	// Currently, we validate "manually" only arguments field.
-	_, err = types.ParseCLI(k6.Arguments)
+	// Currently, we validate "manually" only the k6 arguments.
+	_, err = types.ParseCLI(k6.Argv())
+
+	// Note: an empty element in .spec.args is allowed as a flag value (e.g. `--user-agent ""`)
+	// because k6 CLI allows it; a standalone empty element is rejected by ParseCLI,
+	// same as k6 CLI rejects an extra empty positional argument.
+
 	return
+}
+
+func (k6 *TestRunSpec) usesArgs() bool {
+	return len(k6.Args) > 0
+}
+
+// Argv returns the exact argv elements to be passed to k6.
+// A non-empty .spec.args takes precedence over .spec.arguments.
+// Otherwise, .spec.arguments is split on whitespace.
+func (k6 *TestRunSpec) Argv() []string {
+	if k6.usesArgs() {
+		return slices.Clone(k6.Args)
+	}
+
+	if argv := strings.Fields(k6.Arguments); len(argv) > 0 {
+		return argv
+	}
+	return nil
+}
+
+// NeedsShellCmd reports whether the k6 command must be interpreted by shell:
+// that is the backward-compatible behaviour of .spec.arguments, used unless
+// exact argv elements are provided in .spec.args.
+func (k6 *TestRunSpec) NeedsShellCmd() bool {
+	return !k6.usesArgs()
 }
 
 // Parse extracts Script data bits from K6 spec and performs basic validation

--- a/api/v1alpha1/testrun_types_test.go
+++ b/api/v1alpha1/testrun_types_test.go
@@ -201,3 +201,116 @@ func Test_ParseScript(t *testing.T) {
 		})
 	}
 }
+
+func Test_Argv(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		spec     TestRunSpec
+		expected []string
+	}{
+		{
+			name:     "nothing set",
+			spec:     TestRunSpec{},
+			expected: nil,
+		},
+		{
+			name:     "empty args fall back to arguments",
+			spec:     TestRunSpec{Arguments: "--vus 10", Args: []string{}},
+			expected: []string{"--vus", "10"},
+		},
+		{
+			name:     "args override arguments",
+			spec:     TestRunSpec{Arguments: "--vus 10", Args: []string{"--vus", "20"}},
+			expected: []string{"--vus", "20"},
+		},
+		{
+			name:     "arguments splitting on spaces",
+			spec:     TestRunSpec{Arguments: "--vus 10 --duration 5s"},
+			expected: []string{"--vus", "10", "--duration", "5s"},
+		},
+		{
+			name:     "arguments splitting drops empty elements",
+			spec:     TestRunSpec{Arguments: "  --vus  10   --duration 5s  "},
+			expected: []string{"--vus", "10", "--duration", "5s"},
+		},
+		{
+			name:     "arguments with spaces only",
+			spec:     TestRunSpec{Arguments: "   "},
+			expected: nil,
+		},
+		{
+			// A YAML block scalar leaves a trailing newline. It must be trimmed.
+			name:     "arguments from a block scalar",
+			spec:     TestRunSpec{Arguments: "--vus 10 --duration 5s\n"},
+			expected: []string{"--vus", "10", "--duration", "5s"},
+		},
+		{
+			name: "args come back verbatim",
+			spec: TestRunSpec{Args: []string{
+				"--tag", "note=hello world",
+				"-e", `QUOTED="value"`,
+				"-e", "EMPTY=",
+				"--tag", "price=$$100 $(NAME)",
+				"",
+			}},
+			expected: []string{
+				"--tag", "note=hello world",
+				"-e", `QUOTED="value"`,
+				"-e", "EMPTY=",
+				"--tag", "price=$$100 $(NAME)",
+				"",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			argv := tt.spec.Argv()
+			if !reflect.DeepEqual(argv, tt.expected) {
+				t.Errorf("Argv() = %#v, want %#v", argv, tt.expected)
+			}
+		})
+	}
+}
+
+// ATM, Validate calls Argv() and ParseCLI(), both of which have their own tests.
+// So keeping only simple checks here, with potential future expansion.
+func Test_Validate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		spec        TestRunSpec
+		expectedErr bool
+	}{
+		{
+			name: "exact args",
+			spec: TestRunSpec{Args: []string{"--tag", "note=hello world", "-e", "EMPTY="}},
+		},
+		{
+			name:        "invalid arguments",
+			spec:        TestRunSpec{Arguments: "run script.js"},
+			expectedErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := tt.spec.Validate()
+			if tt.expectedErr && err == nil {
+				t.Errorf("Validate() should have returned an error")
+			}
+			if !tt.expectedErr && err != nil {
+				t.Errorf("Validate() returned unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/api/v1alpha1/testrun_types_test.go
+++ b/api/v1alpha1/testrun_types_test.go
@@ -201,3 +201,132 @@ func Test_ParseScript(t *testing.T) {
 		})
 	}
 }
+
+func Test_Argv(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		spec     TestRunSpec
+		expected []string
+	}{
+		{
+			name:     "nothing set",
+			spec:     TestRunSpec{},
+			expected: nil,
+		},
+		{
+			name:     "empty args fall back to arguments",
+			spec:     TestRunSpec{Arguments: "--vus 10", Args: []string{}},
+			expected: []string{"--vus", "10"},
+		},
+		{
+			name:     "args override arguments",
+			spec:     TestRunSpec{Arguments: "--vus 10", Args: []string{"--vus", "20"}},
+			expected: []string{"--vus", "20"},
+		},
+		{
+			name:     "arguments splitting on spaces",
+			spec:     TestRunSpec{Arguments: "--vus 10 --duration 5s"},
+			expected: []string{"--vus", "10", "--duration", "5s"},
+		},
+		{
+			name:     "arguments splitting drops empty elements",
+			spec:     TestRunSpec{Arguments: "  --vus  10   --duration 5s  "},
+			expected: []string{"--vus", "10", "--duration", "5s"},
+		},
+		{
+			name:     "arguments with spaces only",
+			spec:     TestRunSpec{Arguments: "   "},
+			expected: nil,
+		},
+		{
+			// A YAML block scalar leaves a trailing newline. It must be trimmed.
+			name:     "arguments from a block scalar",
+			spec:     TestRunSpec{Arguments: "--vus 10 --duration 5s\n"},
+			expected: []string{"--vus", "10", "--duration", "5s"},
+		},
+		{
+			name: "args come back verbatim",
+			spec: TestRunSpec{Args: []string{
+				"--tag", "note=hello world",
+				"-e", `QUOTED="value"`,
+				"-e", "EMPTY=",
+				"--tag", "price=$$100 $(NAME)",
+				"",
+			}},
+			expected: []string{
+				"--tag", "note=hello world",
+				"-e", `QUOTED="value"`,
+				"-e", "EMPTY=",
+				"--tag", "price=$$100 $(NAME)",
+				"",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			argv := tt.spec.Argv()
+			if !reflect.DeepEqual(argv, tt.expected) {
+				t.Errorf("Argv() = %#v, want %#v", argv, tt.expected)
+			}
+		})
+	}
+}
+
+func Test_Validate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		spec        TestRunSpec
+		expectedErr bool
+	}{
+		{
+			name: "exact args",
+			spec: TestRunSpec{Args: []string{"--tag", "note=hello world", "-e", "EMPTY="}},
+		},
+		{
+			name:        "empty element in args",
+			spec:        TestRunSpec{Args: []string{"--vus", "10", ""}},
+			expectedErr: true,
+		},
+		{
+			name:        "only an empty element in args",
+			spec:        TestRunSpec{Args: []string{""}},
+			expectedErr: true,
+		},
+		{
+			name: "extra spaces in arguments",
+			spec: TestRunSpec{Arguments: "  --vus  10   --duration 5s  "},
+		},
+		{
+			name:        "invalid arguments",
+			spec:        TestRunSpec{Arguments: "run script.js"},
+			expectedErr: true,
+		},
+		{
+			name: "nothing set",
+			spec: TestRunSpec{},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := tt.spec.Validate()
+			if tt.expectedErr && err == nil {
+				t.Errorf("Validate() should have returned an error")
+			}
+			if !tt.expectedErr && err != nil {
+				t.Errorf("Validate() returned unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -485,6 +485,11 @@ func (in *TestRunList) DeepCopyObject() runtime.Object {
 func (in *TestRunSpec) DeepCopyInto(out *TestRunSpec) {
 	*out = *in
 	out.Script = in.Script
+	if in.Args != nil {
+		in, out := &in.Args, &out.Args
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Ports != nil {
 		in, out := &in.Ports, &out.Ports
 		*out = make([]v1.ContainerPort, len(*in))

--- a/charts/k6-operator/templates/crds/testrun.yaml
+++ b/charts/k6-operator/templates/crds/testrun.yaml
@@ -43,6 +43,11 @@ spec:
             type: object
           spec:
             properties:
+              args:
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: atomic
               arguments:
                 type: string
               cleanup:

--- a/config/crd/bases/k6.io_testruns.yaml
+++ b/config/crd/bases/k6.io_testruns.yaml
@@ -37,6 +37,11 @@ spec:
             type: object
           spec:
             properties:
+              args:
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: atomic
               arguments:
                 type: string
               cleanup:

--- a/config/samples/k6_v1alpha1_testrun_with_args.yaml
+++ b/config/samples/k6_v1alpha1_testrun_with_args.yaml
@@ -1,0 +1,25 @@
+apiVersion: k6.io/v1alpha1
+kind: TestRun
+metadata:
+  name: k6-sample-with-args
+spec:
+  parallelism: 2
+  script:
+    configMap:
+      name: k6-test
+      file: test.js
+  # Each element of `args` is passed to k6 exactly as written, so values can
+  # contain spaces, quotes and `$`. Shell features are never interpreted here.
+  # A non-empty `args` overrides `arguments`.
+  args:
+    - --tag
+    - note=nightly run of "checkout" flow
+    - -e
+    - PRICE_LABEL=$$100 and up
+    # Kubernetes expands `$(NAME)`, so env vars are still usable:
+    - -e
+    - BASE_URL=$(BASE_URL)
+  runner:
+    env:
+      - name: BASE_URL
+        value: https://test.k6.io

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -2,6 +2,7 @@
 resources:
   - k6_v1alpha1_configmap.yaml
   - k6_v1alpha1_privateloadzone.yaml
+  - k6_v1alpha1_testrun_with_args.yaml
   - k6_v1alpha1_testrun_with_initContainers.yaml
   - k6_v1alpha1_testrun_with_localfile.yaml
   - k6_v1alpha1_testrun_with_output.yaml

--- a/docs/crd-generated.md
+++ b/docs/crd-generated.md
@@ -16952,10 +16952,19 @@ TestRunSpec defines the desired state of TestRun
         </td>
         <td>true</td>
       </tr><tr>
+        <td><b>args</b></td>
+        <td>[]string</td>
+        <td>
+          Args contains exact argv elements passed to k6.
+A non-empty Args overrides Arguments.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>arguments</b></td>
         <td>string</td>
         <td>
-          Arguments to pass to the k6 process.<br/>
+          Arguments to pass to the k6 process, as a space-separated string.
+Prefer `args` for values that contain spaces or quotes.<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -63,7 +63,7 @@ nano e2e/.env
 Run the following command from the root of repository to help avoid committing secrets by mistake:
 
 ```sh
-git update-index --skip-worktree e2e/testrun-cloud-output/manifests/secret.yaml e2e/testrun-simultaneous-cloud-output/manifests/secret.yaml
+git update-index --skip-worktree e2e/testrun-cloud-output/manifests/secret.yaml e2e/testrun-cloud-output-args/manifests/secret.yaml e2e/testrun-simultaneous-cloud-output/manifests/secret.yaml
 ```
 
 ## How to add a test

--- a/e2e/testrun-cloud-output-args/manifests/configmap.yaml
+++ b/e2e/testrun-cloud-output-args/manifests/configmap.yaml
@@ -1,0 +1,68 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test
+  namespace: k6-tests
+data:
+  test.js: |
+    // base source: https://github.com/grafana/quickpizza/blob/main/k6/foundations/04.metrics.js
+    import http from "k6/http";
+    import { check, sleep } from "k6";
+    import { Trend, Counter } from "k6/metrics";
+
+    const BASE_URL = __ENV.BASE_URL || 'http://localhost:3333';
+
+    // The value `spec.args` asks for, as k6 should see it: one argument, with
+    // the quote kept, `$$` collapsed to a single `$` and `$(BASE_URL)` resolved.
+    // This runs in the init context, so a mismatch fails both `k6 archive` in
+    // the initializer and `k6 run` in the runners before they open their API,
+    // which makes the TestRun stall short of the `started` stage.
+    const WANT_PIZZA_NOTE = 'hello "world" $5 and https://pizza.grafana.fun';
+    if (__ENV.PIZZA_NOTE !== WANT_PIZZA_NOTE) {
+      throw new Error(`PIZZA_NOTE is [${__ENV.PIZZA_NOTE}], want [${WANT_PIZZA_NOTE}]`);
+    }
+
+    export const options = {
+      stages: [
+        { duration: '5s', target: 5 },
+        { duration: '10s', target: 5 },
+        { duration: '5s', target: 0 },
+      ],
+      cloud: {
+        projectID: $PROJECT_ID,
+        name: 'k6-operator-e2e-cloud-output-args'
+      }
+    };
+
+    const pizzas = new Counter('quickpizza_number_of_pizzas');
+    const ingredients = new Trend('quickpizza_ingredients');
+
+    export function setup() {
+      console.log("Starting folks!")
+    }
+
+    export default function () {
+      let restrictions = {
+        maxCaloriesPerSlice: 500,
+        mustBeVegetarian: false,
+        excludedIngredients: ["pepperoni"],
+        excludedTools: ["knife"],
+        maxNumberOfToppings: 6,
+        minNumberOfToppings: 2
+      }
+      let res = http.post(`${BASE_URL}/api/pizza`, JSON.stringify(restrictions), {
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'token abcdef0123456789',
+        },
+      });
+      check(res, { "status is 200": (res) => res.status === 200 });
+      console.log(`${res.json().pizza.name} (${res.json().pizza.ingredients.length} ingredients)`);
+      pizzas.add(1);
+      ingredients.add(res.json().pizza.ingredients.length);
+      sleep(1);
+    }
+
+    export function teardown(){
+      console.log("That's all folks!")
+    }

--- a/e2e/testrun-cloud-output-args/manifests/configmap.yaml
+++ b/e2e/testrun-cloud-output-args/manifests/configmap.yaml
@@ -1,0 +1,70 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test
+  namespace: k6-tests
+data:
+  test.js: |
+    // base source: https://github.com/grafana/quickpizza/blob/main/k6/foundations/04.metrics.js
+    import http from "k6/http";
+    import { check, sleep } from "k6";
+    import { Trend, Counter } from "k6/metrics";
+
+    const BASE_URL = __ENV.BASE_URL || 'http://localhost:3333';
+
+    // The value `spec.args` asks for, as k6 should see it: one argument, with
+    // the quote kept, `$$` collapsed to a single `$` and `$(BASE_URL)` resolved.
+    // This runs in the init context, so a mismatch fails both `k6 archive` in
+    // the initializer and `k6 run` in the runners before they open their API,
+    // which makes the TestRun stall short of the `started` stage.
+    const WANT_PIZZA_NOTE = 'hello "world" $5 and https://pizza.grafana.fun';
+    if (__ENV.PIZZA_NOTE !== WANT_PIZZA_NOTE) {
+      throw new Error(`PIZZA_NOTE is [${__ENV.PIZZA_NOTE}], want [${WANT_PIZZA_NOTE}]`);
+    }
+
+    export const options = {
+      stages: [
+        { duration: '5s', target: 5 },
+        { duration: '10s', target: 5 },
+        { duration: '5s', target: 0 },
+      ],
+      cloud: {
+        projectID: $PROJECT_ID,
+        name: 'k6-operator-e2e-cloud-output-args'
+      }
+    };
+
+    const pizzas = new Counter('quickpizza_number_of_pizzas');
+    const ingredients = new Trend('quickpizza_ingredients');
+
+    export function setup() {
+      // TODO: Send notification to Slack
+      console.log("Starting folks!")
+    }
+
+    export default function () {
+      let restrictions = {
+        maxCaloriesPerSlice: 500,
+        mustBeVegetarian: false,
+        excludedIngredients: ["pepperoni"],
+        excludedTools: ["knife"],
+        maxNumberOfToppings: 6,
+        minNumberOfToppings: 2
+      }
+      let res = http.post(`/api/pizza`, JSON.stringify(restrictions), {
+        headers: {
+          'Content-Type': 'application/json',
+          'X-User-ID': 23423,
+        },
+      });
+      check(res, { "status is 200": (res) => res.status === 200 });
+      console.log(`${res.json().pizza.name} (${res.json().pizza.ingredients.length} ingredients)`);
+      pizzas.add(1);
+      ingredients.add(res.json().pizza.ingredients.length);
+      sleep(1);
+    }
+
+    export function teardown(){
+      // TODO: Send notification to Slack
+      console.log("That's all folks!")
+    }

--- a/e2e/testrun-cloud-output-args/manifests/kustomization.yaml
+++ b/e2e/testrun-cloud-output-args/manifests/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../latest/
+- configmap.yaml
+- namespace.yaml
+- secret.yaml

--- a/e2e/testrun-cloud-output-args/manifests/namespace.yaml
+++ b/e2e/testrun-cloud-output-args/manifests/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: k6-tests

--- a/e2e/testrun-cloud-output-args/manifests/secret.yaml
+++ b/e2e/testrun-cloud-output-args/manifests/secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cloud-token
+  namespace: k6-operator-system
+  labels:
+    k6cloud: token
+data:
+  token: $CLOUD_TOKEN

--- a/e2e/testrun-cloud-output-args/test.js
+++ b/e2e/testrun-cloud-output-args/test.js
@@ -1,0 +1,85 @@
+import { Environment } from 'k6/x/environment';
+import { sleep } from 'k6';
+import { expect } from '../assertions.js';
+
+export const options = {
+  setupTimeout: '60s',
+};
+
+const PARENT = "./"
+const TEST_NAME = "k6-sample-args"
+const NAMESPACE = "k6-tests"
+
+const env = new Environment({
+  name: "testrun-cloud-output-args",
+  implementation: "vcluster",
+  initFolder: PARENT + "manifests", // initial folder with everything that wil be loaded at init
+})
+
+export function setup() {
+  console.log("init returns", env.init());
+  // it is best to have a bit of delay between creating a CRD and
+  // a corresponding CR, so as to avoid the "no matches" error
+  sleep(0.5);
+}
+
+// Same scenario as testrun-cloud-output, with the k6 arguments expressed as
+// `spec.args`: exact argv elements, including values with spaces and quotes.
+//
+// The script asserts the `-e` value it receives in its init context, so if the
+// arguments do not reach k6 as authored, the initializer and the runners fail
+// and the TestRun never reaches `started`. The mismatch itself is reported in
+// the logs of the initializer pod.
+export default function () {
+  let err = env.apply(PARENT + "testrun.yaml");
+  console.log("apply testrun returns", err);
+
+  err = env.wait({
+    kind: "TestRun",
+    name: TEST_NAME,
+    namespace: NAMESPACE,
+    status_key: "stage",
+    status_value: "started",
+  }, {
+    timeout: "1m",
+    interval: "10s",
+  });
+
+  expect(err, "wait for started returns").toBeNull();
+
+  let allPods = env.getN("pods", {
+    "namespace": NAMESPACE,
+    "app": "k6",
+    "k6_cr": TEST_NAME,
+  });
+
+  let runnerPods = env.getN("pods", {
+    "namespace": NAMESPACE,
+    "app": "k6",
+    "k6_cr": TEST_NAME,
+    "runner": "true",
+  });
+
+  // there should be N runners pods + initializer + starter
+  expect(runnerPods, "runner pod count").toBe(4);
+  expect(allPods, "total pod count").toBe(runnerPods + 2);
+
+  err = env.wait({
+    kind: "TestRun",
+    name: TEST_NAME,
+    namespace: NAMESPACE,
+    status_key: "stage",
+    status_value: "finished",
+  }, {
+    timeout: "5m",
+    interval: "10s",
+  });
+
+  // TODO: add check for status of the pods
+
+  expect(err, "wait for finished returns").toBeNull();
+}
+
+export function teardown() {
+  console.log("delete returns", env.delete());
+}

--- a/e2e/testrun-cloud-output-args/testrun.yaml
+++ b/e2e/testrun-cloud-output-args/testrun.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: k6.io/v1alpha1
+kind: TestRun
+metadata:
+  name: k6-sample-args
+  namespace: k6-tests
+spec:
+  parallelism: 4
+  script:
+    configMap:
+      name: "test"
+      file: "test.js"
+  # Same test as testrun-cloud-output, expressed with `args` instead of
+  # `arguments`. Each element reaches k6 exactly as written, so values can
+  # hold spaces and quotes. `$$` is a literal `$` and `$(NAME)` is resolved
+  # by Kubernetes.
+  args:
+    - --out
+    - cloud
+    - --tag
+    - office=hours
+    - --tag
+    - note=hello world
+    - -e
+    - PIZZA_NOTE=hello "world" $$5 and $(BASE_URL)
+  runner:
+    env:
+      - name: BASE_URL
+        value: https://pizza.grafana.fun

--- a/e2e/tests.yaml
+++ b/e2e/tests.yaml
@@ -94,6 +94,15 @@ tests:
       - "pkg/resources/jobs/runner.go"
     requires_env: [CLOUD_TOKEN, PROJECT_ID]
 
+  - name: testrun-cloud-output-args
+    source_patterns:
+      - "pkg/cloud/"
+      - "pkg/types/k6cli.go"
+      - "pkg/types/script.go"
+      - "pkg/resources/jobs/runner.go"
+      - "pkg/resources/jobs/initializer.go"
+    requires_env: [CLOUD_TOKEN, PROJECT_ID]
+
   - name: testrun-simultaneous-cloud-output
     source_patterns:
       - "pkg/cloud/"

--- a/internal/controller/k6_initialize.go
+++ b/internal/controller/k6_initialize.go
@@ -23,7 +23,7 @@ func InitializeJobs(ctx context.Context, log logr.Logger, k6 *v1alpha1.TestRun, 
 	res = ctrl.Result{RequeueAfter: time.Second * 5}
 
 	// validation has already happened, so error here can be ignored
-	cli, _ := types.ParseCLI(k6.GetSpec().Arguments)
+	cli, _ := types.ParseCLI(k6.GetSpec().Argv())
 
 	var initializer *batchv1.Job
 	if initializer, err = jobs.NewInitializerJob(k6, cli.ArchiveArgs); err != nil {
@@ -53,7 +53,7 @@ func RunValidations(ctx context.Context, log logr.Logger, k6 *v1alpha1.TestRun, 
 	res = ctrl.Result{RequeueAfter: time.Second * 5}
 
 	// validation has already happened, so error here can be ignored
-	cli, _ := types.ParseCLI(k6.GetSpec().Arguments)
+	cli, _ := types.ParseCLI(k6.GetSpec().Argv())
 
 	inspectOutput, inspectReady, err := inspectTestRun(ctx, log, k6, r.Client)
 	if err != nil {

--- a/internal/controller/testrun_controller.go
+++ b/internal/controller/testrun_controller.go
@@ -152,7 +152,7 @@ func (r *TestRunReconciler) reconcile(ctx context.Context, req ctrl.Request, log
 
 		// Skip initializer if disabled, unless --out cloud is present
 		// (cloud output tests require initializer to run k6 inspect)
-		cli, _ := k6types.ParseCLI(k6.GetSpec().Arguments)
+		cli, _ := k6types.ParseCLI(k6.GetSpec().Argv())
 		if !cli.HasCloudOut && k6.IsInitializerDisabled() {
 			log.Info("Initializer is disabled, skipping initialization step")
 

--- a/pkg/cloud/apitypes.go
+++ b/pkg/cloud/apitypes.go
@@ -63,10 +63,10 @@ type TestRunData struct {
 	LZDistribution `json:"load_zone_distribution,omitempty"`
 
 	// Pre-processed k6 arguments and env vars, populated by Preprocess().
-	TagArgs string `json:"-"`
-	EnvArgs string `json:"-"`
-	// RunnerEnvVars holds k6 option env vars (user agent, blacklists) and
-	// K6_CLOUD_OPERATOR_ENV_* helper env vars referenced from EnvArgs.
+	// TagArgs and EnvArgs hold exact argv pairs, e.g. `--tag`, `key=value`.
+	TagArgs []string `json:"-"`
+	EnvArgs []string `json:"-"`
+	// RunnerEnvVars holds k6 option env vars, e.g. user agent and blacklists.
 	RunnerEnvVars []corev1.EnvVar `json:"-"`
 }
 
@@ -82,7 +82,7 @@ func (trd *TestRunData) Preprocess() error {
 		return fmt.Errorf("only tests with one load zone are supported, provided: %+v", trd.LZDistribution)
 	}
 
-	trd.TagArgs = "--tag load_zone=" + trd.LZName()
+	trd.TagArgs = []string{"--tag", "load_zone=" + escapeKubeExpansion(trd.LZName())}
 
 	// Handle k6 CLI options that need to be passed as env vars to the runners.
 
@@ -136,22 +136,24 @@ func (trd *TestRunData) Preprocess() error {
 	}
 	sort.Strings(keys)
 
-	// These env vars are set as env vars with the name `K6_CLOUD_OPERATOR_ENV_0..N`
-	// in the pods and then passed to k6 command with `-e KEY="${K6_CLOUD_OPERATOR_ENV_0..N}"`.
-	// Why: this keeps values with spaces, quotes etc. intact, as we don't have a guarantee
-	// that the values are sanitized here.
+	// These env vars are passed to the k6 command as exact `-e`, `KEY=value`
+	// argv pairs, so values with spaces, quotes etc. stay intact even though we
+	// don't have a guarantee that they are sanitized here.
 	// Also, see https://github.com/grafana/k6/issues/2730 for additional context.
-	envArgs := make([]string, 0, len(keys))
-	for i, k := range keys {
-		helper := fmt.Sprintf("K6_CLOUD_OPERATOR_ENV_%d", i)
-		envArgs = append(envArgs, fmt.Sprintf(`-e %s="${%s}"`, k, helper))
-		trd.RunnerEnvVars = append(trd.RunnerEnvVars, corev1.EnvVar{
-			Name: helper, Value: trd.Environment[k],
-		})
+	envArgs := make([]string, 0, len(keys)*2)
+	for _, k := range keys {
+		envArgs = append(envArgs, "-e", k+"="+escapeKubeExpansion(trd.Environment[k]))
 	}
-	trd.EnvArgs = strings.Join(envArgs, " ")
+	trd.EnvArgs = envArgs
 
 	return nil
+}
+
+// escapeKubeExpansion: `$` -> `$$`
+// Kubelet reduces `$$` back to a single `$` without further expansion.
+// If someone passes $(..) as a value, this will allow it to reach k6 as it was sent.
+func escapeKubeExpansion(value string) string {
+	return strings.ReplaceAll(value, "$", "$$")
 }
 
 type LZConfig struct {

--- a/pkg/cloud/apitypes.go
+++ b/pkg/cloud/apitypes.go
@@ -63,10 +63,10 @@ type TestRunData struct {
 	LZDistribution `json:"load_zone_distribution,omitempty"`
 
 	// Pre-processed k6 arguments and env vars, populated by Preprocess().
-	TagArgs string `json:"-"`
-	EnvArgs string `json:"-"`
-	// RunnerEnvVars holds k6 option env vars (user agent, blacklists) and
-	// K6_CLOUD_OPERATOR_ENV_* helper env vars referenced from EnvArgs.
+	// TagArgs and EnvArgs hold exact argv pairs, e.g. {`--tag`, `key=value`} or {`-e`, `key=value`}.
+	TagArgs []string `json:"-"`
+	EnvArgs []string `json:"-"`
+	// RunnerEnvVars holds k6 option env vars, e.g. user agent and blacklists.
 	RunnerEnvVars []corev1.EnvVar `json:"-"`
 }
 
@@ -82,15 +82,16 @@ func (trd *TestRunData) Preprocess() error {
 		return fmt.Errorf("only tests with one load zone are supported, provided: %+v", trd.LZDistribution)
 	}
 
-	trd.TagArgs = "--tag load_zone=" + trd.LZName()
+	trd.TagArgs = []string{"--tag", "load_zone=" + escapeKubeExpansion(trd.LZName())}
 
 	// Handle k6 CLI options that need to be passed as env vars to the runners.
 
 	if len(trd.UserAgent) > 0 {
 		trd.RunnerEnvVars = append(trd.RunnerEnvVars, corev1.EnvVar{
-			Name: "K6_USER_AGENT", Value: trd.UserAgent,
+			Name: "K6_USER_AGENT", Value: escapeKubeExpansion(trd.UserAgent),
 		})
 	}
+
 	if len(trd.BlacklistIPs) > 0 {
 		trd.RunnerEnvVars = append(trd.RunnerEnvVars, corev1.EnvVar{
 			Name: "K6_BLACKLIST_IPS", Value: strings.Join(trd.BlacklistIPs, ","),
@@ -136,22 +137,23 @@ func (trd *TestRunData) Preprocess() error {
 	}
 	sort.Strings(keys)
 
-	// These env vars are set as env vars with the name `K6_CLOUD_OPERATOR_ENV_0..N`
-	// in the pods and then passed to k6 command with `-e KEY="${K6_CLOUD_OPERATOR_ENV_0..N}"`.
-	// Why: this keeps values with spaces, quotes etc. intact, as we don't have a guarantee
-	// that the values are sanitized here.
+	// These env vars are passed to the k6 command as exact {`-e`, `key=value`}
+	// argv pairs, so values with spaces, quotes etc. stay intact.
 	// Also, see https://github.com/grafana/k6/issues/2730 for additional context.
-	envArgs := make([]string, 0, len(keys))
-	for i, k := range keys {
-		helper := fmt.Sprintf("K6_CLOUD_OPERATOR_ENV_%d", i)
-		envArgs = append(envArgs, fmt.Sprintf(`-e %s="${%s}"`, k, helper))
-		trd.RunnerEnvVars = append(trd.RunnerEnvVars, corev1.EnvVar{
-			Name: helper, Value: trd.Environment[k],
-		})
+	envArgs := make([]string, 0, len(keys)*2)
+	for _, k := range keys {
+		envArgs = append(envArgs, "-e", fmt.Sprintf("%s=%s", escapeKubeExpansion(k), escapeKubeExpansion(trd.Environment[k])))
 	}
-	trd.EnvArgs = strings.Join(envArgs, " ")
+	trd.EnvArgs = envArgs
 
 	return nil
+}
+
+// escapeKubeExpansion: `$` -> `$$`
+// Kubelet reduces `$$` back to a single `$` without further expansion.
+// If someone passes $(..) as a value, this will allow it to reach k6 as it was sent.
+func escapeKubeExpansion(value string) string {
+	return strings.ReplaceAll(value, "$", "$$")
 }
 
 type LZConfig struct {

--- a/pkg/cloud/apitypes_test.go
+++ b/pkg/cloud/apitypes_test.go
@@ -1,6 +1,7 @@
 package cloud
 
 import (
+	"reflect"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -159,16 +160,19 @@ func TestTestRunData_Preprocess(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		if expected := "--tag load_zone=zone"; trd.TagArgs != expected {
-			t.Errorf("TagArgs = %q, want %q", trd.TagArgs, expected)
+		expectedTagArgs := []string{"--tag", "load_zone=zone"}
+		if !reflect.DeepEqual(trd.TagArgs, expectedTagArgs) {
+			t.Errorf("TagArgs = %q, want %q", trd.TagArgs, expectedTagArgs)
 		}
 
 		// first are org env vars from API, then the reserved env vars
-		expectedEnvArgs := `-e GREETING="${K6_CLOUD_OPERATOR_ENV_0}"` +
-			` -e K6_CLOUDRUN_DISTRIBUTION="${K6_CLOUD_OPERATOR_ENV_1}"` +
-			` -e K6_CLOUDRUN_LOAD_ZONE="${K6_CLOUD_OPERATOR_ENV_2}"` +
-			` -e K6_CLOUDRUN_TEST_RUN_ID="${K6_CLOUD_OPERATOR_ENV_3}"`
-		if trd.EnvArgs != expectedEnvArgs {
+		expectedEnvArgs := []string{
+			"-e", "GREETING=hello world",
+			"-e", "K6_CLOUDRUN_DISTRIBUTION=label",
+			"-e", "K6_CLOUDRUN_LOAD_ZONE=zone",
+			"-e", "K6_CLOUDRUN_TEST_RUN_ID=42",
+		}
+		if !reflect.DeepEqual(trd.EnvArgs, expectedEnvArgs) {
 			t.Errorf("EnvArgs = %q, want %q", trd.EnvArgs, expectedEnvArgs)
 		}
 
@@ -182,10 +186,6 @@ func TestTestRunData_Preprocess(t *testing.T) {
 			{Name: "K6_CLOUD_METRIC_PUSH_INTERVAL", Value: "0s"},
 			{Name: "K6_CLOUD_METRIC_PUSH_CONCURRENCY", Value: "0"},
 			{Name: "K6_CLOUD_HOST", Value: "https://ingest.k6.io"},
-			{Name: "K6_CLOUD_OPERATOR_ENV_0", Value: "hello world"},
-			{Name: "K6_CLOUD_OPERATOR_ENV_1", Value: "label"},
-			{Name: "K6_CLOUD_OPERATOR_ENV_2", Value: "zone"},
-			{Name: "K6_CLOUD_OPERATOR_ENV_3", Value: "42"},
 		}
 
 		if len(trd.RunnerEnvVars) != len(expectedEnvVars) {
@@ -195,6 +195,36 @@ func TestTestRunData_Preprocess(t *testing.T) {
 			if trd.RunnerEnvVars[i] != expectedEnvVars[i] {
 				t.Errorf("RunnerEnvVars[%d] = %v, want %v", i, trd.RunnerEnvVars[i], expectedEnvVars[i])
 			}
+		}
+	})
+
+	t.Run("escape `$` in literals", func(t *testing.T) {
+		t.Parallel()
+		trd := TestRunData{
+			LZDistribution: LZDistribution{"label": Distribution{LoadZone: "zone-$(EVIL)", Percent: 100}},
+			LZConfig: LZConfig{
+				Environment: map[string]string{
+					"PRICE": "$100 for $(NAME) and ${OTHER}",
+				},
+			},
+		}
+		if err := trd.Preprocess(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		expectedTagArgs := []string{"--tag", "load_zone=zone-$$(EVIL)"}
+		if !reflect.DeepEqual(trd.TagArgs, expectedTagArgs) {
+			t.Errorf("TagArgs = %q, want %q", trd.TagArgs, expectedTagArgs)
+		}
+
+		expectedEnvArgs := []string{
+			"-e", "K6_CLOUDRUN_DISTRIBUTION=label",
+			"-e", "K6_CLOUDRUN_LOAD_ZONE=zone-$$(EVIL)",
+			"-e", "K6_CLOUDRUN_TEST_RUN_ID=0",
+			"-e", "PRICE=$$100 for $$(NAME) and $${OTHER}",
+		}
+		if !reflect.DeepEqual(trd.EnvArgs, expectedEnvArgs) {
+			t.Errorf("EnvArgs = %q, want %q", trd.EnvArgs, expectedEnvArgs)
 		}
 	})
 }

--- a/pkg/plz/worker.go
+++ b/pkg/plz/worker.go
@@ -161,8 +161,19 @@ func (w *PLZWorker) createTemplate(plz *v1alpha1.PrivateLoadZone) {
 	}
 }
 
-// the --log-output argument of PLZ runners; also used in unit tests
+// the --log-output argument of PLZ runners
 const plzLogOutputFormat = `--log-output=loki=https://cloudlogs.k6.io/api/v1/push,label.lz=%s,label.test_run_id=%s,header.Authorization=Token $(K6_CLOUD_TOKEN)`
+
+// plzk6Args builds the exact argv the worker is expected to produce.
+func plzk6Args(plzName string, testRunID string, trData *cloud.TestRunData) []string {
+	args := []string{"--out", "cloud"}
+	args = append(args, trData.TagArgs...)
+	args = append(args, "--no-thresholds")
+	args = append(args, fmt.Sprintf(plzLogOutputFormat, plzName, testRunID))
+	args = append(args, trData.EnvArgs...)
+	args = append(args, fmt.Sprintf("--include-system-env-vars=%t", trData.IncludeSystemEnvVars))
+	return args
+}
 
 // complete modifies tr with data from trData, which is specific for this test run.
 func (w *PLZWorker) complete(tr *v1alpha1.TestRun, trData *cloud.TestRunData) {
@@ -183,14 +194,7 @@ func (w *PLZWorker) complete(tr *v1alpha1.TestRun, trData *cloud.TestRunData) {
 	tr.Spec.TestRunID = trData.TestRunID()
 
 	// Building the argument list to k6.
-	args := []string{"--out", "cloud"}
-	args = append(args, trData.TagArgs...)
-	args = append(args, "--no-thresholds")
-	args = append(args, fmt.Sprintf(plzLogOutputFormat, w.plz.Name, trData.TestRunID()))
-	args = append(args, trData.EnvArgs...)
-	args = append(args, fmt.Sprintf("--include-system-env-vars=%t", trData.IncludeSystemEnvVars))
-
-	tr.Spec.Args = args
+	tr.Spec.Args = plzk6Args(w.plz.Name, trData.TestRunID(), trData)
 }
 
 // handle creates a new PLZ TestRun from the given test run id. The context is

--- a/pkg/plz/worker.go
+++ b/pkg/plz/worker.go
@@ -3,8 +3,6 @@ package plz
 import (
 	"context"
 	"fmt"
-	"slices"
-	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/grafana/k6-operator/api/v1alpha1"
@@ -163,6 +161,9 @@ func (w *PLZWorker) createTemplate(plz *v1alpha1.PrivateLoadZone) {
 	}
 }
 
+// the --log-output argument of PLZ runners; also used in unit tests
+const plzLogOutputFormat = `--log-output=loki=https://cloudlogs.k6.io/api/v1/push,label.lz=%s,label.test_run_id=%s,header.Authorization=Token $(K6_CLOUD_TOKEN)`
+
 // complete modifies tr with data from trData, which is specific for this test run.
 func (w *PLZWorker) complete(tr *v1alpha1.TestRun, trData *cloud.TestRunData) {
 	tr.Name = testrun.PLZTestName(trData.TestRunID())
@@ -182,17 +183,14 @@ func (w *PLZWorker) complete(tr *v1alpha1.TestRun, trData *cloud.TestRunData) {
 	tr.Spec.TestRunID = trData.TestRunID()
 
 	// Building the argument list to k6.
-	args := []string{
-		"--out cloud",
-		trData.TagArgs,
-		"--no-thresholds",
-		fmt.Sprintf(`--log-output=loki=https://cloudlogs.k6.io/api/v1/push,label.lz=%s,label.test_run_id=%s,header.Authorization="Token $(K6_CLOUD_TOKEN)"`, w.plz.Name, trData.TestRunID()),
-		trData.EnvArgs,
-	}
+	args := []string{"--out", "cloud"}
+	args = append(args, trData.TagArgs...)
+	args = append(args, "--no-thresholds")
+	args = append(args, fmt.Sprintf(plzLogOutputFormat, w.plz.Name, trData.TestRunID()))
+	args = append(args, trData.EnvArgs...)
 	args = append(args, fmt.Sprintf("--include-system-env-vars=%t", trData.IncludeSystemEnvVars))
 
-	args = slices.DeleteFunc(args, func(s string) bool { return s == "" })
-	tr.Spec.Arguments = strings.Join(args, " ")
+	tr.Spec.Args = args
 }
 
 // handle creates a new PLZ TestRun from the given test run id. The context is
@@ -234,6 +232,28 @@ func (w *PLZWorker) handle(ctx context.Context, testRunId string) {
 
 	if err := w.k8sClient.Create(ctx, tr); err != nil {
 		w.logger.Error(err, "Failed to create PLZ test run", "testRunId", testRunId)
+		return
+	}
+
+	// In v1.6.0, k6-operator switches PLZ TestRuns from using .spec.arguments to .spec.args.
+	// On a cluster with an outdated TestRun CRD, .spec.args is silently
+	// pruned as an unknown field (the object modified during Create):
+	// the test would then run without cloud output and the user would see
+	// only a timeout in GCk6 UI. So checking this case here, to fail explicitly instead.
+	// TODO: remove it in a couple of releases.
+	if len(tr.Spec.Args) == 0 {
+		err := fmt.Errorf("TestRun was stored without .spec.args: the TestRun CRD on this cluster is outdated and must be upgraded (see v1.6.0 release notes)")
+		w.logger.Error(err, "Aborting the PLZ test run", "testRunId", testRunId)
+
+		events := cloud.ErrorEvent(cloud.K6OperatorStartError).
+			WithDetail("k6-operator: PLZ is misconfigured (outdated TestRun CRD); upgrade the k6-operator CRDs").
+			WithAbort()
+		cloud.SendTestRunEvents(w.poller.Client, testRunId, w.logger, events)
+
+		if err := w.k8sClient.Delete(ctx, tr); err != nil {
+			w.logger.Error(err, "Failed to delete the incomplete PLZ test run", "testRunId", testRunId)
+		}
+		return
 	}
 
 	w.logger.Info("Created new test run", "testRunId", testRunId)

--- a/pkg/plz/worker.go
+++ b/pkg/plz/worker.go
@@ -3,8 +3,6 @@ package plz
 import (
 	"context"
 	"fmt"
-	"slices"
-	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/grafana/k6-operator/api/v1alpha1"
@@ -182,17 +180,16 @@ func (w *PLZWorker) complete(tr *v1alpha1.TestRun, trData *cloud.TestRunData) {
 	tr.Spec.TestRunID = trData.TestRunID()
 
 	// Building the argument list to k6.
-	args := []string{
-		"--out cloud",
-		trData.TagArgs,
-		"--no-thresholds",
-		fmt.Sprintf(`--log-output=loki=https://cloudlogs.k6.io/api/v1/push,label.lz=%s,label.test_run_id=%s,header.Authorization="Token $(K6_CLOUD_TOKEN)"`, w.plz.Name, trData.TestRunID()),
-		trData.EnvArgs,
-	}
+	args := []string{"--out", "cloud"}
+	args = append(args, trData.TagArgs...)
+	args = append(args, "--no-thresholds")
+	args = append(args, fmt.Sprintf(
+		`--log-output=loki=https://cloudlogs.k6.io/api/v1/push,label.lz=%s,label.test_run_id=%s,header.Authorization=Token $(K6_CLOUD_TOKEN)`,
+		w.plz.Name, trData.TestRunID()))
+	args = append(args, trData.EnvArgs...)
 	args = append(args, fmt.Sprintf("--include-system-env-vars=%t", trData.IncludeSystemEnvVars))
 
-	args = slices.DeleteFunc(args, func(s string) bool { return s == "" })
-	tr.Spec.Arguments = strings.Join(args, " ")
+	tr.Spec.Args = args
 }
 
 // handle creates a new PLZ TestRun from the given test run id. The context is

--- a/pkg/plz/worker_test.go
+++ b/pkg/plz/worker_test.go
@@ -69,6 +69,17 @@ func Test_complete_correctDefinitionOfTestRun(t *testing.T) {
 	// The following are the definitions that
 	// are expected from PLZ worker now.
 
+	// plzArgs builds the exact argv the worker is expected to produce.
+	plzArgs := func(tagArgs []string, testRunID string, envArgs []string, includeSysEnvVars bool) []string {
+		args := []string{"--out", "cloud"}
+		args = append(args, tagArgs...)
+		args = append(args, "--no-thresholds", fmt.Sprintf(
+			`--log-output=loki=https://cloudlogs.k6.io/api/v1/push,label.lz=,label.test_run_id=%s,header.Authorization=Token $(K6_CLOUD_TOKEN)`,
+			testRunID))
+		args = append(args, envArgs...)
+		return append(args, fmt.Sprintf("--include-system-env-vars=%t", includeSysEnvVars))
+	}
+
 	var (
 		mainIngest = "https://ingest.k6.io"
 
@@ -105,7 +116,7 @@ func Test_complete_correctDefinitionOfTestRun(t *testing.T) {
 				},
 				Parallelism: int32(0),
 				Separate:    false,
-				Arguments:   `--out cloud --no-thresholds --log-output=loki=https://cloudlogs.k6.io/api/v1/push,label.lz=,label.test_run_id=0,header.Authorization="Token $(K6_CLOUD_TOKEN)" --include-system-env-vars=false`,
+				Args:        plzArgs(nil, "0", nil, false),
 				Cleanup:     v1alpha1.Cleanup("post"),
 
 				TestRunID: "0",
@@ -171,14 +182,19 @@ func Test_complete_correctDefinitionOfTestRun(t *testing.T) {
 		includeSysEnvVarsTestRun = defaultTestRun //nolint:ineffassign
 	)
 
-	cloudExecEnvArgs := ` -e K6_CLOUDRUN_DISTRIBUTION="${K6_CLOUD_OPERATOR_ENV_0}"` +
-		` -e K6_CLOUDRUN_LOAD_ZONE="${K6_CLOUD_OPERATOR_ENV_1}"` +
-		` -e K6_CLOUDRUN_TEST_RUN_ID="${K6_CLOUD_OPERATOR_ENV_2}"`
-	cloudEnvVarsEnvArgs := ` -e ENV="${K6_CLOUD_OPERATOR_ENV_0}"` +
-		` -e K6_CLOUDRUN_DISTRIBUTION="${K6_CLOUD_OPERATOR_ENV_1}"` +
-		` -e K6_CLOUDRUN_LOAD_ZONE="${K6_CLOUD_OPERATOR_ENV_2}"` +
-		` -e K6_CLOUDRUN_TEST_RUN_ID="${K6_CLOUD_OPERATOR_ENV_3}"` +
-		` -e foo="${K6_CLOUD_OPERATOR_ENV_4}"`
+	someLZTagArgs := []string{"--tag", "load_zone=some-zone"}
+	cloudExecEnvArgs := []string{
+		"-e", "K6_CLOUDRUN_DISTRIBUTION=some-label",
+		"-e", "K6_CLOUDRUN_LOAD_ZONE=some-zone",
+		"-e", "K6_CLOUDRUN_TEST_RUN_ID=6543",
+	}
+	cloudEnvVarsEnvArgs := []string{
+		"-e", "ENV=VALUE",
+		"-e", "K6_CLOUDRUN_DISTRIBUTION=some-label",
+		"-e", "K6_CLOUDRUN_LOAD_ZONE=some-zone",
+		"-e", "K6_CLOUDRUN_TEST_RUN_ID=6543",
+		"-e", "foo=bar",
+	}
 
 	// populate TestRuns for different test cases
 
@@ -195,19 +211,11 @@ func Test_complete_correctDefinitionOfTestRun(t *testing.T) {
 	cloudFieldsTestRun = requiredFieldsTestRun // build up on top of required field case
 	cloudFieldsTestRun.Name = testrun.PLZTestName(fmt.Sprintf("%d", someTestRunID))
 	cloudFieldsTestRun.Spec.TestRunID = fmt.Sprintf("%d", someTestRunID)
-	cloudFieldsTestRun.Spec.Arguments = strings.Replace(requiredFieldsTestRun.Spec.Arguments,
-		"test_run_id=0",
-		fmt.Sprintf("test_run_id=%d", someTestRunID),
-		1)
-	cloudFieldsTestRun.Spec.Arguments = strings.Replace(cloudFieldsTestRun.Spec.Arguments,
-		`--out cloud --no-thresholds`,
-		`--out cloud --tag load_zone=some-zone --no-thresholds`,
-		1)
-	// env args are inserted before the --include-system-env-vars flag
-	cloudFieldsTestRun.Spec.Arguments = strings.Replace(cloudFieldsTestRun.Spec.Arguments,
-		" --include-system-env-vars",
-		cloudExecEnvArgs+" --include-system-env-vars",
-		1)
+	cloudFieldsTestRun.Spec.Args = plzArgs(
+		someLZTagArgs,
+		fmt.Sprintf("%d", someTestRunID),
+		cloudExecEnvArgs,
+		false)
 	cloudFieldsTestRun.Spec.Runner.InitContainers = []v1alpha1.InitContainer{
 		containers.NewS3InitContainer(
 			someArchiveURL,
@@ -221,16 +229,14 @@ func Test_complete_correctDefinitionOfTestRun(t *testing.T) {
 	cloudFieldsTestRun.Spec.Runner.Env = append(
 		cloudFieldsTestRun.Spec.Runner.Env,
 		corev1.EnvVar{Name: "K6_CLOUD_HOST", Value: mainIngest},
-		corev1.EnvVar{Name: "K6_CLOUD_OPERATOR_ENV_0", Value: "some-label"},
-		corev1.EnvVar{Name: "K6_CLOUD_OPERATOR_ENV_1", Value: "some-zone"},
-		corev1.EnvVar{Name: "K6_CLOUD_OPERATOR_ENV_2", Value: "6543"},
 	)
 
 	cloudEnvVarsTestRun = cloudFieldsTestRun // build up on top of cloud fields case
-	cloudEnvVarsTestRun.Spec.Arguments = strings.Replace(cloudEnvVarsTestRun.Spec.Arguments,
-		cloudExecEnvArgs,
+	cloudEnvVarsTestRun.Spec.Args = plzArgs(
+		someLZTagArgs,
+		fmt.Sprintf("%d", someTestRunID),
 		cloudEnvVarsEnvArgs,
-		1)
+		false)
 	cloudEnvVarsTestRun.Spec.Runner.Env = []corev1.EnvVar{
 		{Name: "K6_USER_AGENT", Value: "Grafana Cloud k6"},
 	}
@@ -241,11 +247,6 @@ func Test_complete_correctDefinitionOfTestRun(t *testing.T) {
 	cloudEnvVarsTestRun.Spec.Runner.Env = append(
 		cloudEnvVarsTestRun.Spec.Runner.Env,
 		corev1.EnvVar{Name: "K6_CLOUD_HOST", Value: mainIngest},
-		corev1.EnvVar{Name: "K6_CLOUD_OPERATOR_ENV_0", Value: "VALUE"},
-		corev1.EnvVar{Name: "K6_CLOUD_OPERATOR_ENV_1", Value: "some-label"},
-		corev1.EnvVar{Name: "K6_CLOUD_OPERATOR_ENV_2", Value: "some-zone"},
-		corev1.EnvVar{Name: "K6_CLOUD_OPERATOR_ENV_3", Value: "6543"},
-		corev1.EnvVar{Name: "K6_CLOUD_OPERATOR_ENV_4", Value: "bar"},
 	)
 
 	podTemplateTolerationsTestRun = requiredFieldsTestRun
@@ -269,10 +270,11 @@ func Test_complete_correctDefinitionOfTestRun(t *testing.T) {
 	podTemplateAllTestRun.Spec.Starter.SecurityContext = somePodSecCtx
 
 	includeSysEnvVarsTestRun = cloudFieldsTestRun
-	includeSysEnvVarsTestRun.Spec.Arguments = strings.Replace(cloudFieldsTestRun.Spec.Arguments,
-		"--include-system-env-vars=false",
-		"--include-system-env-vars=true",
-		1)
+	includeSysEnvVarsTestRun.Spec.Args = plzArgs(
+		someLZTagArgs,
+		fmt.Sprintf("%d", someTestRunID),
+		cloudExecEnvArgs,
+		true)
 
 	someSecretsConfig := &cloud.SecretsConfig{
 		Endpoint:     "https://api.k6.io/provisioning/v1/test_runs/6543/decrypt_secret?name={key}",
@@ -289,9 +291,6 @@ func Test_complete_correctDefinitionOfTestRun(t *testing.T) {
 		corev1.EnvVar{Name: "K6_SECRET_SOURCE_URL_RESPONSE_PATH", Value: someSecretsConfig.ResponsePath},
 		corev1.EnvVar{Name: "K6_SECRET_SOURCE_URL_HEADER_AUTHORIZATION", Value: "Bearer " + someTestRunToken},
 		corev1.EnvVar{Name: "K6_CLOUD_HOST", Value: mainIngest},
-		corev1.EnvVar{Name: "K6_CLOUD_OPERATOR_ENV_0", Value: "some-label"},
-		corev1.EnvVar{Name: "K6_CLOUD_OPERATOR_ENV_1", Value: "some-zone"},
-		corev1.EnvVar{Name: "K6_CLOUD_OPERATOR_ENV_2", Value: "6543"},
 	)
 
 	testCases := []struct {
@@ -550,6 +549,54 @@ func Test_complete_correctDefinitionOfTestRun(t *testing.T) {
 				t.Errorf("worker.complete returned unexpected data, diff: %s", diff)
 			}
 		})
+	}
+}
+
+func Test_complete_argsAreExact(t *testing.T) {
+	c, _ := client.New(nil, client.Options{})
+	worker := NewPLZWorker(&v1alpha1.PrivateLoadZone{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-plz"},
+	}, "token", c, logr.Logger{})
+
+	trData := &cloud.TestRunData{
+		TestRunId:      42,
+		LZDistribution: cloud.LZDistribution{"label": cloud.Distribution{LoadZone: "zone", Percent: 100}},
+		LZConfig: cloud.LZConfig{
+			Environment: map[string]string{"GREETING": "hello world"},
+		},
+	}
+	if err := trData.Preprocess(); err != nil {
+		t.Fatalf("Preprocess errored: %v", err)
+	}
+
+	tr := worker.template.Create()
+	worker.complete(tr, trData)
+
+	if tr.Spec.Arguments != "" {
+		t.Errorf("legacy Arguments should stay empty, got: %q", tr.Spec.Arguments)
+	}
+
+	expected := []string{
+		"--out", "cloud",
+		"--tag", "load_zone=zone",
+		"--no-thresholds",
+		`--log-output=loki=https://cloudlogs.k6.io/api/v1/push,label.lz=my-plz,label.test_run_id=42,header.Authorization=Token $(K6_CLOUD_TOKEN)`,
+		"-e", "GREETING=hello world",
+		"-e", "K6_CLOUDRUN_DISTRIBUTION=label",
+		"-e", "K6_CLOUDRUN_LOAD_ZONE=zone",
+		"-e", "K6_CLOUDRUN_TEST_RUN_ID=42",
+		"--include-system-env-vars=false",
+	}
+	if diff := deep.Equal(tr.Spec.Args, expected); diff != nil {
+		t.Errorf("Spec.Args diff: %s", diff)
+	}
+
+	// Nothing parses quotes on this path, so a literal one would end up inside
+	// the Authorization header value.
+	for _, arg := range tr.Spec.Args {
+		if strings.Contains(arg, `"`) {
+			t.Errorf("argument should carry no literal quote: %q", arg)
+		}
 	}
 }
 

--- a/pkg/plz/worker_test.go
+++ b/pkg/plz/worker_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	rand "math/rand/v2"
 	"runtime"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -69,6 +68,15 @@ func Test_complete_correctDefinitionOfTestRun(t *testing.T) {
 	// The following are the definitions that
 	// are expected from PLZ worker now.
 
+	// plzArgs builds the exact argv the worker is expected to produce.
+	plzArgs := func(plzName string, tagArgs []string, testRunID string, envArgs []string, includeSysEnvVars bool) []string {
+		args := []string{"--out", "cloud"}
+		args = append(args, tagArgs...)
+		args = append(args, "--no-thresholds", fmt.Sprintf(plzLogOutputFormat, plzName, testRunID))
+		args = append(args, envArgs...)
+		return append(args, fmt.Sprintf("--include-system-env-vars=%t", includeSysEnvVars))
+	}
+
 	var (
 		mainIngest = "https://ingest.k6.io"
 
@@ -105,7 +113,7 @@ func Test_complete_correctDefinitionOfTestRun(t *testing.T) {
 				},
 				Parallelism: int32(0),
 				Separate:    false,
-				Arguments:   `--out cloud --no-thresholds --log-output=loki=https://cloudlogs.k6.io/api/v1/push,label.lz=,label.test_run_id=0,header.Authorization="Token $(K6_CLOUD_TOKEN)" --include-system-env-vars=false`,
+				Args:        plzArgs("", nil, "0", nil, false),
 				Cleanup:     v1alpha1.Cleanup("post"),
 
 				TestRunID: "0",
@@ -121,12 +129,13 @@ func Test_complete_correctDefinitionOfTestRun(t *testing.T) {
 			corev1.ResourceCPU:    resource.MustParse("200m"),
 			corev1.ResourceMemory: resource.MustParse("1G"),
 		}
+		somePLZName     = "my-plz"
 		someTestRunID   = 6543
 		someRunnerImage = "grafana/k6:0.52.0"
 		someInstances   = 10
 		someArchiveURL  = "https://foo.s3.amazonaws.com"
 		someEnvVars     = map[string]string{
-			"ENV": "VALUE",
+			"ENV": "hello world",
 			"foo": "bar",
 		}
 		someLZDistribution = cloud.LZDistribution{
@@ -171,14 +180,19 @@ func Test_complete_correctDefinitionOfTestRun(t *testing.T) {
 		includeSysEnvVarsTestRun = defaultTestRun //nolint:ineffassign
 	)
 
-	cloudExecEnvArgs := ` -e K6_CLOUDRUN_DISTRIBUTION="${K6_CLOUD_OPERATOR_ENV_0}"` +
-		` -e K6_CLOUDRUN_LOAD_ZONE="${K6_CLOUD_OPERATOR_ENV_1}"` +
-		` -e K6_CLOUDRUN_TEST_RUN_ID="${K6_CLOUD_OPERATOR_ENV_2}"`
-	cloudEnvVarsEnvArgs := ` -e ENV="${K6_CLOUD_OPERATOR_ENV_0}"` +
-		` -e K6_CLOUDRUN_DISTRIBUTION="${K6_CLOUD_OPERATOR_ENV_1}"` +
-		` -e K6_CLOUDRUN_LOAD_ZONE="${K6_CLOUD_OPERATOR_ENV_2}"` +
-		` -e K6_CLOUDRUN_TEST_RUN_ID="${K6_CLOUD_OPERATOR_ENV_3}"` +
-		` -e foo="${K6_CLOUD_OPERATOR_ENV_4}"`
+	someLZTagArgs := []string{"--tag", "load_zone=some-zone"}
+	cloudExecEnvArgs := []string{
+		"-e", "K6_CLOUDRUN_DISTRIBUTION=some-label",
+		"-e", "K6_CLOUDRUN_LOAD_ZONE=some-zone",
+		"-e", "K6_CLOUDRUN_TEST_RUN_ID=6543",
+	}
+	cloudEnvVarsEnvArgs := []string{
+		"-e", "ENV=hello world",
+		"-e", "K6_CLOUDRUN_DISTRIBUTION=some-label",
+		"-e", "K6_CLOUDRUN_LOAD_ZONE=some-zone",
+		"-e", "K6_CLOUDRUN_TEST_RUN_ID=6543",
+		"-e", "foo=bar",
+	}
 
 	// populate TestRuns for different test cases
 
@@ -195,19 +209,12 @@ func Test_complete_correctDefinitionOfTestRun(t *testing.T) {
 	cloudFieldsTestRun = requiredFieldsTestRun // build up on top of required field case
 	cloudFieldsTestRun.Name = testrun.PLZTestName(fmt.Sprintf("%d", someTestRunID))
 	cloudFieldsTestRun.Spec.TestRunID = fmt.Sprintf("%d", someTestRunID)
-	cloudFieldsTestRun.Spec.Arguments = strings.Replace(requiredFieldsTestRun.Spec.Arguments,
-		"test_run_id=0",
-		fmt.Sprintf("test_run_id=%d", someTestRunID),
-		1)
-	cloudFieldsTestRun.Spec.Arguments = strings.Replace(cloudFieldsTestRun.Spec.Arguments,
-		`--out cloud --no-thresholds`,
-		`--out cloud --tag load_zone=some-zone --no-thresholds`,
-		1)
-	// env args are inserted before the --include-system-env-vars flag
-	cloudFieldsTestRun.Spec.Arguments = strings.Replace(cloudFieldsTestRun.Spec.Arguments,
-		" --include-system-env-vars",
-		cloudExecEnvArgs+" --include-system-env-vars",
-		1)
+	cloudFieldsTestRun.Spec.Args = plzArgs(
+		"",
+		someLZTagArgs,
+		fmt.Sprintf("%d", someTestRunID),
+		cloudExecEnvArgs,
+		false)
 	cloudFieldsTestRun.Spec.Runner.InitContainers = []v1alpha1.InitContainer{
 		containers.NewS3InitContainer(
 			someArchiveURL,
@@ -221,16 +228,15 @@ func Test_complete_correctDefinitionOfTestRun(t *testing.T) {
 	cloudFieldsTestRun.Spec.Runner.Env = append(
 		cloudFieldsTestRun.Spec.Runner.Env,
 		corev1.EnvVar{Name: "K6_CLOUD_HOST", Value: mainIngest},
-		corev1.EnvVar{Name: "K6_CLOUD_OPERATOR_ENV_0", Value: "some-label"},
-		corev1.EnvVar{Name: "K6_CLOUD_OPERATOR_ENV_1", Value: "some-zone"},
-		corev1.EnvVar{Name: "K6_CLOUD_OPERATOR_ENV_2", Value: "6543"},
 	)
 
 	cloudEnvVarsTestRun = cloudFieldsTestRun // build up on top of cloud fields case
-	cloudEnvVarsTestRun.Spec.Arguments = strings.Replace(cloudEnvVarsTestRun.Spec.Arguments,
-		cloudExecEnvArgs,
+	cloudEnvVarsTestRun.Spec.Args = plzArgs(
+		somePLZName,
+		someLZTagArgs,
+		fmt.Sprintf("%d", someTestRunID),
 		cloudEnvVarsEnvArgs,
-		1)
+		false)
 	cloudEnvVarsTestRun.Spec.Runner.Env = []corev1.EnvVar{
 		{Name: "K6_USER_AGENT", Value: "Grafana Cloud k6"},
 	}
@@ -241,11 +247,6 @@ func Test_complete_correctDefinitionOfTestRun(t *testing.T) {
 	cloudEnvVarsTestRun.Spec.Runner.Env = append(
 		cloudEnvVarsTestRun.Spec.Runner.Env,
 		corev1.EnvVar{Name: "K6_CLOUD_HOST", Value: mainIngest},
-		corev1.EnvVar{Name: "K6_CLOUD_OPERATOR_ENV_0", Value: "VALUE"},
-		corev1.EnvVar{Name: "K6_CLOUD_OPERATOR_ENV_1", Value: "some-label"},
-		corev1.EnvVar{Name: "K6_CLOUD_OPERATOR_ENV_2", Value: "some-zone"},
-		corev1.EnvVar{Name: "K6_CLOUD_OPERATOR_ENV_3", Value: "6543"},
-		corev1.EnvVar{Name: "K6_CLOUD_OPERATOR_ENV_4", Value: "bar"},
 	)
 
 	podTemplateTolerationsTestRun = requiredFieldsTestRun
@@ -269,10 +270,12 @@ func Test_complete_correctDefinitionOfTestRun(t *testing.T) {
 	podTemplateAllTestRun.Spec.Starter.SecurityContext = somePodSecCtx
 
 	includeSysEnvVarsTestRun = cloudFieldsTestRun
-	includeSysEnvVarsTestRun.Spec.Arguments = strings.Replace(cloudFieldsTestRun.Spec.Arguments,
-		"--include-system-env-vars=false",
-		"--include-system-env-vars=true",
-		1)
+	includeSysEnvVarsTestRun.Spec.Args = plzArgs(
+		"",
+		someLZTagArgs,
+		fmt.Sprintf("%d", someTestRunID),
+		cloudExecEnvArgs,
+		true)
 
 	someSecretsConfig := &cloud.SecretsConfig{
 		Endpoint:     "https://api.k6.io/provisioning/v1/test_runs/6543/decrypt_secret?name={key}",
@@ -289,9 +292,6 @@ func Test_complete_correctDefinitionOfTestRun(t *testing.T) {
 		corev1.EnvVar{Name: "K6_SECRET_SOURCE_URL_RESPONSE_PATH", Value: someSecretsConfig.ResponsePath},
 		corev1.EnvVar{Name: "K6_SECRET_SOURCE_URL_HEADER_AUTHORIZATION", Value: "Bearer " + someTestRunToken},
 		corev1.EnvVar{Name: "K6_CLOUD_HOST", Value: mainIngest},
-		corev1.EnvVar{Name: "K6_CLOUD_OPERATOR_ENV_0", Value: "some-label"},
-		corev1.EnvVar{Name: "K6_CLOUD_OPERATOR_ENV_1", Value: "some-zone"},
-		corev1.EnvVar{Name: "K6_CLOUD_OPERATOR_ENV_2", Value: "6543"},
 	)
 
 	testCases := []struct {
@@ -366,6 +366,7 @@ func Test_complete_correctDefinitionOfTestRun(t *testing.T) {
 		{
 			name: "cloud fields with env vars",
 			plz: &v1alpha1.PrivateLoadZone{
+				ObjectMeta: metav1.ObjectMeta{Name: somePLZName},
 				Spec: v1alpha1.PrivateLoadZoneSpec{
 					Token: someToken,
 					Resources: corev1.ResourceRequirements{

--- a/pkg/plz/worker_test.go
+++ b/pkg/plz/worker_test.go
@@ -64,18 +64,66 @@ func Test_StopFactory_idempotent(t *testing.T) {
 	}
 }
 
+func Test_plzk6Args(t *testing.T) {
+	tests := []struct {
+		name      string
+		plzName   string
+		testRunID string
+		trData    *cloud.TestRunData
+		expected  []string
+	}{
+		{
+			name:      "default, hard-coded values",
+			plzName:   "",
+			testRunID: "0",
+			trData:    &cloud.TestRunData{},
+			expected: []string{
+				"--out",
+				"cloud",
+				"--no-thresholds",
+				"--log-output=loki=https://cloudlogs.k6.io/api/v1/push,label.lz=,label.test_run_id=0,header.Authorization=Token $(K6_CLOUD_TOKEN)",
+				"--include-system-env-vars=false",
+			},
+		},
+		{
+			name:      "arguments from preprocessing",
+			plzName:   "private-zone",
+			testRunID: "1234",
+			trData: &cloud.TestRunData{
+				TagArgs: []string{"--tag", "load_zone=private-zone", "--tag", "team=operator"},
+				EnvArgs: []string{"-e", "K6_CLOUDRUN_TEST_RUN_ID=1234"},
+				LZConfig: cloud.LZConfig{
+					CLIArgs: cloud.CLIArgs{IncludeSystemEnvVars: true},
+				},
+			},
+			expected: []string{
+				"--out",
+				"cloud",
+				"--tag",
+				"load_zone=private-zone",
+				"--tag",
+				"team=operator",
+				"--no-thresholds",
+				"--log-output=loki=https://cloudlogs.k6.io/api/v1/push,label.lz=private-zone,label.test_run_id=1234,header.Authorization=Token $(K6_CLOUD_TOKEN)",
+				"-e",
+				"K6_CLOUDRUN_TEST_RUN_ID=1234",
+				"--include-system-env-vars=true",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if diff := deep.Equal(test.expected, plzk6Args(test.plzName, test.testRunID, test.trData)); diff != nil {
+				t.Error(diff)
+			}
+		})
+	}
+}
+
 func Test_complete_correctDefinitionOfTestRun(t *testing.T) {
 	// The following are the definitions that
 	// are expected from PLZ worker now.
-
-	// plzArgs builds the exact argv the worker is expected to produce.
-	plzArgs := func(plzName string, tagArgs []string, testRunID string, envArgs []string, includeSysEnvVars bool) []string {
-		args := []string{"--out", "cloud"}
-		args = append(args, tagArgs...)
-		args = append(args, "--no-thresholds", fmt.Sprintf(plzLogOutputFormat, plzName, testRunID))
-		args = append(args, envArgs...)
-		return append(args, fmt.Sprintf("--include-system-env-vars=%t", includeSysEnvVars))
-	}
 
 	var (
 		mainIngest = "https://ingest.k6.io"
@@ -113,7 +161,7 @@ func Test_complete_correctDefinitionOfTestRun(t *testing.T) {
 				},
 				Parallelism: int32(0),
 				Separate:    false,
-				Args:        plzArgs("", nil, "0", nil, false),
+				Args:        plzk6Args("", "0", &cloud.TestRunData{}),
 				Cleanup:     v1alpha1.Cleanup("post"),
 
 				TestRunID: "0",
@@ -209,12 +257,13 @@ func Test_complete_correctDefinitionOfTestRun(t *testing.T) {
 	cloudFieldsTestRun = requiredFieldsTestRun // build up on top of required field case
 	cloudFieldsTestRun.Name = testrun.PLZTestName(fmt.Sprintf("%d", someTestRunID))
 	cloudFieldsTestRun.Spec.TestRunID = fmt.Sprintf("%d", someTestRunID)
-	cloudFieldsTestRun.Spec.Args = plzArgs(
+	cloudFieldsTestRun.Spec.Args = plzk6Args(
 		"",
-		someLZTagArgs,
 		fmt.Sprintf("%d", someTestRunID),
-		cloudExecEnvArgs,
-		false)
+		&cloud.TestRunData{
+			TagArgs: someLZTagArgs,
+			EnvArgs: cloudExecEnvArgs,
+		})
 	cloudFieldsTestRun.Spec.Runner.InitContainers = []v1alpha1.InitContainer{
 		containers.NewS3InitContainer(
 			someArchiveURL,
@@ -231,12 +280,13 @@ func Test_complete_correctDefinitionOfTestRun(t *testing.T) {
 	)
 
 	cloudEnvVarsTestRun = cloudFieldsTestRun // build up on top of cloud fields case
-	cloudEnvVarsTestRun.Spec.Args = plzArgs(
+	cloudEnvVarsTestRun.Spec.Args = plzk6Args(
 		somePLZName,
-		someLZTagArgs,
 		fmt.Sprintf("%d", someTestRunID),
-		cloudEnvVarsEnvArgs,
-		false)
+		&cloud.TestRunData{
+			TagArgs: someLZTagArgs,
+			EnvArgs: cloudEnvVarsEnvArgs,
+		})
 	cloudEnvVarsTestRun.Spec.Runner.Env = []corev1.EnvVar{
 		{Name: "K6_USER_AGENT", Value: "Grafana Cloud k6"},
 	}
@@ -270,12 +320,14 @@ func Test_complete_correctDefinitionOfTestRun(t *testing.T) {
 	podTemplateAllTestRun.Spec.Starter.SecurityContext = somePodSecCtx
 
 	includeSysEnvVarsTestRun = cloudFieldsTestRun
-	includeSysEnvVarsTestRun.Spec.Args = plzArgs(
+	includeSysEnvVarsTestRun.Spec.Args = plzk6Args(
 		"",
-		someLZTagArgs,
 		fmt.Sprintf("%d", someTestRunID),
-		cloudExecEnvArgs,
-		true)
+		&cloud.TestRunData{
+			TagArgs:  someLZTagArgs,
+			EnvArgs:  cloudExecEnvArgs,
+			LZConfig: cloud.LZConfig{CLIArgs: cloud.CLIArgs{IncludeSystemEnvVars: true}},
+		})
 
 	someSecretsConfig := &cloud.SecretsConfig{
 		Endpoint:     "https://api.k6.io/provisioning/v1/test_runs/6543/decrypt_secret?name={key}",

--- a/pkg/resources/jobs/initializer.go
+++ b/pkg/resources/jobs/initializer.go
@@ -3,6 +3,7 @@ package jobs
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/grafana/k6-operator/api/v1alpha1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -12,8 +13,8 @@ import (
 
 const initializerMissingK6Message = `level=error msg="k6 executable not found in PATH; initializer image must contain k6"`
 
-// NewInitializerJob builds a template used to initializefor creating a starter job
-func NewInitializerJob(k6 *v1alpha1.TestRun, argLine string) (*batchv1.Job, error) {
+// NewInitializerJob builds a template used to create an initializer job
+func NewInitializerJob(k6 *v1alpha1.TestRun, archiveArgs []string) (*batchv1.Job, error) {
 	script, err := k6.GetSpec().ParseScript()
 	if err != nil {
 		return nil, err
@@ -57,26 +58,18 @@ func NewInitializerJob(k6 *v1alpha1.TestRun, argLine string) (*batchv1.Job, erro
 		automountServiceAccountToken, _ = strconv.ParseBool(k6.GetSpec().Initializer.AutomountServiceAccountToken)
 	}
 
-	// NOTE: only .env are passed to k6 CLI, not .envFrom
-	// This is esp. relevant for the cloud output test where
-	// duration of the test may depend on env var values. IOW,
-	// these env vars must always be passed in cloud output mode.
-	//
-	// The value of env var is expanded by Shell inside quotes.
-	// This keeps values with spaces, quotes, `$(...)` etc. intact.
-	// It also passes the actual values of Secret-backed env vars (ValueFrom).
-	var envVarString string
-	for _, ev := range k6.GetSpec().Initializer.Env {
-		envVarString += fmt.Sprintf(` -e %s="${%s}"`, ev.Name, ev.Name)
-	}
-
 	var (
 		// k6 allows to run archive command on archives too so type of file here doesn't matter
 		scriptName  = script.FullName()
 		archiveName = fmt.Sprintf("/tmp/%s.archived.tar", script.Filename)
 	)
 	istioCommand, istioEnabled := newIstioCommand(k6.GetSpec().Scuttle.Enabled, []string{"sh", "-c"})
-	command := append(istioCommand, newInitializerCommand(scriptName, archiveName, envVarString, argLine))
+
+	// NOTE: only .env are passed to k6 CLI, not .envFrom.
+	// This is esp. relevant for the cloud output test where
+	// duration of the test may depend on env var values.
+	command := append(istioCommand,
+		newInitializerCommand(scriptName, archiveName, k6.GetSpec().Initializer.Env, archiveArgs, k6.GetSpec().NeedsShellCmd())...)
 
 	env := append(newIstioEnvVar(k6.GetSpec().Scuttle, istioEnabled), k6.GetSpec().Initializer.Env...)
 
@@ -141,26 +134,34 @@ func NewInitializerJob(k6 *v1alpha1.TestRun, argLine string) (*batchv1.Job, erro
 	return job, nil
 }
 
-func newInitializerCommand(scriptName, archiveName, envVarString, argLine string) string {
-	// There can be several scenarios from k6 command here:
-	// a) script is correct and `k6 inspect` outputs JSON;
-	// b) script is partially incorrect and `k6` outputs a warning log message and
-	// then a JSON;
-	// c) script is incorrect and `k6` outputs an error log message;
-	// d) k6 binary is missing;
-	// e) k6 binary exists but is corrupted or otherwise unexecutable.
-	//
-	// Warnings at this point are not necessary (warning messages will re-appear in
-	// runner's logs and the user can see them there) so we need a pure JSON here,
-	// without any additional messages in cases a) and b). In cases c) - e), output
-	// should contain an error message and the Job is to exit with non-zero code.
-	//
-	// Due to some peculiarities of k6 logging, to achieve the above behaviour,
-	// we need to use a workaround to store all log messages in temp file while
-	// printing JSON as usual. Then parse temp file only for errors, ignoring
-	// any other log messages.
-	// Related: https://github.com/grafana/k6-docs/issues/877
-
+// initializerShellScript renders the initializer's shell program.
+// Parameters:
+//   - setup: executed before k6 invocation; used by .spec.args flow.
+//   - archiveRef: where k6 archive is stored.
+//   - archiveCmd: the `k6 archive` command.
+//
+// About the log handling: there can be several scenarios from the k6 command:
+// a) script is correct and `k6 inspect` outputs JSON;
+// b) script is partially incorrect and `k6` outputs a warning log message and
+// then a JSON;
+// c) script is incorrect and `k6` outputs an error log message;
+// d) k6 binary is missing;
+// e) k6 binary exists but is corrupted or otherwise unexecutable.
+//
+// Warnings at this point are not necessary (warning messages will re-appear in
+// runner's logs and the user can see them there) so we need a pure JSON here,
+// without any additional messages in cases a) and b). In cases c) - e), output
+// should contain an error message and the Job is to exit with non-zero code.
+//
+// Due to some peculiarities of k6 logging, to achieve the above behaviour,
+// we need to use a workaround to store all log messages in temp file while
+// printing JSON as usual. Then parse temp file only for errors, ignoring
+// any other log messages.
+// Related: https://github.com/grafana/k6-docs/issues/877
+func initializerShellScript(setup, archiveRef, archiveCmd string) string {
+	if setup != "" {
+		setup += "\n"
+	}
 	return fmt.Sprintf(
 		`if ! command -v k6 >/dev/null 2>&1; then
   echo '%[1]s' >&2
@@ -168,12 +169,12 @@ func newInitializerCommand(scriptName, archiveName, envVarString, argLine string
 fi
 
 logs=/tmp/k6logs
-
+%[2]s
 if ! mkdir -p "$(dirname %[3]s)"; then
   exit 1
 fi
 
-if ! k6 archive %[2]s%[4]s -O %[3]s %[5]s 2> "${logs}"; then
+if ! %[4]s 2> "${logs}"; then
   cat "${logs}"
   exit 1
 fi
@@ -187,9 +188,51 @@ if grep 'level.*error' "${logs}"; then
   exit 1
 fi`,
 		initializerMissingK6Message,
-		scriptName,
-		archiveName,
-		envVarString,
-		argLine,
+		setup,
+		archiveRef,
+		archiveCmd,
 	)
+}
+
+// also referenced by the unit tests
+var initializerScript = initializerShellScript("archive=\"$1\"\nshift", `"${archive}"`, `"$@"`)
+
+// newInitializerCommand builds the `sh -c` arguments that run the initializer.
+// As the necessary step, it builds the archive command from the arguments.
+// The command can take two forms:
+//   - with .spec.arguments, via shell interpreter `sh -c` and concat of arguments.
+//     The env var values are passed as ${..} to be expanded by Shell.
+//   - with .spec.args, via shell positional arguments (more correct and safer)
+//     The env var values are passed as $(..) to be expanded by kubelet.
+//
+// Env vars are passed as a ref by name to account for both Value and ValueFrom cases.
+// The function assumes that the env vars are being passed to the container.
+func newInitializerCommand(scriptName, archiveName string, env []corev1.EnvVar, archiveArgs []string, needsShellCmd bool) []string {
+	if needsShellCmd {
+		// .spec.arguments case
+		var envVarString string
+		for _, ev := range env {
+			// Env values are expanded by the shell inside quotes.
+			envVarString += fmt.Sprintf(` -e %s="${%s}"`, ev.Name, ev.Name)
+		}
+
+		// Arguments are joined back verbatim, retaining their original quote
+		// context; `$(NAME)` refs in them are left for kubelet expansion.
+		argLine := strings.Join(archiveArgs, " ")
+
+		archiveCmd := fmt.Sprintf("k6 archive %s%s -O %s %s", scriptName, envVarString, archiveName, argLine)
+		return []string{initializerShellScript("", archiveName, archiveCmd)}
+	}
+
+	// .spec.args case
+	archiveCommand := []string{"k6", "archive", scriptName}
+	for _, ev := range env {
+		archiveCommand = append(archiveCommand, "-e", fmt.Sprintf("%s=$(%s)", ev.Name, ev.Name))
+	}
+	archiveCommand = append(archiveCommand, "-O", archiveName)
+	archiveCommand = append(archiveCommand, archiveArgs...)
+
+	// `sh` is a placeholder for $0 (unused in the script), archive name is $1.
+	command := []string{initializerScript, "sh", archiveName}
+	return append(command, archiveCommand...)
 }

--- a/pkg/resources/jobs/initializer.go
+++ b/pkg/resources/jobs/initializer.go
@@ -3,8 +3,10 @@ package jobs
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/grafana/k6-operator/api/v1alpha1"
+	"github.com/grafana/k6-operator/pkg/types"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -12,8 +14,8 @@ import (
 
 const initializerMissingK6Message = `level=error msg="k6 executable not found in PATH; initializer image must contain k6"`
 
-// NewInitializerJob builds a template used to initializefor creating a starter job
-func NewInitializerJob(k6 *v1alpha1.TestRun, argLine string) (*batchv1.Job, error) {
+// NewInitializerJob builds a template used to create an initializer job
+func NewInitializerJob(k6 *v1alpha1.TestRun, archiveArgs []string) (*batchv1.Job, error) {
 	script, err := k6.GetSpec().ParseScript()
 	if err != nil {
 		return nil, err
@@ -57,26 +59,18 @@ func NewInitializerJob(k6 *v1alpha1.TestRun, argLine string) (*batchv1.Job, erro
 		automountServiceAccountToken, _ = strconv.ParseBool(k6.GetSpec().Initializer.AutomountServiceAccountToken)
 	}
 
-	// NOTE: only .env are passed to k6 CLI, not .envFrom
-	// This is esp. relevant for the cloud output test where
-	// duration of the test may depend on env var values. IOW,
-	// these env vars must always be passed in cloud output mode.
-	//
-	// The value of env var is expanded by Shell inside quotes.
-	// This keeps values with spaces, quotes, `$(...)` etc. intact.
-	// It also passes the actual values of Secret-backed env vars (ValueFrom).
-	var envVarString string
-	for _, ev := range k6.GetSpec().Initializer.Env {
-		envVarString += fmt.Sprintf(` -e %s="${%s}"`, ev.Name, ev.Name)
-	}
-
 	var (
 		// k6 allows to run archive command on archives too so type of file here doesn't matter
 		scriptName  = script.FullName()
 		archiveName = fmt.Sprintf("/tmp/%s.archived.tar", script.Filename)
 	)
 	istioCommand, istioEnabled := newIstioCommand(k6.GetSpec().Scuttle.Enabled, []string{"sh", "-c"})
-	command := append(istioCommand, newInitializerCommand(scriptName, archiveName, envVarString, argLine))
+
+	// NOTE: only .env are passed to k6 CLI, not .envFrom.
+	// This is esp. relevant for the cloud output test where
+	// duration of the test may depend on env var values.
+	command := append(istioCommand,
+		newInitializerCommand(scriptName, archiveName, k6.GetSpec().Initializer.Env, archiveArgs, len(k6.GetSpec().Args) == 0)...)
 
 	env := append(newIstioEnvVar(k6.GetSpec().Scuttle, istioEnabled), k6.GetSpec().Initializer.Env...)
 
@@ -141,26 +135,34 @@ func NewInitializerJob(k6 *v1alpha1.TestRun, argLine string) (*batchv1.Job, erro
 	return job, nil
 }
 
-func newInitializerCommand(scriptName, archiveName, envVarString, argLine string) string {
-	// There can be several scenarios from k6 command here:
-	// a) script is correct and `k6 inspect` outputs JSON;
-	// b) script is partially incorrect and `k6` outputs a warning log message and
-	// then a JSON;
-	// c) script is incorrect and `k6` outputs an error log message;
-	// d) k6 binary is missing;
-	// e) k6 binary exists but is corrupted or otherwise unexecutable.
-	//
-	// Warnings at this point are not necessary (warning messages will re-appear in
-	// runner's logs and the user can see them there) so we need a pure JSON here,
-	// without any additional messages in cases a) and b). In cases c) - e), output
-	// should contain an error message and the Job is to exit with non-zero code.
-	//
-	// Due to some peculiarities of k6 logging, to achieve the above behaviour,
-	// we need to use a workaround to store all log messages in temp file while
-	// printing JSON as usual. Then parse temp file only for errors, ignoring
-	// any other log messages.
-	// Related: https://github.com/grafana/k6-docs/issues/877
-
+// initializerShellScript renders the initializer's shell program.
+// Parameters:
+//   - setup: executed before k6 invocation; used by .spec.args flow.
+//   - archiveRef: where k6 archive is stored.
+//   - archiveCmd: the `k6 archive` command.
+//
+// About the log handling: there can be several scenarios from the k6 command:
+// a) script is correct and `k6 inspect` outputs JSON;
+// b) script is partially incorrect and `k6` outputs a warning log message and
+// then a JSON;
+// c) script is incorrect and `k6` outputs an error log message;
+// d) k6 binary is missing;
+// e) k6 binary exists but is corrupted or otherwise unexecutable.
+//
+// Warnings at this point are not necessary (warning messages will re-appear in
+// runner's logs and the user can see them there) so we need a pure JSON here,
+// without any additional messages in cases a) and b). In cases c) - e), output
+// should contain an error message and the Job is to exit with non-zero code.
+//
+// Due to some peculiarities of k6 logging, to achieve the above behaviour,
+// we need to use a workaround to store all log messages in temp file while
+// printing JSON as usual. Then parse temp file only for errors, ignoring
+// any other log messages.
+// Related: https://github.com/grafana/k6-docs/issues/877
+func initializerShellScript(setup, archiveRef, archiveCmd string) string {
+	if setup != "" {
+		setup += "\n"
+	}
 	return fmt.Sprintf(
 		`if ! command -v k6 >/dev/null 2>&1; then
   echo '%[1]s' >&2
@@ -168,12 +170,12 @@ func newInitializerCommand(scriptName, archiveName, envVarString, argLine string
 fi
 
 logs=/tmp/k6logs
-
+%[2]s
 if ! mkdir -p "$(dirname %[3]s)"; then
   exit 1
 fi
 
-if ! k6 archive %[2]s%[4]s -O %[3]s %[5]s 2> "${logs}"; then
+if ! %[4]s 2> "${logs}"; then
   cat "${logs}"
   exit 1
 fi
@@ -187,9 +189,49 @@ if grep 'level.*error' "${logs}"; then
   exit 1
 fi`,
 		initializerMissingK6Message,
-		scriptName,
-		archiveName,
-		envVarString,
-		argLine,
+		setup,
+		archiveRef,
+		archiveCmd,
 	)
+}
+
+// also referenced by the unit tests
+var initializerScript = initializerShellScript("archive=\"$1\"\nshift", `"${archive}"`, `"$@"`)
+
+// newInitializerCommand builds the `sh -c` arguments that run the initializer.
+// As the necessary step, it builds the archive command from the arguments.
+// The command can take two forms:
+//   - with .spec.arguments, via shell interpreter `sh -c` and concat of arguments.
+//     The env var values are passed as ${..} to be expanded by Shell.
+//   - with .spec.args, via shell positional arguments (more correct and safer)
+//     The env var values are passed as $(..) to be expanded by kubelet.
+//
+// Env vars are passed as a ref by name to account for both Value and ValueFrom cases.
+// The function assumes that the env vars are being passed to the container.
+func newInitializerCommand(scriptName, archiveName string, env []corev1.EnvVar, archiveArgs []string, needsShellCmd bool) []string {
+	if needsShellCmd {
+		// .spec.arguments case
+		var envVarString string
+		for _, ev := range env {
+			// Env values are expanded by the shell inside quotes.
+			envVarString += fmt.Sprintf(` -e %s="${%s}"`, ev.Name, ev.Name)
+		}
+
+		argLine := types.KubeExpansionToShell(strings.Join(archiveArgs, " "))
+
+		archiveCmd := fmt.Sprintf("k6 archive %s%s -O %s %s", scriptName, envVarString, archiveName, argLine)
+		return []string{initializerShellScript("", archiveName, archiveCmd)}
+	}
+
+	// .spec.args case
+	archiveCommand := []string{"k6", "archive", scriptName}
+	for _, ev := range env {
+		archiveCommand = append(archiveCommand, "-e", fmt.Sprintf("%s=$(%s)", ev.Name, ev.Name))
+	}
+	archiveCommand = append(archiveCommand, "-O", archiveName)
+	archiveCommand = append(archiveCommand, archiveArgs...)
+
+	// `sh` is a placeholder for $0 (unused in the script), archive name is $1.
+	command := []string{initializerScript, "sh", archiveName}
+	return append(command, archiveCommand...)
 }

--- a/pkg/resources/jobs/initializer_test.go
+++ b/pkg/resources/jobs/initializer_test.go
@@ -1,6 +1,7 @@
 package jobs
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -100,15 +101,14 @@ func defaultExpectedJobForInitializer() *batchv1.Job {
 							Image:           "grafana/k6:latest",
 							ImagePullPolicy: "",
 							Name:            "k6",
-							Command: []string{
-								"sh", "-c",
+							Command: append([]string{"sh", "-c"},
 								newInitializerCommand(
 									"/test/test.js",
 									"/tmp/test.js.archived.tar",
-									"",
-									"--out cloud",
-								),
-							},
+									nil,
+									[]string{"--out", "cloud"},
+									true,
+								)...),
 							Env: []corev1.EnvVar{},
 							EnvFrom: []corev1.EnvFromSource{
 								{
@@ -135,24 +135,43 @@ func defaultExpectedJobForInitializer() *batchv1.Job {
 func Test_NewInitializerJob(t *testing.T) {
 	tests := []struct {
 		name             string
-		argLine          string
+		archiveArgs      []string
 		setupTestRun     func(*v1alpha1.TestRun)
 		setupExpectedJob func(*batchv1.Job)
 	}{
 		{
 			name:             "base",
-			argLine:          "--out cloud",
+			archiveArgs:      []string{"--out", "cloud"},
 			setupTestRun:     func(k6 *v1alpha1.TestRun) {},
 			setupExpectedJob: func(j *batchv1.Job) {},
 		},
 		{
-			name:    "with custom scheduler name",
-			argLine: "--out cloud",
+			name:        "with custom scheduler name",
+			archiveArgs: []string{"--out", "cloud"},
 			setupTestRun: func(k6 *v1alpha1.TestRun) {
 				k6.Spec.Initializer.SchedulerName = "custom-scheduler"
 			},
 			setupExpectedJob: func(j *batchv1.Job) {
 				j.Spec.Template.Spec.SchedulerName = "custom-scheduler"
+			},
+		},
+		{
+			// The shell source must stay the static script (initializerScript).
+			// Everything else remains a verbatim positional element.
+			name:        ".spec.args use the static script",
+			archiveArgs: []string{"--tag", "note=hello world; rm -rf /"},
+			setupTestRun: func(k6 *v1alpha1.TestRun) {
+				k6.Spec.Arguments = ""
+				k6.Spec.Args = []string{"--out", "cloud", "--tag", "note=hello world; rm -rf /"}
+			},
+			setupExpectedJob: func(j *batchv1.Job) {
+				j.Spec.Template.Spec.Containers[0].Command = []string{
+					"sh", "-c", initializerScript,
+					"sh", "/tmp/test.js.archived.tar",
+					"k6", "archive", "/test/test.js",
+					"-O", "/tmp/test.js.archived.tar",
+					"--tag", "note=hello world; rm -rf /",
+				}
 			},
 		},
 	}
@@ -172,7 +191,7 @@ func Test_NewInitializerJob(t *testing.T) {
 				tt.setupExpectedJob(expectedJob)
 			}
 
-			job, err := NewInitializerJob(k6, tt.argLine)
+			job, err := NewInitializerJob(k6, tt.archiveArgs)
 
 			if err != nil {
 				t.Fatalf("NewInitializerJob errored: %v", err)
@@ -208,7 +227,6 @@ func Test_InitializerEnvVarFlags(t *testing.T) {
 	tests := []struct {
 		name             string
 		setup            func(k6 *v1alpha1.TestRun)
-		expectedInCmd    []string
 		expectedInEnvVar []string
 		noEFlag          bool
 	}{
@@ -222,7 +240,6 @@ func Test_InitializerEnvVarFlags(t *testing.T) {
 					},
 				}
 			},
-			expectedInCmd:    []string{`-e FOO="${FOO}"`, `-e OTHER="${OTHER}"`},
 			expectedInEnvVar: []string{"FOO", "OTHER"},
 		},
 		{
@@ -234,7 +251,6 @@ func Test_InitializerEnvVarFlags(t *testing.T) {
 					},
 				}
 			},
-			expectedInCmd:    []string{`-e FOO="${FOO}"`},
 			expectedInEnvVar: []string{"FOO"},
 		},
 		{
@@ -251,7 +267,6 @@ func Test_InitializerEnvVarFlags(t *testing.T) {
 					},
 				}
 			},
-			expectedInCmd:    []string{`-e TEST_TAG="${TEST_TAG}"`},
 			expectedInEnvVar: []string{"TEST_TAG"},
 		},
 		{
@@ -263,48 +278,110 @@ func Test_InitializerEnvVarFlags(t *testing.T) {
 					},
 				}
 			},
-			expectedInCmd:    []string{`-e THRESHOLDS="${THRESHOLDS}"`},
 			expectedInEnvVar: []string{"THRESHOLDS"},
+		},
+		{
+			name: "env var from a Secret",
+			setup: func(k6 *v1alpha1.TestRun) {
+				k6.Spec.Runner = v1alpha1.Pod{
+					Env: []corev1.EnvVar{
+						{Name: "SECRET_TOKEN", ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "creds"},
+								Key:                  "token",
+							},
+						}},
+					},
+				}
+			},
+			expectedInEnvVar: []string{"SECRET_TOKEN"},
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			k6 := baseTestRun()
-			tt.setup(k6)
+	// modes creates a "matrix" of passing the same test cases to both
+	// .spec.arguments and .spec.args. The diff is in format of env var.
+	modes := []struct {
+		name      string
+		args      []string // add this to TestRun .spec.args
+		envVarFmt string   // expected -e format
+	}{
+		{".spec.arguments", nil, `-e %s="${%s}"`},
+		{".spec.args", []string{"--vus", "1"}, `-e %s=$(%s)`},
+	}
 
-			job, err := NewInitializerJob(k6, "")
-			if err != nil {
-				t.Fatalf("NewInitializerJob errored: %v", err)
-			}
+	for _, mode := range modes {
+		for _, tt := range tests {
+			t.Run(mode.name+": "+tt.name, func(t *testing.T) {
+				k6 := baseTestRun()
+				tt.setup(k6)
+				k6.Spec.Args = mode.args
 
-			cmd := strings.Join(job.Spec.Template.Spec.Containers[0].Command, " ")
-
-			for _, want := range tt.expectedInCmd {
-				if !strings.Contains(cmd, want) {
-					t.Errorf("command should contain %q, got: %s", want, cmd)
+				job, err := NewInitializerJob(k6, nil)
+				if err != nil {
+					t.Fatalf("NewInitializerJob errored: %v", err)
 				}
-			}
 
-			envVars := job.Spec.Template.Spec.Containers[0].Env
-			for _, expected := range tt.expectedInEnvVar {
-				found := false
-				for _, ev := range envVars {
-					if ev.Name == expected {
-						found = true
-						break
+				// find expected env vars in command and container's env vars
+				cmd := strings.Join(job.Spec.Template.Spec.Containers[0].Command, " ")
+				envVars := job.Spec.Template.Spec.Containers[0].Env
+
+				for _, name := range tt.expectedInEnvVar {
+					if want := fmt.Sprintf(mode.envVarFmt, name, name); !strings.Contains(cmd, want) {
+						t.Errorf("command should contain %q, got: %s", want, cmd)
+					}
+
+					found := false
+					for _, ev := range envVars {
+						if ev.Name == name {
+							found = true
+							break
+						}
+					}
+					if !found {
+						t.Errorf("container env should contain %q, got: %v", name, envVars)
 					}
 				}
-				if !found {
-					t.Errorf("container env should contain %q, got: %v", expected, envVars)
-				}
-			}
 
-			if tt.noEFlag {
-				if strings.Contains(cmd, " -e ") {
-					t.Errorf("command should NOT contain `-e`, got: %s", cmd)
+				if tt.noEFlag {
+					if strings.Contains(cmd, " -e ") {
+						t.Errorf("command should NOT contain `-e`, got: %s", cmd)
+					}
 				}
-			}
-		})
+			})
+		}
+	}
+}
+
+func Test_InitializerScuttle(t *testing.T) {
+	baseTestRun := func() *v1alpha1.TestRun {
+		return &v1alpha1.TestRun{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"},
+			Spec: v1alpha1.TestRunSpec{
+				Script: v1alpha1.K6Script{
+					ConfigMap: v1alpha1.K6Configmap{Name: "test", File: "test.js"},
+				},
+				Scuttle: v1alpha1.K6Scuttle{Enabled: "true"},
+			},
+		}
+	}
+
+	// Scuttle command does not depend on the arguments mode, so check just one.
+	k6 := baseTestRun()
+	k6.Spec.Args = []string{"--vus", "1"}
+
+	job, err := NewInitializerJob(k6, []string{"--vus", "1"})
+	if err != nil {
+		t.Fatalf("NewInitializerJob errored: %v", err)
+	}
+
+	cmd := job.Spec.Template.Spec.Containers[0].Command
+	if diff := deep.Equal(cmd, []string{
+		"scuttle", "sh", "-c", initializerScript,
+		"sh", "/tmp/test.js.archived.tar",
+		"k6", "archive", "/test/test.js",
+		"-O", "/tmp/test.js.archived.tar",
+		"--vus", "1",
+	}); diff != nil {
+		t.Errorf("initializer command diff: %v", diff)
 	}
 }

--- a/pkg/resources/jobs/initializer_test.go
+++ b/pkg/resources/jobs/initializer_test.go
@@ -1,6 +1,7 @@
 package jobs
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -100,15 +101,14 @@ func defaultExpectedJobForInitializer() *batchv1.Job {
 							Image:           "grafana/k6:latest",
 							ImagePullPolicy: "",
 							Name:            "k6",
-							Command: []string{
-								"sh", "-c",
+							Command: append([]string{"sh", "-c"},
 								newInitializerCommand(
 									"/test/test.js",
 									"/tmp/test.js.archived.tar",
-									"",
-									"--out cloud",
-								),
-							},
+									nil,
+									[]string{"--out", "cloud"},
+									true,
+								)...),
 							Env: []corev1.EnvVar{},
 							EnvFrom: []corev1.EnvFromSource{
 								{
@@ -135,24 +135,41 @@ func defaultExpectedJobForInitializer() *batchv1.Job {
 func Test_NewInitializerJob(t *testing.T) {
 	tests := []struct {
 		name             string
-		argLine          string
+		archiveArgs      []string
 		setupTestRun     func(*v1alpha1.TestRun)
 		setupExpectedJob func(*batchv1.Job)
 	}{
 		{
 			name:             "base",
-			argLine:          "--out cloud",
+			archiveArgs:      []string{"--out", "cloud"},
 			setupTestRun:     func(k6 *v1alpha1.TestRun) {},
 			setupExpectedJob: func(j *batchv1.Job) {},
 		},
 		{
-			name:    "with custom scheduler name",
-			argLine: "--out cloud",
+			name:        "with custom scheduler name",
+			archiveArgs: []string{"--out", "cloud"},
 			setupTestRun: func(k6 *v1alpha1.TestRun) {
 				k6.Spec.Initializer.SchedulerName = "custom-scheduler"
 			},
 			setupExpectedJob: func(j *batchv1.Job) {
 				j.Spec.Template.Spec.SchedulerName = "custom-scheduler"
+			},
+		},
+		{
+			name:        ".spec.args use the static script",
+			archiveArgs: []string{"--tag", "note=hello world"},
+			setupTestRun: func(k6 *v1alpha1.TestRun) {
+				k6.Spec.Arguments = ""
+				k6.Spec.Args = []string{"--out", "cloud", "--tag", "note=hello world"}
+			},
+			setupExpectedJob: func(j *batchv1.Job) {
+				j.Spec.Template.Spec.Containers[0].Command = []string{
+					"sh", "-c", initializerScript,
+					"sh", "/tmp/test.js.archived.tar",
+					"k6", "archive", "/test/test.js",
+					"-O", "/tmp/test.js.archived.tar",
+					"--tag", "note=hello world",
+				}
 			},
 		},
 	}
@@ -172,7 +189,7 @@ func Test_NewInitializerJob(t *testing.T) {
 				tt.setupExpectedJob(expectedJob)
 			}
 
-			job, err := NewInitializerJob(k6, tt.argLine)
+			job, err := NewInitializerJob(k6, tt.archiveArgs)
 
 			if err != nil {
 				t.Fatalf("NewInitializerJob errored: %v", err)
@@ -208,7 +225,6 @@ func Test_InitializerEnvVarFlags(t *testing.T) {
 	tests := []struct {
 		name             string
 		setup            func(k6 *v1alpha1.TestRun)
-		expectedInCmd    []string
 		expectedInEnvVar []string
 		noEFlag          bool
 	}{
@@ -222,7 +238,6 @@ func Test_InitializerEnvVarFlags(t *testing.T) {
 					},
 				}
 			},
-			expectedInCmd:    []string{`-e FOO="${FOO}"`, `-e OTHER="${OTHER}"`},
 			expectedInEnvVar: []string{"FOO", "OTHER"},
 		},
 		{
@@ -234,7 +249,6 @@ func Test_InitializerEnvVarFlags(t *testing.T) {
 					},
 				}
 			},
-			expectedInCmd:    []string{`-e FOO="${FOO}"`},
 			expectedInEnvVar: []string{"FOO"},
 		},
 		{
@@ -251,7 +265,6 @@ func Test_InitializerEnvVarFlags(t *testing.T) {
 					},
 				}
 			},
-			expectedInCmd:    []string{`-e TEST_TAG="${TEST_TAG}"`},
 			expectedInEnvVar: []string{"TEST_TAG"},
 		},
 		{
@@ -263,48 +276,179 @@ func Test_InitializerEnvVarFlags(t *testing.T) {
 					},
 				}
 			},
-			expectedInCmd:    []string{`-e THRESHOLDS="${THRESHOLDS}"`},
 			expectedInEnvVar: []string{"THRESHOLDS"},
+		},
+		{
+			name: "env var from a Secret",
+			setup: func(k6 *v1alpha1.TestRun) {
+				k6.Spec.Runner = v1alpha1.Pod{
+					Env: []corev1.EnvVar{
+						{Name: "SECRET_TOKEN", ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "creds"},
+								Key:                  "token",
+							},
+						}},
+					},
+				}
+			},
+			expectedInEnvVar: []string{"SECRET_TOKEN"},
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			k6 := baseTestRun()
-			tt.setup(k6)
+	// modes creates a "matrix" of passing the same test cases to both
+	// .spec.arguments and .spec.args. The diff is in format of env var.
+	modes := []struct {
+		name      string
+		args      []string // add this to TestRun .spec.args
+		envVarFmt string   // expected -e format
+	}{
+		{".spec.arguments", nil, `-e %s="${%s}"`},
+		{".spec.args", []string{"--vus", "1"}, `-e %s=$(%s)`},
+	}
 
-			job, err := NewInitializerJob(k6, "")
-			if err != nil {
-				t.Fatalf("NewInitializerJob errored: %v", err)
-			}
+	for _, mode := range modes {
+		for _, tt := range tests {
+			t.Run(mode.name+": "+tt.name, func(t *testing.T) {
+				k6 := baseTestRun()
+				tt.setup(k6)
+				k6.Spec.Args = mode.args
 
-			cmd := strings.Join(job.Spec.Template.Spec.Containers[0].Command, " ")
-
-			for _, want := range tt.expectedInCmd {
-				if !strings.Contains(cmd, want) {
-					t.Errorf("command should contain %q, got: %s", want, cmd)
+				job, err := NewInitializerJob(k6, nil)
+				if err != nil {
+					t.Fatalf("NewInitializerJob errored: %v", err)
 				}
-			}
 
-			envVars := job.Spec.Template.Spec.Containers[0].Env
-			for _, expected := range tt.expectedInEnvVar {
-				found := false
-				for _, ev := range envVars {
-					if ev.Name == expected {
-						found = true
-						break
+				// find expected env vars in command and container's env vars
+				cmd := strings.Join(job.Spec.Template.Spec.Containers[0].Command, " ")
+				envVars := job.Spec.Template.Spec.Containers[0].Env
+
+				for _, name := range tt.expectedInEnvVar {
+					if want := fmt.Sprintf(mode.envVarFmt, name, name); !strings.Contains(cmd, want) {
+						t.Errorf("command should contain %q, got: %s", want, cmd)
+					}
+
+					found := false
+					for _, ev := range envVars {
+						if ev.Name == name {
+							found = true
+							break
+						}
+					}
+					if !found {
+						t.Errorf("container env should contain %q, got: %v", name, envVars)
 					}
 				}
-				if !found {
-					t.Errorf("container env should contain %q, got: %v", expected, envVars)
-				}
-			}
 
-			if tt.noEFlag {
-				if strings.Contains(cmd, " -e ") {
-					t.Errorf("command should NOT contain `-e`, got: %s", cmd)
+				if tt.noEFlag {
+					if strings.Contains(cmd, " -e ") {
+						t.Errorf("command should NOT contain `-e`, got: %s", cmd)
+					}
 				}
-			}
-		})
+			})
+		}
 	}
+}
+
+// When YAML block scalar is used for .spec.arguments, it adds a newline to it.
+// It can break the initializer shell script, so checking its removal.
+func Test_InitializerCommand_ArgumentsRemoveNewlineInYamlBlock(t *testing.T) {
+	k6 := &v1alpha1.TestRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"},
+		Spec: v1alpha1.TestRunSpec{
+			Script: v1alpha1.K6Script{
+				ConfigMap: v1alpha1.K6Configmap{Name: "test", File: "test.js"},
+			},
+			Arguments: "--vus 10 --duration 5s\n",
+		},
+	}
+
+	cli, err := types.ParseCLI(k6.Spec.Argv())
+	if err != nil {
+		t.Fatalf("ParseCLI errored: %v", err)
+	}
+
+	job, err := NewInitializerJob(k6, cli.ArchiveArgs)
+	if err != nil {
+		t.Fatalf("NewInitializerJob errored: %v", err)
+	}
+
+	shellSource := job.Spec.Template.Spec.Containers[0].Command[2]
+	if want := `--duration 5s 2> "${logs}"`; !strings.Contains(shellSource, want) {
+		t.Errorf("archive line should be one line ending in %q, got:\n%s", want, shellSource)
+	}
+}
+
+func Test_InitializerScuttle(t *testing.T) {
+	baseTestRun := func() *v1alpha1.TestRun {
+		return &v1alpha1.TestRun{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"},
+			Spec: v1alpha1.TestRunSpec{
+				Script: v1alpha1.K6Script{
+					ConfigMap: v1alpha1.K6Configmap{Name: "test", File: "test.js"},
+				},
+				Scuttle: v1alpha1.K6Scuttle{Enabled: "true"},
+			},
+		}
+	}
+
+	t.Run(".spec.arguments", func(t *testing.T) {
+		k6 := baseTestRun()
+		k6.Spec.Arguments = "--vus 1"
+
+		job, err := NewInitializerJob(k6, []string{"--vus", "1"})
+		if err != nil {
+			t.Fatalf("NewInitializerJob errored: %v", err)
+		}
+
+		cmd := job.Spec.Template.Spec.Containers[0].Command
+		if diff := deep.Equal(cmd, append([]string{"scuttle", "sh", "-c"},
+			newInitializerCommand("/test/test.js", "/tmp/test.js.archived.tar", nil, []string{"--vus", "1"}, true)...)); diff != nil {
+			t.Errorf("initializer command diff: %v", diff)
+		}
+	})
+
+	t.Run(".spec.args", func(t *testing.T) {
+		k6 := baseTestRun()
+		k6.Spec.Args = []string{"--vus", "1"}
+
+		job, err := NewInitializerJob(k6, []string{"--vus", "1"})
+		if err != nil {
+			t.Fatalf("NewInitializerJob errored: %v", err)
+		}
+
+		cmd := job.Spec.Template.Spec.Containers[0].Command
+		if diff := deep.Equal(cmd, []string{
+			"scuttle", "sh", "-c", initializerScript,
+			"sh", "/tmp/test.js.archived.tar",
+			"k6", "archive", "/test/test.js",
+			"-O", "/tmp/test.js.archived.tar",
+			"--vus", "1",
+		}); diff != nil {
+			t.Errorf("initializer command diff: %v", diff)
+		}
+	})
+}
+
+func Test_InitializerScript_NoDynamicValues(t *testing.T) {
+	k6 := &v1alpha1.TestRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"},
+		Spec: v1alpha1.TestRunSpec{
+			Script: v1alpha1.K6Script{
+				ConfigMap: v1alpha1.K6Configmap{Name: "test", File: "test.js"},
+			},
+			Args: []string{"--tag", "note=hello world; rm -rf /"}, // shell injection
+		},
+	}
+
+	job, err := NewInitializerJob(k6, []string{"--tag", "note=hello world; rm -rf /"})
+	if err != nil {
+		t.Fatalf("NewInitializerJob errored: %v", err)
+	}
+
+	command := job.Spec.Template.Spec.Containers[0].Command
+	if command[2] != initializerScript {
+		t.Errorf("shell source is not the static script: %s", command[2])
+	}
+	// at this point, we can be certain that command[2] does not contain rm -rf
 }

--- a/pkg/resources/jobs/runner.go
+++ b/pkg/resources/jobs/runner.go
@@ -3,7 +3,6 @@ package jobs
 import (
 	"fmt"
 	"strconv"
-	"strings"
 
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -48,10 +47,7 @@ func NewRunnerJob(k6 *v1alpha1.TestRun, index int, tokenInfo *cloud.TokenInfo) (
 		return nil, err
 	}
 
-	if k6.GetSpec().Arguments != "" {
-		args := strings.Split(k6.GetSpec().Arguments, " ")
-		command = append(command, args...)
-	}
+	command = append(command, k6.GetSpec().Argv()...)
 
 	command = append(
 		command,
@@ -82,7 +78,7 @@ func NewRunnerJob(k6 *v1alpha1.TestRun, index int, tokenInfo *cloud.TokenInfo) (
 		command = append(command, "-e", fmt.Sprintf(`%s=%d`, cloud.IIDCloudExecVar, index))
 	}
 
-	command = script.UpdateCommand(command)
+	command = script.UpdateCommand(command, k6.GetSpec().NeedsShellCmd())
 
 	var (
 		zero32                       int32 = 0

--- a/pkg/resources/jobs/runner.go
+++ b/pkg/resources/jobs/runner.go
@@ -3,7 +3,6 @@ package jobs
 import (
 	"fmt"
 	"strconv"
-	"strings"
 
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -48,10 +47,7 @@ func NewRunnerJob(k6 *v1alpha1.TestRun, index int, tokenInfo *cloud.TokenInfo) (
 		return nil, err
 	}
 
-	if k6.GetSpec().Arguments != "" {
-		args := strings.Split(k6.GetSpec().Arguments, " ")
-		command = append(command, args...)
-	}
+	command = append(command, k6.GetSpec().Argv()...)
 
 	command = append(
 		command,
@@ -82,7 +78,7 @@ func NewRunnerJob(k6 *v1alpha1.TestRun, index int, tokenInfo *cloud.TokenInfo) (
 		command = append(command, "-e", fmt.Sprintf(`%s=%d`, cloud.IIDCloudExecVar, index))
 	}
 
-	command = script.UpdateCommand(command)
+	command = script.UpdateCommand(command, len(k6.GetSpec().Args) == 0)
 
 	var (
 		zero32                       int32 = 0

--- a/pkg/resources/jobs/runner_test.go
+++ b/pkg/resources/jobs/runner_test.go
@@ -1,6 +1,7 @@
 package jobs
 
 import (
+	"strings"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -39,6 +40,14 @@ func defaultScript() *types.Script {
 		Name:     "test",
 		Filename: "thing.js",
 		Type:     "ConfigMap",
+	}
+}
+
+func localFileScript() *types.Script {
+	return &types.Script{
+		Name:     "test",
+		Filename: "/test/test.js",
+		Type:     "LocalFile",
 	}
 }
 
@@ -221,13 +230,27 @@ func Test_NewRunnerJob(t *testing.T) {
 			},
 		},
 		{
-			name: "modifying k6 command: arguments",
+			name: "modifying k6 command: .spec.arguments",
 			setupTestRun: func(k6 *v1alpha1.TestRun) {
 				k6.Spec.Arguments = "--cool-thing"
 			},
 			setupExpectedJob: func(j *batchv1.Job) {
 				j.Spec.Template.Spec.Containers[0].Command = []string{
 					"k6", "run", "--quiet", "--cool-thing", "/test/test.js", "--address=0.0.0.0:6565", "--paused",
+					"--tag", "instance_id=1", "--tag", "testrun_name=test",
+				}
+			},
+		},
+		{
+			name: "modifying k6 command: .spec.args",
+			setupTestRun: func(k6 *v1alpha1.TestRun) {
+				k6.Spec.Args = []string{"--tag", "note=hello world", "-e", `QUOTED="value"`, "-e", "PRICE=$$100"}
+			},
+			setupExpectedJob: func(j *batchv1.Job) {
+				j.Spec.Template.Spec.Containers[0].Command = []string{
+					"k6", "run", "--quiet",
+					"--tag", "note=hello world", "-e", `QUOTED="value"`, "-e", "PRICE=$$100",
+					"/test/test.js", "--address=0.0.0.0:6565", "--paused",
 					"--tag", "instance_id=1", "--tag", "testrun_name=test",
 				}
 			},
@@ -272,7 +295,7 @@ func Test_NewRunnerJob(t *testing.T) {
 			},
 		},
 		{
-			name: "LocalFile",
+			name: "LocalFile with .spec.arguments",
 			script: &types.Script{
 				Name:     "test",
 				Filename: "/test/test.js",
@@ -283,17 +306,55 @@ func Test_NewRunnerJob(t *testing.T) {
 				k6.Spec.Scuttle = v1alpha1.K6Scuttle{Enabled: "false"}
 			},
 			setupExpectedJob: func(j *batchv1.Job) {
-				localScript := &types.Script{
-					Name:     "test",
-					Filename: "/test/test.js",
-					Type:     "LocalFile",
-				}
-				j.Spec.Template.Spec.Containers[0].Command = []string{
-					"sh", "-c",
-					"if [ ! -f /test/test.js ]; then echo \"LocalFile not found exiting...\"; exit 1; fi;\nk6 run --quiet /test/test.js --address=0.0.0.0:6565 --paused --tag instance_id=1 --tag testrun_name=test",
-				}
+				localScript := localFileScript()
+				j.Spec.Template.Spec.Containers[0].Command = localScript.UpdateCommand([]string{
+					"k6", "run", "--quiet", "/test/test.js", "--address=0.0.0.0:6565",
+					"--paused", "--tag", "instance_id=1", "--tag", "testrun_name=test",
+				}, true)
 				j.Spec.Template.Spec.Containers[0].VolumeMounts = localScript.VolumeMount()
 				j.Spec.Template.Spec.Volumes = localScript.Volume()
+			},
+		},
+		{
+			name:   "LocalFile with .spec.args",
+			script: localFileScript(),
+			setupTestRun: func(k6 *v1alpha1.TestRun) {
+				k6.Spec.Script = v1alpha1.K6Script{LocalFile: "/test/test.js"}
+				k6.Spec.Args = []string{"--tag", "note=hello world"}
+			},
+			setupExpectedJob: func(j *batchv1.Job) {
+				localScript := localFileScript()
+				j.Spec.Template.Spec.Containers[0].Command = localScript.UpdateCommand([]string{
+					"k6", "run", "--quiet", "--tag", "note=hello world",
+					"/test/test.js", "--address=0.0.0.0:6565", "--paused",
+					"--tag", "instance_id=1", "--tag", "testrun_name=test",
+				}, false)
+				j.Spec.Template.Spec.Containers[0].VolumeMounts = localScript.VolumeMount()
+				j.Spec.Template.Spec.Volumes = localScript.Volume()
+			},
+		},
+		{
+			name:   "LocalFile with .spec.args and scuttle",
+			script: localFileScript(),
+			setupTestRun: func(k6 *v1alpha1.TestRun) {
+				k6.Spec.Script = v1alpha1.K6Script{LocalFile: "/test/test.js"}
+				k6.Spec.Args = []string{"--tag", "note=hello world"}
+				k6.Spec.Scuttle = v1alpha1.K6Scuttle{Enabled: "true"}
+			},
+			setupExpectedJob: func(j *batchv1.Job) {
+				localScript := localFileScript()
+				j.Spec.Template.Spec.Containers[0].Command = localScript.UpdateCommand([]string{
+					"scuttle", "k6", "run", "--quiet", "--tag", "note=hello world",
+					"/test/test.js", "--address=0.0.0.0:6565", "--paused",
+					"--tag", "instance_id=1", "--tag", "testrun_name=test",
+				}, false)
+				j.Spec.Template.Spec.Containers[0].VolumeMounts = localScript.VolumeMount()
+				j.Spec.Template.Spec.Volumes = localScript.Volume()
+				j.Spec.Template.Spec.Containers[0].Env = []corev1.EnvVar{
+					{Name: "ENVOY_ADMIN_API", Value: "http://127.0.0.1:15000"},
+					{Name: "ISTIO_QUIT_API", Value: "http://127.0.0.1:15020"},
+					{Name: "WAIT_FOR_ENVOY_TIMEOUT", Value: "15"},
+				}
 			},
 		},
 		{
@@ -501,6 +562,61 @@ func Test_NewRunnerJob(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_NewRunnerJob_LocalFilePreservesLogOutputArgument(t *testing.T) {
+	const (
+		argsLogOutput      = `--log-output=loki=https://cloudlogs.k6.io/api/v1/push,label.lz=my-plz,header.Authorization=Token $(K6_CLOUD_TOKEN)`
+		argumentsLogOutput = `--log-output=loki=https://cloudlogs.k6.io/api/v1/push,label.lz=my-plz,header.Authorization="Token $(K6_CLOUD_TOKEN)"`
+	)
+
+	t.Run(".spec.arguments keep the shell quoting", func(t *testing.T) {
+		k6 := defaultTestRun()
+		k6.Spec.Script = v1alpha1.K6Script{LocalFile: "/test/test.js"}
+		k6.Spec.Arguments = "--out cloud " + argumentsLogOutput
+
+		job, err := NewRunnerJob(k6, 1, cloud.NewTokenInfo("", ""))
+		if err != nil {
+			t.Fatalf("NewRunnerJob errored: %v", err)
+		}
+
+		command := job.Spec.Template.Spec.Containers[0].Command
+		// arguments are wrapped as `sh -c "<joined>"` and passed as
+		// positional parameters to the existence-check script.
+		if len(command) != 8 || command[5] != "sh" || command[6] != "-c" {
+			t.Fatalf("expected a `sh -c` wrapper as positional parameters, got: %v", command)
+		}
+		if !strings.Contains(command[7], argumentsLogOutput) {
+			t.Errorf("inner shell command should contain %q, got: %s", argumentsLogOutput, command[7])
+		}
+	})
+
+	t.Run(".spec.args propagate the log output as one element", func(t *testing.T) {
+		k6 := defaultTestRun()
+		k6.Spec.Script = v1alpha1.K6Script{LocalFile: "/test/test.js"}
+		k6.Spec.Args = []string{"--out", "cloud", argsLogOutput}
+
+		job, err := NewRunnerJob(k6, 1, cloud.NewTokenInfo("", ""))
+		if err != nil {
+			t.Fatalf("NewRunnerJob errored: %v", err)
+		}
+
+		command := job.Spec.Template.Spec.Containers[0].Command
+		found := 0
+		for _, arg := range command {
+			if arg == argsLogOutput {
+				found++
+			}
+		}
+		if found != 1 {
+			t.Errorf("expected the log output as exactly one element, found %d in: %v", found, command)
+		}
+		for _, arg := range command[3:] {
+			if strings.Contains(arg, `"`) {
+				t.Errorf("no argument should carry a literal quote, got: %q", arg)
+			}
+		}
+	})
 }
 
 func Test_NewAntiAffinity(t *testing.T) {

--- a/pkg/resources/jobs/runner_test.go
+++ b/pkg/resources/jobs/runner_test.go
@@ -1,6 +1,7 @@
 package jobs
 
 import (
+	"strings"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -39,6 +40,14 @@ func defaultScript() *types.Script {
 		Name:     "test",
 		Filename: "thing.js",
 		Type:     "ConfigMap",
+	}
+}
+
+func localFileScript() *types.Script {
+	return &types.Script{
+		Name:     "test",
+		Filename: "/test/test.js",
+		Type:     "LocalFile",
 	}
 }
 
@@ -221,13 +230,41 @@ func Test_NewRunnerJob(t *testing.T) {
 			},
 		},
 		{
-			name: "modifying k6 command: arguments",
+			name: "modifying k6 command: .spec.arguments",
 			setupTestRun: func(k6 *v1alpha1.TestRun) {
 				k6.Spec.Arguments = "--cool-thing"
 			},
 			setupExpectedJob: func(j *batchv1.Job) {
 				j.Spec.Template.Spec.Containers[0].Command = []string{
 					"k6", "run", "--quiet", "--cool-thing", "/test/test.js", "--address=0.0.0.0:6565", "--paused",
+					"--tag", "instance_id=1", "--tag", "testrun_name=test",
+				}
+			},
+		},
+		{
+			name: "modifying k6 command: .spec.args",
+			setupTestRun: func(k6 *v1alpha1.TestRun) {
+				k6.Spec.Args = []string{"--tag", "note=hello world", "-e", `QUOTED="value"`, "-e", "PRICE=$$100"}
+			},
+			setupExpectedJob: func(j *batchv1.Job) {
+				j.Spec.Template.Spec.Containers[0].Command = []string{
+					"k6", "run", "--quiet",
+					"--tag", "note=hello world", "-e", `QUOTED="value"`, "-e", "PRICE=$$100",
+					"/test/test.js", "--address=0.0.0.0:6565", "--paused",
+					"--tag", "instance_id=1", "--tag", "testrun_name=test",
+				}
+			},
+		},
+		{
+			name: "modifying k6 command: .spec.args override .spec.arguments",
+			setupTestRun: func(k6 *v1alpha1.TestRun) {
+				k6.Spec.Arguments = "--vus 10"
+				k6.Spec.Args = []string{"--vus", "20"}
+			},
+			setupExpectedJob: func(j *batchv1.Job) {
+				j.Spec.Template.Spec.Containers[0].Command = []string{
+					"k6", "run", "--quiet", "--vus", "20",
+					"/test/test.js", "--address=0.0.0.0:6565", "--paused",
 					"--tag", "instance_id=1", "--tag", "testrun_name=test",
 				}
 			},
@@ -272,7 +309,7 @@ func Test_NewRunnerJob(t *testing.T) {
 			},
 		},
 		{
-			name: "LocalFile",
+			name: "LocalFile with .spec.arguments",
 			script: &types.Script{
 				Name:     "test",
 				Filename: "/test/test.js",
@@ -283,17 +320,109 @@ func Test_NewRunnerJob(t *testing.T) {
 				k6.Spec.Scuttle = v1alpha1.K6Scuttle{Enabled: "false"}
 			},
 			setupExpectedJob: func(j *batchv1.Job) {
-				localScript := &types.Script{
-					Name:     "test",
-					Filename: "/test/test.js",
-					Type:     "LocalFile",
-				}
-				j.Spec.Template.Spec.Containers[0].Command = []string{
-					"sh", "-c",
-					"if [ ! -f /test/test.js ]; then echo \"LocalFile not found exiting...\"; exit 1; fi;\nk6 run --quiet /test/test.js --address=0.0.0.0:6565 --paused --tag instance_id=1 --tag testrun_name=test",
-				}
+				localScript := localFileScript()
+				j.Spec.Template.Spec.Containers[0].Command = localScript.UpdateCommand([]string{
+					"k6", "run", "--quiet", "/test/test.js", "--address=0.0.0.0:6565",
+					"--paused", "--tag", "instance_id=1", "--tag", "testrun_name=test",
+				}, true)
 				j.Spec.Template.Spec.Containers[0].VolumeMounts = localScript.VolumeMount()
 				j.Spec.Template.Spec.Volumes = localScript.Volume()
+			},
+		},
+		{
+			name:   "LocalFile with .spec.args",
+			script: localFileScript(),
+			setupTestRun: func(k6 *v1alpha1.TestRun) {
+				k6.Spec.Script = v1alpha1.K6Script{LocalFile: "/test/test.js"}
+				k6.Spec.Args = []string{"--tag", "note=hello world"}
+			},
+			setupExpectedJob: func(j *batchv1.Job) {
+				localScript := localFileScript()
+				j.Spec.Template.Spec.Containers[0].Command = localScript.UpdateCommand([]string{
+					"k6", "run", "--quiet", "--tag", "note=hello world",
+					"/test/test.js", "--address=0.0.0.0:6565", "--paused",
+					"--tag", "instance_id=1", "--tag", "testrun_name=test",
+				}, false)
+				j.Spec.Template.Spec.Containers[0].VolumeMounts = localScript.VolumeMount()
+				j.Spec.Template.Spec.Volumes = localScript.Volume()
+			},
+		},
+		{
+			name:   "LocalFile with .spec.args and scuttle",
+			script: localFileScript(),
+			setupTestRun: func(k6 *v1alpha1.TestRun) {
+				k6.Spec.Script = v1alpha1.K6Script{LocalFile: "/test/test.js"}
+				k6.Spec.Args = []string{"--tag", "note=hello world"}
+				k6.Spec.Scuttle = v1alpha1.K6Scuttle{Enabled: "true"}
+			},
+			setupExpectedJob: func(j *batchv1.Job) {
+				localScript := localFileScript()
+				j.Spec.Template.Spec.Containers[0].Command = localScript.UpdateCommand([]string{
+					"scuttle", "k6", "run", "--quiet", "--tag", "note=hello world",
+					"/test/test.js", "--address=0.0.0.0:6565", "--paused",
+					"--tag", "instance_id=1", "--tag", "testrun_name=test",
+				}, false)
+				j.Spec.Template.Spec.Containers[0].VolumeMounts = localScript.VolumeMount()
+				j.Spec.Template.Spec.Volumes = localScript.Volume()
+				j.Spec.Template.Spec.Containers[0].Env = []corev1.EnvVar{
+					{Name: "ENVOY_ADMIN_API", Value: "http://127.0.0.1:15000"},
+					{Name: "ISTIO_QUIT_API", Value: "http://127.0.0.1:15020"},
+					{Name: "WAIT_FOR_ENVOY_TIMEOUT", Value: "15"},
+				}
+			},
+		},
+		{
+			name:   "LocalFile with .spec.arguments and scuttle",
+			script: localFileScript(),
+			setupTestRun: func(k6 *v1alpha1.TestRun) {
+				k6.Spec.Script = v1alpha1.K6Script{LocalFile: "/test/test.js"}
+				k6.Spec.Arguments = "--vus 10"
+				k6.Spec.Scuttle = v1alpha1.K6Scuttle{Enabled: "true"}
+			},
+			setupExpectedJob: func(j *batchv1.Job) {
+				localScript := localFileScript()
+				j.Spec.Template.Spec.Containers[0].Command = localScript.UpdateCommand([]string{
+					"scuttle", "k6", "run", "--quiet", "--vus", "10", "/test/test.js",
+					"--address=0.0.0.0:6565", "--paused", "--tag", "instance_id=1",
+					"--tag", "testrun_name=test",
+				}, true)
+				j.Spec.Template.Spec.Containers[0].VolumeMounts = localScript.VolumeMount()
+				j.Spec.Template.Spec.Volumes = localScript.Volume()
+				j.Spec.Template.Spec.Containers[0].Env = []corev1.EnvVar{
+					{Name: "ENVOY_ADMIN_API", Value: "http://127.0.0.1:15000"},
+					{Name: "ISTIO_QUIT_API", Value: "http://127.0.0.1:15020"},
+					{Name: "WAIT_FOR_ENVOY_TIMEOUT", Value: "15"},
+				}
+			},
+		},
+		{
+			name: "VolumeClaim with .spec.args",
+			script: &types.Script{
+				Name:     "test",
+				Path:     "/test/",
+				Filename: "test.js",
+				Type:     "VolumeClaim",
+			},
+			setupTestRun: func(k6 *v1alpha1.TestRun) {
+				k6.Spec.Script = v1alpha1.K6Script{
+					VolumeClaim: v1alpha1.K6VolumeClaim{Name: "test", File: "test.js"},
+				}
+				k6.Spec.Args = []string{"--tag", "note=hello world"}
+			},
+			setupExpectedJob: func(j *batchv1.Job) {
+				volumeScript := &types.Script{
+					Name:     "test",
+					Path:     "/test/",
+					Filename: "test.js",
+					Type:     "VolumeClaim",
+				}
+				j.Spec.Template.Spec.Containers[0].Command = []string{
+					"k6", "run", "--quiet", "--tag", "note=hello world",
+					"/test/test.js", "--address=0.0.0.0:6565", "--paused",
+					"--tag", "instance_id=1", "--tag", "testrun_name=test",
+				}
+				j.Spec.Template.Spec.Containers[0].VolumeMounts = volumeScript.VolumeMount()
+				j.Spec.Template.Spec.Volumes = volumeScript.Volume()
 			},
 		},
 		{
@@ -501,6 +630,61 @@ func Test_NewRunnerJob(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_NewRunnerJob_logOutputTransport(t *testing.T) {
+	const (
+		argsLogOutput      = `--log-output=loki=https://cloudlogs.k6.io/api/v1/push,label.lz=my-plz,header.Authorization=Token $(K6_CLOUD_TOKEN)`
+		argumentsLogOutput = `--log-output=loki=https://cloudlogs.k6.io/api/v1/push,label.lz=my-plz,header.Authorization="Token $(K6_CLOUD_TOKEN)"`
+	)
+
+	t.Run(".spec.arguments keep the shell quoting", func(t *testing.T) {
+		k6 := defaultTestRun()
+		k6.Spec.Script = v1alpha1.K6Script{LocalFile: "/test/test.js"}
+		k6.Spec.Arguments = "--out cloud " + argumentsLogOutput
+
+		job, err := NewRunnerJob(k6, 1, cloud.NewTokenInfo("", ""))
+		if err != nil {
+			t.Fatalf("NewRunnerJob errored: %v", err)
+		}
+
+		command := job.Spec.Template.Spec.Containers[0].Command
+		// arguments are wrapped as `sh -c "<joined>"` and passed as
+		// positional parameters to the existence-check script.
+		if len(command) != 8 || command[5] != "sh" || command[6] != "-c" {
+			t.Fatalf("expected a `sh -c` wrapper as positional parameters, got: %v", command)
+		}
+		if !strings.Contains(command[7], argumentsLogOutput) {
+			t.Errorf("inner shell command should contain %q, got: %s", argumentsLogOutput, command[7])
+		}
+	})
+
+	t.Run(".spec.args propagate the log output as one element", func(t *testing.T) {
+		k6 := defaultTestRun()
+		k6.Spec.Script = v1alpha1.K6Script{LocalFile: "/test/test.js"}
+		k6.Spec.Args = []string{"--out", "cloud", argsLogOutput}
+
+		job, err := NewRunnerJob(k6, 1, cloud.NewTokenInfo("", ""))
+		if err != nil {
+			t.Fatalf("NewRunnerJob errored: %v", err)
+		}
+
+		command := job.Spec.Template.Spec.Containers[0].Command
+		found := 0
+		for _, arg := range command {
+			if arg == argsLogOutput {
+				found++
+			}
+		}
+		if found != 1 {
+			t.Errorf("expected the log output as exactly one element, found %d in: %v", found, command)
+		}
+		for _, arg := range command[3:] {
+			if strings.Contains(arg, `"`) {
+				t.Errorf("no argument should carry a literal quote, got: %q", arg)
+			}
+		}
+	})
 }
 
 func Test_NewAntiAffinity(t *testing.T) {

--- a/pkg/types/k6cli.go
+++ b/pkg/types/k6cli.go
@@ -2,31 +2,37 @@ package types
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
 )
-
-// Initializer relies on `sh -c` script so we can't pass Kubernetes-style `$(NAME)`
-// there. For shell, those vars should be substituted into `${NAME}` form. This
-// regexp helps do that.
-var kubeEnvRefRegexp = regexp.MustCompile(`\$\(([a-zA-Z_][a-zA-Z0-9_]*)\)`)
 
 // CLI is an internal type to support k6 invocation in initialization stage.
 // Not all k6 commands allow the same set of arguments so CLI is an object
 // meant to contain only the ones fit for the archive call.
 // Maybe revise this once crococonf is closer to integration?
 type CLI struct {
-	ArchiveArgs string
+	ArchiveArgs []string
 	// k6-operator doesn't care for most values of CLI arguments to k6, with an exception of cloud output
 	HasCloudOut bool
 }
 
-func ParseCLI(arguments string) (*CLI, error) {
+// ParseCLI parses the k6 arguments and returns the subset of them that is
+// suitable for the `k6 archive` call.
+func ParseCLI(argv []string) (*CLI, error) {
+	// find the end of value for last argument
 	lastArgV := func(start int, args []string) (end int) {
 		end = start
 		for end < len(args) {
-			args[end] = strings.TrimSpace(args[end])
-			if len(args[end]) > 0 && args[end][0] == '-' {
+			if len(args[end]) == 0 {
+				// An empty element right after a flag is its value, e.g. `--user-agent ""`:
+				// k6 CLI allows it, so keep the pairing intact. An empty element anywhere
+				// else is positional: don't consume it here, so that the main loop errors
+				// on it; just like k6 CLI errors on an extra empty positional argument.
+				if end == start {
+					end++
+				}
+				break
+			}
+			if args[end][0] == '-' {
 				break
 			}
 			end++
@@ -39,63 +45,42 @@ func ParseCLI(arguments string) (*CLI, error) {
 		err error
 	)
 
-	args := strings.Split(arguments, " ")
 	i := 0
-	for i < len(args) {
-		args[i] = strings.TrimSpace(args[i])
-		if len(args[i]) == 0 {
-			i++
-			continue
-		}
-		if args[i][0] == '-' {
-			end := lastArgV(i+1, args)
+	for i < len(argv) {
+		if len(argv[i]) > 0 && argv[i][0] == '-' {
+			end := lastArgV(i+1, argv)
 
-			if strings.HasPrefix(args[i], "--log-output") {
+			switch {
+			case strings.HasPrefix(argv[i], "--log-output"):
 				// `k6 archive` ignores this argument but if it contains an env var
 				// for token (cloud logs for PLZ test runs), it will break the shell;
 				// so omit it.
-				i = end
-				continue
-			}
 
-			// Unsupported by `k6 archive`.
-			if strings.HasPrefix(args[i], "--block-hostnames") ||
-				strings.HasPrefix(args[i], "--blacklist-ip") ||
-				strings.HasPrefix(args[i], "--user-agent") {
-				i = end
-				continue
-			}
+			case strings.HasPrefix(argv[i], "--block-hostnames"),
+				strings.HasPrefix(argv[i], "--blacklist-ip"),
+				strings.HasPrefix(argv[i], "--user-agent"):
+				// Unsupported by `k6 archive`.
 
-			switch args[i] {
-			case "-e", "--env":
-				// substitute $(NAME) -> ${NAME} for safe initializer command invocation
-				fragment := kubeEnvRefRegexp.ReplaceAllString(strings.Join(args[i:end], " "), `"${$1}"`)
-				if len(cli.ArchiveArgs) > 0 {
-					cli.ArchiveArgs += " "
+			case argv[i] == "-o", argv[i] == "--out":
+				// "cloud" should appear after -o / --out
+				// (Historically) Supported forms: --out cloud, -o cloud
+				if i+1 < end && argv[i+1] == "cloud" {
+					cli.HasCloudOut = true
 				}
-				cli.ArchiveArgs += fragment
-			case "-o", "--out":
-				for j := 0; j < end; j++ {
-					if args[j] == "cloud" {
-						cli.HasCloudOut = true
-					}
-				}
-			case "-l", "--linger", "--no-usage-report":
+
+			case argv[i] == "-l", argv[i] == "--linger", argv[i] == "--no-usage-report":
 				// non-archive arguments, so skip them
-				break
-			case "--verbose", "-v":
+
+			case argv[i] == "--verbose", argv[i] == "-v":
 				// this argument is acceptable by archive but it'd
 				// mess up the JSON output of `k6 inspect`
-				break
+
 			default:
-				if len(cli.ArchiveArgs) > 0 {
-					cli.ArchiveArgs += " "
-				}
-				cli.ArchiveArgs += strings.Join(args[i:end], " ")
+				cli.ArchiveArgs = append(cli.ArchiveArgs, argv[i:end]...)
 			}
 			i = end
 		} else {
-			err = fmt.Errorf("encountered an invalid value for k6 CLI argument: `%s`", args[i])
+			err = fmt.Errorf("encountered an invalid value for k6 CLI argument: `%s`", argv[i])
 			break
 		}
 	}

--- a/pkg/types/k6cli.go
+++ b/pkg/types/k6cli.go
@@ -3,29 +3,36 @@ package types
 import (
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 )
 
-// Initializer relies on `sh -c` script so we can't pass Kubernetes-style `$(NAME)`
-// there. For shell, those vars should be substituted into `${NAME}` form. This
-// regexp helps do that.
+// This is used for .spec.Arguments only: see below.
 var kubeEnvRefRegexp = regexp.MustCompile(`\$\(([a-zA-Z_][a-zA-Z0-9_]*)\)`)
+
+// KubeExpansionToShell: `$(NAME)` -> `"${NAME}"`
+// This is used for .spec.Arguments only, as it relies on Shell expansion
+// and we can't pass Kubernetes-style `$(NAME)` there.
+func KubeExpansionToShell(argLine string) string {
+	return kubeEnvRefRegexp.ReplaceAllString(argLine, `"${$1}"`)
+}
 
 // CLI is an internal type to support k6 invocation in initialization stage.
 // Not all k6 commands allow the same set of arguments so CLI is an object
 // meant to contain only the ones fit for the archive call.
 // Maybe revise this once crococonf is closer to integration?
 type CLI struct {
-	ArchiveArgs string
+	ArchiveArgs []string
 	// k6-operator doesn't care for most values of CLI arguments to k6, with an exception of cloud output
 	HasCloudOut bool
 }
 
-func ParseCLI(arguments string) (*CLI, error) {
+// ParseCLI parses the k6 arguments and returns the subset of them that is
+// suitable for the `k6 archive` call.
+func ParseCLI(argv []string) (*CLI, error) {
 	lastArgV := func(start int, args []string) (end int) {
 		end = start
 		for end < len(args) {
-			args[end] = strings.TrimSpace(args[end])
 			if len(args[end]) > 0 && args[end][0] == '-' {
 				break
 			}
@@ -39,63 +46,45 @@ func ParseCLI(arguments string) (*CLI, error) {
 		err error
 	)
 
-	args := strings.Split(arguments, " ")
+	// empty values are not expected, but clean up just in case
+	argv = slices.DeleteFunc(slices.Clone(argv), func(s string) bool { return len(s) == 0 })
+
 	i := 0
-	for i < len(args) {
-		args[i] = strings.TrimSpace(args[i])
-		if len(args[i]) == 0 {
-			i++
-			continue
-		}
-		if args[i][0] == '-' {
-			end := lastArgV(i+1, args)
+	for i < len(argv) {
+		if argv[i][0] == '-' {
+			end := lastArgV(i+1, argv)
 
-			if strings.HasPrefix(args[i], "--log-output") {
+			switch {
+			case strings.HasPrefix(argv[i], "--log-output"):
 				// `k6 archive` ignores this argument but if it contains an env var
-				// for token (cloud logs for PLZ test runs), it will break the shell;
+				// for token (may be the case for PLZ test runs), it will break the shell;
 				// so omit it.
-				i = end
-				continue
-			}
 
-			// Unsupported by `k6 archive`.
-			if strings.HasPrefix(args[i], "--block-hostnames") ||
-				strings.HasPrefix(args[i], "--blacklist-ip") ||
-				strings.HasPrefix(args[i], "--user-agent") {
-				i = end
-				continue
-			}
+			case strings.HasPrefix(argv[i], "--block-hostnames"),
+				strings.HasPrefix(argv[i], "--blacklist-ip"),
+				strings.HasPrefix(argv[i], "--user-agent"):
+				// Unsupported by `k6 archive`.
 
-			switch args[i] {
-			case "-e", "--env":
-				// substitute $(NAME) -> ${NAME} for safe initializer command invocation
-				fragment := kubeEnvRefRegexp.ReplaceAllString(strings.Join(args[i:end], " "), `"${$1}"`)
-				if len(cli.ArchiveArgs) > 0 {
-					cli.ArchiveArgs += " "
+			case argv[i] == "-o", argv[i] == "--out":
+				// "cloud" should appear after -o / --out
+				// (Historically) Supported forms: --out cloud, -o cloud
+				if i+1 < end && argv[i+1] == "cloud" {
+					cli.HasCloudOut = true
 				}
-				cli.ArchiveArgs += fragment
-			case "-o", "--out":
-				for j := 0; j < end; j++ {
-					if args[j] == "cloud" {
-						cli.HasCloudOut = true
-					}
-				}
-			case "-l", "--linger", "--no-usage-report":
+
+			case argv[i] == "-l", argv[i] == "--linger", argv[i] == "--no-usage-report":
 				// non-archive arguments, so skip them
-				break
-			case "--verbose", "-v":
+
+			case argv[i] == "--verbose", argv[i] == "-v":
 				// this argument is acceptable by archive but it'd
 				// mess up the JSON output of `k6 inspect`
-				break
+
 			default:
-				if len(cli.ArchiveArgs) > 0 {
-					cli.ArchiveArgs += " "
-				}
-				cli.ArchiveArgs += strings.Join(args[i:end], " ")
+				cli.ArchiveArgs = append(cli.ArchiveArgs, argv[i:end]...)
 			}
 			i = end
 		} else {
-			err = fmt.Errorf("encountered an invalid value for k6 CLI argument: `%s`", args[i])
+			err = fmt.Errorf("encountered an invalid value for k6 CLI argument: `%s`", argv[i])
 			break
 		}
 	}

--- a/pkg/types/k6cli_test.go
+++ b/pkg/types/k6cli_test.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,140 +10,241 @@ import (
 func Test_ParseCLI(t *testing.T) {
 	tests := []struct {
 		name             string
-		argLine          string
+		argv             []string
 		cli              CLI
 		invalidArguments bool
 	}{
 		{
 			"EmptyArgs",
-			"",
+			nil,
 			CLI{},
 			false,
 		},
 		{
 			"ShortArchiveArgs",
-			"-u 10 -d 5",
+			[]string{"-u", "10", "-d", "5"},
 			CLI{
-				ArchiveArgs: "-u 10 -d 5",
+				ArchiveArgs: []string{"-u", "10", "-d", "5"},
 			},
 			false,
 		},
 		{
 			"LongArchiveArgs",
-			"--vus 10 --duration 5",
+			[]string{"--vus", "10", "--duration", "5"},
 			CLI{
-				ArchiveArgs: "--vus 10 --duration 5",
+				ArchiveArgs: []string{"--vus", "10", "--duration", "5"},
 			},
 			false,
 		},
 		{
 			"ShortNonArchiveArg",
-			"-u 10 -d 5 -l",
+			[]string{"-u", "10", "-d", "5", "-l"},
 			CLI{
-				ArchiveArgs: "-u 10 -d 5",
+				ArchiveArgs: []string{"-u", "10", "-d", "5"},
 			},
 			false,
 		},
 		{
 			"LongNonArchiveArgs",
-			"--vus 10 --duration 5 --linger",
+			[]string{"--vus", "10", "--duration", "5", "--linger"},
 			CLI{
-				ArchiveArgs: "--vus 10 --duration 5",
+				ArchiveArgs: []string{"--vus", "10", "--duration", "5"},
 			},
 			false,
 		},
 		{
 			"OutWithoutCloudArgs",
-			"--vus 10 -o json -o csv",
+			[]string{"--vus", "10", "-o", "json", "-o", "csv"},
 			CLI{
-				ArchiveArgs: "--vus 10",
+				ArchiveArgs: []string{"--vus", "10"},
 				HasCloudOut: false,
 			},
 			false,
 		},
 		{
 			"OutWithCloudArgs",
-			"--vus 10 --out json -o csv --out cloud",
+			[]string{"--vus", "10", "--out", "json", "-o", "csv", "--out", "cloud"},
 			CLI{
-				ArchiveArgs: "--vus 10",
+				ArchiveArgs: []string{"--vus", "10"},
 				HasCloudOut: true,
 			},
 			false,
 		},
 		{
 			"VerboseOutWithCloudArgs",
-			"--vus 10 --out json -o csv --out cloud --verbose",
+			[]string{"--vus", "10", "--out", "json", "-o", "csv", "--out", "cloud", "--verbose"},
 			CLI{
-				ArchiveArgs: "--vus 10",
+				ArchiveArgs: []string{"--vus", "10"},
 				HasCloudOut: true,
 			},
 			false,
 		},
 		{
-			"OmitLogOutput",
-			`--out cloud --no-thresholds --log-output=loki=https://cloudlogs.k6.io/api/v1/push,label.lz=my-plz,label.test_run_id=1111,header.Authorization="Token $(K6_CLOUD_TOKEN)"`,
+			"FalseCloudInTag",
+			[]string{"--tag", "cloud", "--out", "json"},
 			CLI{
-				ArchiveArgs: "--no-thresholds",
+				ArchiveArgs: []string{"--tag", "cloud"},
+				HasCloudOut: false,
+			},
+			false,
+		},
+		{
+			"StandaloneCloudOut",
+			[]string{"--out", "cloud"},
+			CLI{
 				HasCloudOut: true,
 			},
 			false,
 		},
 		{
-			"OmitLogOutputInDiffOrder",
-			`--out cloud --log-output=loki=https://cloudlogs.k6.io/api/v1/push,label.lz=my-plz,label.test_run_id=1111,header.Authorization="Token $(K6_CLOUD_TOKEN)" --no-thresholds`,
+			"StandaloneShortCloudOut",
+			[]string{"-o", "cloud"},
 			CLI{
-				ArchiveArgs: "--no-thresholds",
+				HasCloudOut: true,
+			},
+			false,
+		},
+		{
+			// with `.spec.arguments`, the value is split and has quotes
+			"OmitLogOutputArguments",
+			[]string{
+				"--out", "cloud", "--no-thresholds",
+				`--log-output=loki=https://cloudlogs.k6.io/api/v1/push,label.lz=my-plz,label.test_run_id=1111,header.Authorization="Token`,
+				`$(K6_CLOUD_TOKEN)"`,
+			},
+			CLI{
+				ArchiveArgs: []string{"--no-thresholds"},
+				HasCloudOut: true,
+			},
+			false,
+		},
+		{
+			// with `.spec.arguments`, the value is split and has quotes
+			"OmitLogOutputAgumentsInDiffOrder",
+			[]string{
+				"--out", "cloud",
+				`--log-output=loki=https://cloudlogs.k6.io/api/v1/push,label.lz=my-plz,label.test_run_id=1111,header.Authorization="Token`,
+				`$(K6_CLOUD_TOKEN)"`,
+				"--no-thresholds",
+			},
+			CLI{
+				ArchiveArgs: []string{"--no-thresholds"},
+				HasCloudOut: true,
+			},
+			false,
+		},
+		{
+			// with `.spec.args`, the value is kept together, without quotes
+			"OmitLogOutputArgs",
+			[]string{
+				"--out", "cloud",
+				`--log-output=loki=https://cloudlogs.k6.io/api/v1/push,label.lz=my-plz,label.test_run_id=1111,header.Authorization=Token $(K6_CLOUD_TOKEN)`,
+				"--no-thresholds",
+			},
+			CLI{
+				ArchiveArgs: []string{"--no-thresholds"},
 				HasCloudOut: true,
 			},
 			false,
 		},
 		{
 			"InvalidArguments",
-			`run this-argument-does-not-matter.js -o json`,
+			[]string{"run", "this-argument-does-not-matter.js", "-o", "json"},
 			CLI{},
 			true,
 		},
 		{
 			"SkipBlockHostnamesEquals",
-			`--vus 10 --block-hostnames="google.com" --duration 5s`,
+			[]string{"--vus", "10", `--block-hostnames="google.com"`, "--duration", "5s"},
 			CLI{
-				ArchiveArgs: "--vus 10 --duration 5s",
+				ArchiveArgs: []string{"--vus", "10", "--duration", "5s"},
 			},
 			false,
 		},
 		{
 			"SkipBlacklistIpEquals",
-			`--vus 10 --blacklist-ip="8.8.8.8/32" --duration 5s`,
+			[]string{"--vus", "10", `--blacklist-ip="8.8.8.8/32"`, "--duration", "5s"},
 			CLI{
-				ArchiveArgs: "--vus 10 --duration 5s",
+				ArchiveArgs: []string{"--vus", "10", "--duration", "5s"},
 			},
 			false,
 		},
 		{
 			"SkipUserAgentEquals",
-			`--vus 10 --user-agent="foo" --duration 5s`,
+			[]string{"--vus", "10", `--user-agent="foo"`, "--duration", "5s"},
 			CLI{
-				ArchiveArgs: "--vus 10 --duration 5s",
+				ArchiveArgs: []string{"--vus", "10", "--duration", "5s"},
 			},
 			false,
 		},
 		{
-			"RewriteKubeEnvRefsForShell",
-			`--out cloud -e FOO=$(K6_OP_ENV_FOO) --no-thresholds -e BAR=plain`,
+			"KeepKubeEnvRefs",
+			[]string{"--out", "cloud", "-e", "FOO=$(K6_OP_ENV_FOO)", "--no-thresholds", "-e", "BAR=plain"},
 			CLI{
-				ArchiveArgs: `-e FOO="${K6_OP_ENV_FOO}" --no-thresholds -e BAR=plain`,
+				ArchiveArgs: []string{"-e", "FOO=$(K6_OP_ENV_FOO)", "--no-thresholds", "-e", "BAR=plain"},
 				HasCloudOut: true,
 			},
 			false,
 		},
 		{
 			"IncludeSystemEnvVars",
-			`--out cloud --include-system-env-vars`,
+			[]string{"--out", "cloud", "--include-system-env-vars"},
 			CLI{
-				ArchiveArgs: "--include-system-env-vars",
+				ArchiveArgs: []string{"--include-system-env-vars"},
 				HasCloudOut: true,
 			},
 			false,
+		},
+		{
+			// valid for .spec.args only
+			"ExactSpacedAndQuotedElements",
+			[]string{"--tag", "note=hello world", "-e", `QUOTED="value"`},
+			CLI{
+				ArchiveArgs: []string{"--tag", "note=hello world", "-e", `QUOTED="value"`},
+			},
+			false,
+		},
+		{
+			// valid for .spec.args only
+			"ExactDollarsAreNotInterpreted",
+			[]string{"--tag", "price=$$100 $(NAME)"},
+			CLI{
+				ArchiveArgs: []string{"--tag", "price=$$100 $(NAME)"},
+			},
+			false,
+		},
+		{
+			// `k6 archive --tag "" --vus 10` is valid, so the pairing must be kept
+			"EmptyElementAsFlagValue",
+			[]string{"--tag", "", "--vus", "10"},
+			CLI{
+				ArchiveArgs: []string{"--tag", "", "--vus", "10"},
+			},
+			false,
+		},
+		{
+			"EmptyElementAsValueOfFilteredFlag",
+			[]string{"--user-agent", "", "--vus", "10"},
+			CLI{
+				ArchiveArgs: []string{"--vus", "10"},
+			},
+			false,
+		},
+		{
+			// k6 CLI rejects an extra empty positional argument, so should ParseCLI
+			"EmptyElementStandaloneLeading",
+			[]string{"", "--vus", "10"},
+			CLI{},
+			true,
+		},
+		{
+			// an empty element after a flag's value is positional, not part of the value
+			"EmptyElementStandaloneTrailing",
+			[]string{"--vus", "10", ""},
+			CLI{
+				ArchiveArgs: []string{"--vus", "10"},
+			},
+			true,
 		},
 	}
 
@@ -150,10 +252,14 @@ func Test_ParseCLI(t *testing.T) {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			cli, err := ParseCLI(test.argLine)
+
+			original := slices.Clone(test.argv)
+
+			cli, err := ParseCLI(test.argv)
 			assert.Equal(t, test.invalidArguments, err != nil)
 			assert.Equal(t, test.cli.ArchiveArgs, cli.ArchiveArgs)
 			assert.Equal(t, test.cli.HasCloudOut, cli.HasCloudOut)
+			assert.Equal(t, original, test.argv, "ParseCLI must not modify its input")
 		})
 	}
 }

--- a/pkg/types/k6cli_test.go
+++ b/pkg/types/k6cli_test.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,138 +10,214 @@ import (
 func Test_ParseCLI(t *testing.T) {
 	tests := []struct {
 		name             string
-		argLine          string
+		argv             []string
 		cli              CLI
 		invalidArguments bool
 	}{
 		{
 			"EmptyArgs",
-			"",
+			nil,
 			CLI{},
 			false,
 		},
 		{
 			"ShortArchiveArgs",
-			"-u 10 -d 5",
+			[]string{"-u", "10", "-d", "5"},
 			CLI{
-				ArchiveArgs: "-u 10 -d 5",
+				ArchiveArgs: []string{"-u", "10", "-d", "5"},
 			},
 			false,
 		},
 		{
 			"LongArchiveArgs",
-			"--vus 10 --duration 5",
+			[]string{"--vus", "10", "--duration", "5"},
 			CLI{
-				ArchiveArgs: "--vus 10 --duration 5",
+				ArchiveArgs: []string{"--vus", "10", "--duration", "5"},
 			},
 			false,
 		},
 		{
 			"ShortNonArchiveArg",
-			"-u 10 -d 5 -l",
+			[]string{"-u", "10", "-d", "5", "-l"},
 			CLI{
-				ArchiveArgs: "-u 10 -d 5",
+				ArchiveArgs: []string{"-u", "10", "-d", "5"},
 			},
 			false,
 		},
 		{
 			"LongNonArchiveArgs",
-			"--vus 10 --duration 5 --linger",
+			[]string{"--vus", "10", "--duration", "5", "--linger"},
 			CLI{
-				ArchiveArgs: "--vus 10 --duration 5",
+				ArchiveArgs: []string{"--vus", "10", "--duration", "5"},
 			},
 			false,
 		},
 		{
 			"OutWithoutCloudArgs",
-			"--vus 10 -o json -o csv",
+			[]string{"--vus", "10", "-o", "json", "-o", "csv"},
 			CLI{
-				ArchiveArgs: "--vus 10",
+				ArchiveArgs: []string{"--vus", "10"},
 				HasCloudOut: false,
 			},
 			false,
 		},
 		{
 			"OutWithCloudArgs",
-			"--vus 10 --out json -o csv --out cloud",
+			[]string{"--vus", "10", "--out", "json", "-o", "csv", "--out", "cloud"},
 			CLI{
-				ArchiveArgs: "--vus 10",
+				ArchiveArgs: []string{"--vus", "10"},
 				HasCloudOut: true,
 			},
 			false,
 		},
 		{
 			"VerboseOutWithCloudArgs",
-			"--vus 10 --out json -o csv --out cloud --verbose",
+			[]string{"--vus", "10", "--out", "json", "-o", "csv", "--out", "cloud", "--verbose"},
 			CLI{
-				ArchiveArgs: "--vus 10",
+				ArchiveArgs: []string{"--vus", "10"},
 				HasCloudOut: true,
 			},
 			false,
 		},
 		{
-			"OmitLogOutput",
-			`--out cloud --no-thresholds --log-output=loki=https://cloudlogs.k6.io/api/v1/push,label.lz=my-plz,label.test_run_id=1111,header.Authorization="Token $(K6_CLOUD_TOKEN)"`,
+			"FalseCloudInTag",
+			[]string{"--tag", "cloud", "--out", "json"},
 			CLI{
-				ArchiveArgs: "--no-thresholds",
+				ArchiveArgs: []string{"--tag", "cloud"},
+				HasCloudOut: false,
+			},
+			false,
+		},
+		{
+			"StandaloneCloudOut",
+			[]string{"--out", "cloud"},
+			CLI{
 				HasCloudOut: true,
 			},
 			false,
 		},
 		{
-			"OmitLogOutputInDiffOrder",
-			`--out cloud --log-output=loki=https://cloudlogs.k6.io/api/v1/push,label.lz=my-plz,label.test_run_id=1111,header.Authorization="Token $(K6_CLOUD_TOKEN)" --no-thresholds`,
+			"StandaloneShortCloudOut",
+			[]string{"-o", "cloud"},
 			CLI{
-				ArchiveArgs: "--no-thresholds",
+				HasCloudOut: true,
+			},
+			false,
+		},
+		{
+			// with `.spec.arguments`, the value is split and has quotes
+			"OmitLogOutputArguments",
+			[]string{
+				"--out", "cloud", "--no-thresholds",
+				`--log-output=loki=https://cloudlogs.k6.io/api/v1/push,label.lz=my-plz,label.test_run_id=1111,header.Authorization="Token`,
+				`$(K6_CLOUD_TOKEN)"`,
+			},
+			CLI{
+				ArchiveArgs: []string{"--no-thresholds"},
+				HasCloudOut: true,
+			},
+			false,
+		},
+		{
+			// with `.spec.arguments`, the value is split and has quotes
+			"OmitLogOutputAgumentsInDiffOrder",
+			[]string{
+				"--out", "cloud",
+				`--log-output=loki=https://cloudlogs.k6.io/api/v1/push,label.lz=my-plz,label.test_run_id=1111,header.Authorization="Token`,
+				`$(K6_CLOUD_TOKEN)"`,
+				"--no-thresholds",
+			},
+			CLI{
+				ArchiveArgs: []string{"--no-thresholds"},
+				HasCloudOut: true,
+			},
+			false,
+		},
+		{
+			// with `.spec.args`, the value is kept together, without quotes
+			"OmitLogOutputArgs",
+			[]string{
+				"--out", "cloud",
+				`--log-output=loki=https://cloudlogs.k6.io/api/v1/push,label.lz=my-plz,label.test_run_id=1111,header.Authorization=Token $(K6_CLOUD_TOKEN)`,
+				"--no-thresholds",
+			},
+			CLI{
+				ArchiveArgs: []string{"--no-thresholds"},
 				HasCloudOut: true,
 			},
 			false,
 		},
 		{
 			"InvalidArguments",
-			`run this-argument-does-not-matter.js -o json`,
+			[]string{"run", "this-argument-does-not-matter.js", "-o", "json"},
 			CLI{},
 			true,
 		},
 		{
 			"SkipBlockHostnamesEquals",
-			`--vus 10 --block-hostnames="google.com" --duration 5s`,
+			[]string{"--vus", "10", `--block-hostnames="google.com"`, "--duration", "5s"},
 			CLI{
-				ArchiveArgs: "--vus 10 --duration 5s",
+				ArchiveArgs: []string{"--vus", "10", "--duration", "5s"},
 			},
 			false,
 		},
 		{
 			"SkipBlacklistIpEquals",
-			`--vus 10 --blacklist-ip="8.8.8.8/32" --duration 5s`,
+			[]string{"--vus", "10", `--blacklist-ip="8.8.8.8/32"`, "--duration", "5s"},
 			CLI{
-				ArchiveArgs: "--vus 10 --duration 5s",
+				ArchiveArgs: []string{"--vus", "10", "--duration", "5s"},
 			},
 			false,
 		},
 		{
 			"SkipUserAgentEquals",
-			`--vus 10 --user-agent="foo" --duration 5s`,
+			[]string{"--vus", "10", `--user-agent="foo"`, "--duration", "5s"},
 			CLI{
-				ArchiveArgs: "--vus 10 --duration 5s",
+				ArchiveArgs: []string{"--vus", "10", "--duration", "5s"},
 			},
 			false,
 		},
 		{
-			"RewriteKubeEnvRefsForShell",
-			`--out cloud -e FOO=$(K6_OP_ENV_FOO) --no-thresholds -e BAR=plain`,
+			"KeepKubeEnvRefs",
+			[]string{"--out", "cloud", "-e", "FOO=$(K6_OP_ENV_FOO)", "--no-thresholds", "-e", "BAR=plain"},
 			CLI{
-				ArchiveArgs: `-e FOO="${K6_OP_ENV_FOO}" --no-thresholds -e BAR=plain`,
+				ArchiveArgs: []string{"-e", "FOO=$(K6_OP_ENV_FOO)", "--no-thresholds", "-e", "BAR=plain"},
 				HasCloudOut: true,
 			},
 			false,
 		},
 		{
 			"IncludeSystemEnvVars",
-			`--out cloud --include-system-env-vars`,
+			[]string{"--out", "cloud", "--include-system-env-vars"},
 			CLI{
-				ArchiveArgs: "--include-system-env-vars",
+				ArchiveArgs: []string{"--include-system-env-vars"},
 				HasCloudOut: true,
+			},
+			false,
+		},
+		{
+			// valid for .spec.args only
+			"ExactSpacedAndQuotedElements",
+			[]string{"--tag", "note=hello world", "-e", `QUOTED="value"`},
+			CLI{
+				ArchiveArgs: []string{"--tag", "note=hello world", "-e", `QUOTED="value"`},
+			},
+			false,
+		},
+		{
+			// valid for .spec.args only
+			"ExactDollarsAreNotInterpreted",
+			[]string{"--tag", "price=$$100 $(NAME)"},
+			CLI{
+				ArchiveArgs: []string{"--tag", "price=$$100 $(NAME)"},
+			},
+			false,
+		},
+		{
+			"EmptyElement",
+			[]string{"", "--vus", "", "10"},
+			CLI{
+				ArchiveArgs: []string{"--vus", "10"},
 			},
 			false,
 		},
@@ -150,10 +227,21 @@ func Test_ParseCLI(t *testing.T) {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			cli, err := ParseCLI(test.argLine)
+
+			original := slices.Clone(test.argv)
+
+			cli, err := ParseCLI(test.argv)
 			assert.Equal(t, test.invalidArguments, err != nil)
 			assert.Equal(t, test.cli.ArchiveArgs, cli.ArchiveArgs)
 			assert.Equal(t, test.cli.HasCloudOut, cli.HasCloudOut)
+			assert.Equal(t, original, test.argv, "ParseCLI must not modify its input")
 		})
 	}
+}
+
+func Test_KubeExpansionToShell(t *testing.T) {
+	assert.Equal(t,
+		`-e FOO="${K6_OP_ENV_FOO}" -e BAR=plain`,
+		KubeExpansionToShell(`-e FOO=$(K6_OP_ENV_FOO) -e BAR=plain`),
+	)
 }

--- a/pkg/types/script.go
+++ b/pkg/types/script.go
@@ -1,7 +1,6 @@
 package types
 
 import (
-	"fmt"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -86,17 +85,31 @@ func (s *Script) VolumeMount() []corev1.VolumeMount {
 
 }
 
+const localFileCheckScript = `if [ ! -f "$1" ]; then
+  echo "LocalFile not found exiting..."
+  exit 1
+fi
+shift
+exec "$@"`
+
 // UpdateCommand modifies command to check for script existence in case of LocalFile;
-// otherwise, command remains unmodified
-func (s *Script) UpdateCommand(cmd []string) []string {
-	if s.Type == "LocalFile" {
-		joincmd := strings.Join(cmd, " ")
-		checkCommand := []string{
-			"sh",
-			"-c",
-			fmt.Sprintf("if [ ! -f %v ]; then echo \"LocalFile not found exiting...\"; exit 1; fi;\n%v", s.FullName(), joincmd),
-		}
-		return checkCommand
+// otherwise, command remains unmodified.
+// The command, when passed to the existence check, can take two forms:
+// - with .spec.arguments, via shell interpreter `sh -c` and concat of arguments
+// - with .spec.args, via shell positional arguments (more correct and safer)
+func (s *Script) UpdateCommand(cmd []string, needsShellCmd bool) []string {
+	if s.Type != "LocalFile" {
+		return cmd
 	}
-	return cmd
+
+	// The command from .spec.arguments needs shell interpretation.
+	// This is a backwards compatible approach.
+	if needsShellCmd {
+		cmd = []string{"sh", "-c", strings.Join(cmd, " ")}
+	}
+
+	// Second `sh` is a placeholder for $0 (unused in the existence check, so doesn't matter)
+	// Script name ($1) is always a positional argument.
+	checkCommand := []string{"sh", "-c", localFileCheckScript, "sh", s.FullName()}
+	return append(checkCommand, cmd...)
 }

--- a/pkg/types/script_test.go
+++ b/pkg/types/script_test.go
@@ -140,18 +140,38 @@ func Test_Script_UpdateCommand(t *testing.T) {
 	baseCmd := []string{"k6", "run", "script.js"}
 
 	tests := []struct {
-		name   string
-		script Script
-		check  func(t *testing.T, result []string)
+		name          string
+		script        Script
+		needsShellCmd bool
+		check         func(t *testing.T, result []string)
 	}{
 		{
-			name:   "LocalFile wraps command with existence check",
+			name:          "LocalFile with .spec.arguments",
+			script:        Script{Type: "LocalFile", Path: "/test/", Filename: "script.js"},
+			needsShellCmd: true,
+			check: func(t *testing.T, result []string) {
+				assert.Equal(t, []string{
+					"sh", "-c", localFileCheckScript,
+					"sh", "/test/script.js",
+					"sh", "-c", "k6 run script.js",
+				}, result)
+				// no dynamic value in the shell source
+				assert.NotContains(t, result[2], "/test/script.js")
+				assert.NotContains(t, result[2], "k6")
+			},
+		},
+		{
+			name:   "LocalFile with .spec.args",
 			script: Script{Type: "LocalFile", Path: "/test/", Filename: "script.js"},
 			check: func(t *testing.T, result []string) {
-				assert.Equal(t, []string{"sh", "-c"}, result[:2])
-				assert.Contains(t, result[2], "/test/script.js")
-				assert.Contains(t, result[2], "LocalFile not found exiting...")
-				assert.Contains(t, result[2], "k6 run script.js")
+				assert.Equal(t, []string{
+					"sh", "-c", localFileCheckScript,
+					"sh", "/test/script.js",
+					"k6", "run", "script.js",
+				}, result)
+				// no dynamic value in the shell source
+				assert.NotContains(t, result[2], "/test/script.js")
+				assert.NotContains(t, result[2], "k6")
 			},
 		},
 		{
@@ -172,7 +192,7 @@ func Test_Script_UpdateCommand(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := tt.script.UpdateCommand(baseCmd)
+			result := tt.script.UpdateCommand(baseCmd, tt.needsShellCmd)
 			tt.check(t, result)
 		})
 	}


### PR DESCRIPTION
Supplementary work for https://github.com/grafana/k6-operator/issues/742 (not directly related to API changes but required to make arbitrary tags and env vars work).

Adding an alternative way to specify the k6 arguments. The initial approach, `.spec.arguments`, is ultimately faulty because it requires k6-operator to split the string into separate arguments. This is a complex task in a general case, prone to brittle results (see https://github.com/grafana/k6-operator/issues/162, https://github.com/grafana/k6-operator/issues/757); and given the Shell scripts in initializer job and in LocalFile test, it's also unsafe. The array of strings `.spec.args` allows a user to format their arguments as separate strings explicitly, which can then be passed to the k6 pods as is, minimizing the risk of misinterpretation of the values from k6-operator.

- New field in TestRun `.spec.args` as []string, which overrides `.spec.arguments` when present
- The initializer and LocalFile shell script revamped to support both forms, "simple" positional args for `.spec.args` and `sh -c` as before for joined `.spec.arguments` 
    - Since k6-operator avoided dragging in the full parsing of the string to avoid a complex implementation and to keep deps small, the only options are to offload it to the Shell (`.spec.arguments`) or to let user to be explicit about arguments as they know them best (`.spec.args`)
- PLZ flow switched to the `.spec.args`. In effect, this PR partially reverts bits from the PR https://github.com/grafana/k6-operator/pull/839: with `.spec.args`, the problem with arbitrary values in user env vars can be passed simply as "classic" `-e ...`. Future tags in PLZ will use the same approach (the next PR in this stack).