### PR TITLE
PLZ: merge user tags with cloud-reserved tag (3/3)

### DIFF
--- a/pkg/cloud/apitypes.go
+++ b/pkg/cloud/apitypes.go
@@ -82,7 +82,7 @@ func (trd *TestRunData) Preprocess() error {
 		return fmt.Errorf("only tests with one load zone are supported, provided: %+v", trd.LZDistribution)
 	}
 
-	trd.TagArgs = []string{"--tag", "load_zone=" + escapeKubeExpansion(trd.LZName())}
+	trd.preprocessTags()
 
 	// Handle k6 CLI options that need to be passed as env vars to the runners.
 
@@ -104,7 +104,6 @@ func (trd *TestRunData) Preprocess() error {
 	}
 
 	// Handle env vars that configure k6 CLI as received from the Cloud.
-	// Note: GCk6 reserved env vars are handled separately ATM.
 
 	trd.RunnerEnvVars = append(trd.RunnerEnvVars, AggregationEnvVars(&trd.RuntimeConfig)...)
 	trd.RunnerEnvVars = append(trd.RunnerEnvVars, trd.secretsEnvVars()...)
@@ -174,12 +173,11 @@ type LZConfig struct {
 }
 
 type CLIArgs struct {
-	BlacklistIPs         []string `json:"blacklist_ips,omitempty"`
-	BlockedHostnames     []string `json:"blocked_hostnames,omitempty"`
-	IncludeSystemEnvVars bool     `json:"include_system_env_vars,omitempty"`
-	UserAgent            string   `json:"user_agent,omitempty"`
-	// not used ATM
-	// Tags                 map[string]string `json:"tags,omitempty"`
+	BlacklistIPs         []string          `json:"blacklist_ips,omitempty"`
+	BlockedHostnames     []string          `json:"blocked_hostnames,omitempty"`
+	IncludeSystemEnvVars bool              `json:"include_system_env_vars,omitempty"`
+	UserAgent            string            `json:"user_agent,omitempty"`
+	Tags                 map[string]string `json:"tags,omitempty"`
 }
 
 type LZDistribution map[string]Distribution
@@ -226,6 +224,35 @@ func (trd *TestRunData) secretsEnvVars() []corev1.EnvVar {
 		})
 	}
 	return ev
+}
+
+func (trd *TestRunData) preprocessTags() {
+	if trd.Tags == nil {
+		trd.Tags = make(map[string]string)
+	}
+	// trd.Tags holds the user-set tags from the archive, extracted by GCk6.
+	// We need to overwrite by key here to prevent k6 from discarding the
+	// whole map. This way, we're effectively "merging" the user-provided
+	// tags with the Cloud reserved tag.
+	// Related k6 issue: https://github.com/grafana/k6/issues/2694
+	// If this issue becomes the default behaviour of k6 CLI, we'll be
+	// be able to remove this logic (and once everyone has migrated to the newest k6).
+	trd.Tags["load_zone"] = trd.LZName()
+
+	keys := make([]string, 0, len(trd.Tags))
+	for k := range trd.Tags {
+		// k6 doesn't forbid empty values in general case
+		if len(k) > 0 && len(trd.Tags[k]) > 0 {
+			keys = append(keys, k)
+		}
+	}
+	// to have deterministic order in the resulting args
+	sort.Strings(keys)
+
+	trd.TagArgs = make([]string, 0, len(keys)*3)
+	for _, k := range keys {
+		trd.TagArgs = append(trd.TagArgs, "--tag", fmt.Sprintf("%s=%s", escapeKubeExpansion(k), escapeKubeExpansion(trd.Tags[k])))
+	}
 }
 
 // LZLabel assumes there is only one LZ.

--- a/pkg/cloud/apitypes_test.go
+++ b/pkg/cloud/apitypes_test.go
@@ -122,6 +122,98 @@ func TestLZConfig_reservedEnvVars(t *testing.T) {
 	}
 }
 
