### PR TITLE
ci: skip Helm test for release-prep PRs

### DIFF
--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -11,6 +11,7 @@ on:
   pull_request:
     branches-ignore:
       - "release-**/bundle-update"
+      - "release-**/prepare"
 
 jobs:
   test:


### PR DESCRIPTION
Release-prep branches reference images that are built after merge, so chart-testing cannot install them before the release is finalized.

Closes #878