### PR TITLE
ci: skip Helm install test for release-prep PRs

### DIFF
--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -14,6 +14,13 @@ on:
 
 jobs:
   test:
+    # Release-prep PRs update image tags before those images are built. The
+    # install test would therefore fail by attempting to pull a future tag.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.user.login != 'github-actions[bot]' ||
+      !startsWith(github.head_ref, 'release-') ||
+      !endsWith(github.head_ref, '/prepare')
     runs-on: ubuntu-x64
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

Skip the Helm install-test job only for automated release-prep pull requests: PRs authored by `github-actions[bot]` whose head branch follows the release workflow's `release-*/prepare` convention. Pushes and ordinary pull requests continue to run the job.

This avoids trying to install an image tag that is intentionally built only after the release-prep PR is merged.

Fixes #878.

## Validation

- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/helm-test.yaml`

AI assistance: this implementation was prepared with AI-assisted tooling. The focused checks listed above were run on the submitted commit.