+func TestTestRunData_preprocessTags(t *testing.T) {
+	t.Parallel()
+
+	oneLZ := LZDistribution{"label": Distribution{LoadZone: "zone", Percent: 100}}
+
+	tests := []struct {
+		name     string
+		trd      TestRunData
+		expected []string
+	}{
+		{
+			name:     "nil tags from API",
+			trd:      TestRunData{LZDistribution: oneLZ},
+			expected: []string{"--tag", "load_zone=zone"},
+		},
+		{
+			name: "empty tags from API",
+			trd: TestRunData{
+				LZDistribution: oneLZ,
+				LZConfig:       LZConfig{CLIArgs: CLIArgs{Tags: map[string]string{}}},
+			},
+			expected: []string{"--tag", "load_zone=zone"},
+		},
+		{
+			name: "merging tags",
+			trd: TestRunData{
+				LZDistribution: oneLZ,
+				LZConfig: LZConfig{CLIArgs: CLIArgs{Tags: map[string]string{
+					"env":  "staging",
+					"team": "backend",
+				}}},
+			},
+			expected: []string{"--tag", "env=staging", "--tag", "load_zone=zone", "--tag", "team=backend"},
+		},
+		{
+			name: "load_zone tag is reserved and can't be overwritten",
+			trd: TestRunData{
+				LZDistribution: oneLZ,
+				LZConfig: LZConfig{CLIArgs: CLIArgs{Tags: map[string]string{
+					"load_zone": "user-zone",
+					"env":       "staging",
+				}}},
+			},
+			expected: []string{"--tag", "env=staging", "--tag", "load_zone=zone"},
+		},
+		{
+			name: "tag values with spaces",
+			trd: TestRunData{
+				LZDistribution: oneLZ,
+				LZConfig: LZConfig{CLIArgs: CLIArgs{Tags: map[string]string{
+					"description": "my test run",
+				}}},
+			},
+			expected: []string{"--tag", "description=my test run", "--tag", "load_zone=zone"},
+		},
+		{
+			// k6 CLI rejects `--tag k=` with "invalid tag, empty value",
+			// while `options.tags` in the script allows empty values, so
+			// such tags can legitimately reach trd.Tags. They are skipped.
+			// TODO: come up with a test for k6 bug report
+			name: "skip tags with empty keys or values",
+			trd: TestRunData{
+				LZDistribution: oneLZ,
+				LZConfig: LZConfig{CLIArgs: CLIArgs{Tags: map[string]string{
+					"env":      "staging",
+					"emptyval": "",
+					"":         "emptykey",
+				}}},
+			},
+			expected: []string{"--tag", "env=staging", "--tag", "load_zone=zone"},
+		},
+		{
+			name:     "missing distribution",
+			trd:      TestRunData{},
+			expected: []string{"--tag", "load_zone=unknown_lz_name"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.trd.preprocessTags()
+
+			if !reflect.DeepEqual(tt.trd.TagArgs, tt.expected) {
+				t.Errorf("TagArgs = %q, want %q", tt.trd.TagArgs, tt.expected)
+			}
+		})
+	}
+}
+
 func TestTestRunData_Preprocess(t *testing.T) {
 	t.Parallel()
 
@@ -153,6 +245,7 @@ func TestTestRunData_Preprocess(t *testing.T) {
 					UserAgent:        "Grafana Cloud k6",
 					BlacklistIPs:     []string{"8.8.8.8/32", "1.1.1.1/32"},
 					BlockedHostnames: []string{"example.com"},
+					Tags:             map[string]string{"env": "staging"},
 				},
 			},
 		}
@@ -160,7 +253,7 @@ func TestTestRunData_Preprocess(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		expectedTagArgs := []string{"--tag", "load_zone=zone"}
+		expectedTagArgs := []string{"--tag", "env=staging", "--tag", "load_zone=zone"}
 		if !reflect.DeepEqual(trd.TagArgs, expectedTagArgs) {
 			t.Errorf("TagArgs = %q, want %q", trd.TagArgs, expectedTagArgs)
 		}

--- a/pkg/plz/worker.go
+++ b/pkg/plz/worker.go
@@ -172,6 +172,11 @@ func plzk6Args(plzName string, testRunID string, trData *cloud.TestRunData) []st
 	args = append(args, fmt.Sprintf(plzLogOutputFormat, plzName, testRunID))
 	args = append(args, trData.EnvArgs...)
 	args = append(args, fmt.Sprintf("--include-system-env-vars=%t", trData.IncludeSystemEnvVars))
+	if !trData.IncludeSystemEnvVars {
+		// internal usage; currently PLZ users receive true for system env vars
+		args = append(args, "--verbose", "--summary-mode=disabled")
+	}
+
 	return args
 }
 

--- a/pkg/plz/worker_test.go
+++ b/pkg/plz/worker_test.go
@@ -83,6 +83,8 @@ func Test_plzk6Args(t *testing.T) {
 				"--no-thresholds",
 				"--log-output=loki=https://cloudlogs.k6.io/api/v1/push,label.lz=,label.test_run_id=0,header.Authorization=Token $(K6_CLOUD_TOKEN)",
 				"--include-system-env-vars=false",
+				"--verbose",
+				"--summary-mode=disabled",
 			},
 		},
 		{

--- a/pkg/types/k6cli.go
+++ b/pkg/types/k6cli.go
@@ -53,7 +53,7 @@ func ParseCLI(argv []string) (*CLI, error) {
 			switch {
 			case strings.HasPrefix(argv[i], "--log-output"):
 				// `k6 archive` ignores this argument but if it contains an env var
-				// for token (may be the case for PLZ test runs), it will break the shell;
+				// for token (cloud logs for PLZ test runs), it will break the shell;
 				// so omit it.
 
 			case strings.HasPrefix(argv[i], "--block-hostnames"),

--- a/pkg/types/k6cli.go
+++ b/pkg/types/k6cli.go
@@ -53,7 +53,7 @@ func ParseCLI(argv []string) (*CLI, error) {
 			switch {
 			case strings.HasPrefix(argv[i], "--log-output"):
 				// `k6 archive` ignores this argument but if it contains an env var
-				// for token (cloud logs for PLZ test runs), it will break the shell;
+				// for token (may be the case for PLZ test runs), it will break the shell;
 				// so omit it.
 
 			case strings.HasPrefix(argv[i], "--block-hostnames"),


### PR DESCRIPTION
The last in the group for https://github.com/grafana/k6-operator/issues/742

It ensures that the tags received from GCk6 API are being applied to k6 runners correctly: with addition of reserved `load_zone` tag and without loosing user-side tags.

Tags can be of arbitrary values, but since PLZ is switched to `.spec.args` in https://github.com/grafana/k6-operator/pull/868, k6-operator can now pass such strings.