### PR TITLE
fix: return error on stop / start job create failure

### DIFF
--- a/internal/controller/k6_start.go
+++ b/internal/controller/k6_start.go
@@ -121,7 +121,7 @@ func StartJobs(ctx context.Context, log logr.Logger, k6 *v1alpha1.TestRun, r *Te
 	created, err := createJobIfNotExists(ctx, r.Client, starter)
 	if err != nil {
 		log.Error(err, "Failed to launch k6 test starter")
-		return res, nil
+		return res, err
 	}
 
 	if created {

--- a/internal/controller/k6_stop.go
+++ b/internal/controller/k6_stop.go
@@ -51,7 +51,7 @@ func StopJobs(ctx context.Context, log logr.Logger, k6 *v1alpha1.TestRun, r *Tes
 	created, err := createJobIfNotExists(ctx, r.Client, stopJob)
 	if err != nil {
 		log.Error(err, "Failed to launch k6 test stop job.")
-		return res, nil
+		return res, err
 	}
 
 	if created {


### PR DESCRIPTION
## Problem

When `StopJobs` fails to create the stop job (e.g. due to a transient API server error, quota issue, or RBAC problem), the error is logged but the function returns `ctrl.Result{}, nil` — telling controller-runtime "success, do not requeue".

Since the `TestRun` stage was never updated to `stopped`, nothing else triggers another reconcile, and the object is permanently stuck with no user-visible indication of why.

## Root Cause

In `internal/controller/k6_stop.go` lines 51-54:

```go
created, err := createJobIfNotExists(ctx, r.Client, stopJob)
if err != nil {
    log.Error(err, "Failed to launch k6 test stop job.")
    return res, nil   // res is zero value — no requeue, nil error
}
```

`res` is never assigned in this function, so it is always the zero `ctrl.Result{}`. Returning `nil` as the error signals success to controller-runtime. The reconciler is not retried, and the `TestRun` cannot progress.

## Expected Behaviour

A transient failure creating the stop job should be retried. The error should be returned so controller-runtime re-enqueues the reconcile request.

## Fix

Return `err` instead of `nil` on unexpected Create errors so the reconciler retries.

```go
if err = r.Create(ctx, stopJob); err != nil {
    if !apierrors.IsAlreadyExists(err) {
        log.Error(err, "Failed to launch k6 test stop job.")
        return res, err
    }
    log.Info("Stop job already exists, continuing")
}
```

Fixes #840
