### PR TITLE
Fix duplicate PLZ setup execution across reconciles

### DIFF
--- a/api/v1alpha1/k6conditions.go
+++ b/api/v1alpha1/k6conditions.go
@@ -16,6 +16,13 @@ const (
 	// - if True, it's after successful starter but before all runners have finished
 	TestRunRunning = "TestRunRunning"
 
+	// SetupExecuted indicates whether the `setup()` has been executed on one of the runners.
+	// This condition can be used only in PLZ test runs.
+	// - if False, setup has not been executed
+	// - if Unknown, setup execution is in progress
+	// - if True, setup has been executed successfully
+	SetupExecuted = "SetupExecuted"
+
 	// TeardownExecuted indicates whether the `teardown()` has been executed on one of the runners.
 	// This condition can be used only in PLZ test runs.
 	TeardownExecuted = "TeardownExecuted"
@@ -73,6 +80,13 @@ func Initialize(k6 *TestRun) {
 			Status:             metav1.ConditionUnknown,
 			LastTransitionTime: t,
 			Reason:             "TestRunPreparation",
+			Message:            "",
+		},
+		metav1.Condition{
+			Type:               SetupExecuted,
+			Status:             metav1.ConditionFalse,
+			LastTransitionTime: t,
+			Reason:             "SetupExecutedFalse",
 			Message:            "",
 		},
 		metav1.Condition{

--- a/api/v1alpha1/k6conditions_test.go
+++ b/api/v1alpha1/k6conditions_test.go
@@ -1,0 +1,32 @@
+package v1alpha1
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestInitializeSetupExecuted(t *testing.T) {
+	k6 := &TestRun{}
+
+	Initialize(k6)
+
+	if !IsFalse(k6, SetupExecuted) {
+		t.Fatalf("expected %s to be %s", SetupExecuted, metav1.ConditionFalse)
+	}
+
+	UpdateCondition(k6, SetupExecuted, metav1.ConditionUnknown)
+	if !IsUnknown(k6, SetupExecuted) {
+		t.Fatalf("expected %s to be %s", SetupExecuted, metav1.ConditionUnknown)
+	}
+
+	UpdateCondition(k6, SetupExecuted, metav1.ConditionTrue)
+	if !IsTrue(k6, SetupExecuted) {
+		t.Fatalf("expected %s to be %s", SetupExecuted, metav1.ConditionTrue)
+	}
+
+	UpdateCondition(k6, SetupExecuted, metav1.ConditionFalse)
+	if !IsFalse(k6, SetupExecuted) {
+		t.Fatalf("expected %s to be %s", SetupExecuted, metav1.ConditionFalse)
+	}
+}

--- a/internal/controller/k6_start.go
+++ b/internal/controller/k6_start.go
@@ -95,18 +95,39 @@ func StartJobs(ctx context.Context, log logr.Logger, k6 *v1alpha1.TestRun, r *Te
 	// setup
 
 	if v1alpha1.IsTrue(k6, v1alpha1.CloudPLZTestRun) {
-		if err, retry := runSetup(ctx, hostnames, log); err != nil {
-			if retry {
+		if _, exists := v1alpha1.LastUpdate(k6, v1alpha1.SetupExecuted); exists &&
+			v1alpha1.IsUnknown(k6, v1alpha1.SetupExecuted) {
+			return res, nil
+		}
+
+		if !v1alpha1.IsTrue(k6, v1alpha1.SetupExecuted) {
+			v1alpha1.UpdateCondition(k6, v1alpha1.SetupExecuted, metav1.ConditionUnknown)
+			if err = r.Status().Update(ctx, k6); err != nil {
 				return ctrl.Result{}, err
 			}
 
-			log.Error(err, "Setup function failed, requesting abort.")
-			events := cloud.ErrorEvent(cloud.SetupError).
-				WithDetail(fmt.Sprintf("setup function failed: %v", err)).
-				WithAbort()
-			cloud.SendTestRunEvents(cloudClient, k6.TestRunID(), log, events)
+			if err, retry := runSetup(ctx, hostnames, log); err != nil {
+				if retry {
+					v1alpha1.UpdateCondition(k6, v1alpha1.SetupExecuted, metav1.ConditionFalse)
+					if _, statusErr := r.UpdateStatus(ctx, k6, log); statusErr != nil {
+						return ctrl.Result{}, errors.Join(err, statusErr)
+					}
+					return ctrl.Result{}, err
+				}
 
-			return ctrl.Result{Requeue: false}, nil
+				log.Error(err, "Setup function failed, requesting abort.")
+				events := cloud.ErrorEvent(cloud.SetupError).
+					WithDetail(fmt.Sprintf("setup function failed: %v", err)).
+					WithAbort()
+				cloud.SendTestRunEvents(cloudClient, k6.TestRunID(), log, events)
+
+				return ctrl.Result{Requeue: false}, nil
+			}
+
+			v1alpha1.UpdateCondition(k6, v1alpha1.SetupExecuted, metav1.ConditionTrue)
+			if _, err = r.UpdateStatus(ctx, k6, log); err != nil {
+				return ctrl.Result{}, err
+			}
 		}
 	}
 

--- a/pkg/types/conditions.go
+++ b/pkg/types/conditions.go
@@ -70,6 +70,10 @@ var reasons = map[string]string{
 	"TestRunRunningTrue":    "TestRunRunningTrue",
 	"TestRunRunningFalse":   "TestRunRunningFalse",
 
+	"SetupExecutedUnknown": "TestRunPreparation",
+	"SetupExecutedFalse":   "SetupExecutedFalse",
+	"SetupExecutedTrue":    "SetupExecutedTrue",
+
 	"TeardownExecutedUnknown": "TestRunPreparation",
 	"TeardownExecutedFalse":   "TeardownExecutedFalse",
 	"TeardownExecutedTrue":    "TeardownExecutedTrue",


### PR DESCRIPTION
## What this changes

Fixes #871.

Adds a small `SetupExecuted` condition flow for PLZ test runs:

- `False` (or missing) is saved as `Unknown` before invoking `setup()`.
- A reconcile that observes `Unknown` waits instead of running setup or creating the starter.
- Retryable setup errors reset the condition to `False`.
- Successful setup changes it to `True`; later reconciles skip setup and continue the existing starter flow.

This keeps the change local to the existing condition and `StartJobs` paths. It does not add runner markers, claim IDs, timeouts, recovery phases, or setup-data APIs.

Validation: focused condition tests, `pkg/types` tests, controller package compilation, `go vet` for the changed packages, and `git diff --check`.