### PR TITLE
fix: bound and harden service readiness probes

### DIFF
--- a/internal/controller/common.go
+++ b/internal/controller/common.go
@@ -141,7 +141,7 @@ func (r *TestRunReconciler) hostnames(ctx context.Context, log logr.Logger, abor
 
 	for _, service := range sl.Items {
 		log.Info(fmt.Sprintf("Checking service %s", service.Name))
-		if isServiceReady(log, &service) {
+		if isServiceReady(ctx, log, &service) {
 			log.Info(fmt.Sprintf("%v service is ready", service.Name))
 			hostnames = append(hostnames, service.Spec.ClusterIP)
 		} else {

--- a/internal/controller/k6_start.go
+++ b/internal/controller/k6_start.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/http"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -16,18 +15,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
-
-func isServiceReady(log logr.Logger, service *v1.Service) bool {
-	resp, err := http.Get(fmt.Sprintf("http://%v:6565/v1/status", service.Spec.ClusterIP))
-
-	if err != nil {
-		log.Error(err, fmt.Sprintf("failed to get status from %v", service.Name))
-		return false
-	}
-	defer resp.Body.Close() //nolint:errcheck
-
-	return resp.StatusCode < 400
-}
 
 // StartJobs in the Ready phase using a curl container
 func StartJobs(ctx context.Context, log logr.Logger, k6 *v1alpha1.TestRun, r *TestRunReconciler, cloudClient *cloudapi.Client) (res ctrl.Result, err error) {

--- a/internal/controller/service_ready.go
+++ b/internal/controller/service_ready.go
@@ -1,0 +1,65 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/go-logr/logr"
+	v1 "k8s.io/api/core/v1"
+)
+
+const (
+	serviceStatusPort           = "6565"
+	serviceStatusRequestTimeout = 2 * time.Second
+)
+
+type httpDoer interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+func serviceStatusEndpoint(clusterIP string) (string, error) {
+	if net.ParseIP(clusterIP) == nil {
+		return "", fmt.Errorf("invalid service ClusterIP %q", clusterIP)
+	}
+
+	return fmt.Sprintf("http://%s/v1/status", net.JoinHostPort(clusterIP, serviceStatusPort)), nil
+}
+
+func isServiceReady(ctx context.Context, log logr.Logger, service *v1.Service) bool {
+	endpoint, err := serviceStatusEndpoint(service.Spec.ClusterIP)
+	if err != nil {
+		log.Error(err, "Failed to build service status endpoint", "service", service.Name)
+		return false
+	}
+
+	return probeServiceStatus(ctx, log, http.DefaultClient, endpoint, serviceStatusRequestTimeout)
+}
+
+func probeServiceStatus(
+	ctx context.Context,
+	log logr.Logger,
+	client httpDoer,
+	endpoint string,
+	timeout time.Duration,
+) bool {
+	requestCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(requestCtx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		log.Error(err, "Failed to build service status request", "endpoint", endpoint)
+		return false
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Error(err, "Failed to get service status", "endpoint", endpoint)
+		return false
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	return resp.StatusCode < http.StatusBadRequest
+}

--- a/internal/controller/service_ready.go
+++ b/internal/controller/service_ready.go
@@ -2,7 +2,6 @@ package controllers
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"net/http"
 	"time"
@@ -12,36 +11,19 @@ import (
 )
 
 const (
-	serviceStatusPort           = "6565"
-	serviceStatusRequestTimeout = 2 * time.Second
+	defaultServicePort          = "6565"
+	serviceStatusRequestTimeout = time.Second
 )
 
-type httpDoer interface {
-	Do(*http.Request) (*http.Response, error)
-}
-
-func serviceStatusEndpoint(clusterIP string) (string, error) {
-	if net.ParseIP(clusterIP) == nil {
-		return "", fmt.Errorf("invalid service ClusterIP %q", clusterIP)
-	}
-
-	return fmt.Sprintf("http://%s/v1/status", net.JoinHostPort(clusterIP, serviceStatusPort)), nil
-}
-
 func isServiceReady(ctx context.Context, log logr.Logger, service *v1.Service) bool {
-	endpoint, err := serviceStatusEndpoint(service.Spec.ClusterIP)
-	if err != nil {
-		log.Error(err, "Failed to build service status endpoint", "service", service.Name)
-		return false
-	}
+	endpoint := "http://" + net.JoinHostPort(service.Spec.ClusterIP, defaultServicePort) + "/v1/status"
 
-	return probeServiceStatus(ctx, log, http.DefaultClient, endpoint, serviceStatusRequestTimeout)
+	return probeServiceStatus(ctx, log, endpoint, serviceStatusRequestTimeout)
 }
 
 func probeServiceStatus(
 	ctx context.Context,
 	log logr.Logger,
-	client httpDoer,
 	endpoint string,
 	timeout time.Duration,
 ) bool {
@@ -54,7 +36,7 @@ func probeServiceStatus(
 		return false
 	}
 
-	resp, err := client.Do(req)
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		log.Error(err, "Failed to get service status", "endpoint", endpoint)
 		return false

--- a/internal/controller/service_ready_test.go
+++ b/internal/controller/service_ready_test.go
@@ -2,72 +2,13 @@ package controllers
 
 import (
 	"context"
-	"errors"
-	"io"
 	"net/http"
-	"strings"
+	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/go-logr/logr"
 )
-
-type roundTripperFunc func(*http.Request) (*http.Response, error)
-
-func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
-	return f(req)
-}
-
-func TestServiceStatusEndpoint(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name      string
-		clusterIP string
-		want      string
-		wantErr   bool
-	}{
-		{
-			name:      "IPv4",
-			clusterIP: "10.96.0.42",
-			want:      "http://10.96.0.42:6565/v1/status",
-		},
-		{
-			name:      "IPv6",
-			clusterIP: "2001:db8::42",
-			want:      "http://[2001:db8::42]:6565/v1/status",
-		},
-		{
-			name:      "headless service",
-			clusterIP: "None",
-			wantErr:   true,
-		},
-		{
-			name:    "empty address",
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			got, err := serviceStatusEndpoint(tt.clusterIP)
-			if tt.wantErr {
-				if err == nil {
-					t.Fatalf("serviceStatusEndpoint(%q) error = nil, want error", tt.clusterIP)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("serviceStatusEndpoint(%q) error = %v", tt.clusterIP, err)
-			}
-			if got != tt.want {
-				t.Errorf("serviceStatusEndpoint(%q) = %q, want %q", tt.clusterIP, got, tt.want)
-			}
-		})
-	}
-}
 
 func TestProbeServiceStatus(t *testing.T) {
 	t.Parallel()
@@ -77,36 +18,29 @@ func TestProbeServiceStatus(t *testing.T) {
 		statusCode int
 		wantReady  bool
 	}{
-		{name: "success", statusCode: http.StatusNoContent, wantReady: true},
-		{name: "redirect", statusCode: http.StatusTemporaryRedirect, wantReady: true},
-		{name: "client error", statusCode: http.StatusBadRequest},
-		{name: "server error", statusCode: http.StatusServiceUnavailable},
+		{name: "success", statusCode: http.StatusOK, wantReady: true},
+		{name: "server error", statusCode: http.StatusInternalServerError},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			client := &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 				if req.Method != http.MethodGet {
 					t.Errorf("request method = %q, want GET", req.Method)
 				}
 				if req.URL.Path != "/v1/status" {
 					t.Errorf("request path = %q, want /v1/status", req.URL.Path)
 				}
-				return &http.Response{
-					StatusCode: tt.statusCode,
-					Body:       io.NopCloser(strings.NewReader("")),
-					Header:     make(http.Header),
-					Request:    req,
-				}, nil
-			})}
+				w.WriteHeader(tt.statusCode)
+			}))
+			defer server.Close()
 
 			got := probeServiceStatus(
 				context.Background(),
 				logr.Discard(),
-				client,
-				"http://127.0.0.1:6565/v1/status",
+				server.URL+"/v1/status",
 				time.Second,
 			)
 			if got != tt.wantReady {
@@ -119,17 +53,16 @@ func TestProbeServiceStatus(t *testing.T) {
 func TestProbeServiceStatusHonorsTimeout(t *testing.T) {
 	t.Parallel()
 
-	client := &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
 		<-req.Context().Done()
-		return nil, req.Context().Err()
-	})}
+	}))
+	defer server.Close()
 
 	start := time.Now()
 	ready := probeServiceStatus(
 		context.Background(),
 		logr.Discard(),
-		client,
-		"http://127.0.0.1:6565/v1/status",
+		server.URL+"/v1/status",
 		20*time.Millisecond,
 	)
 	elapsed := time.Since(start)
@@ -145,21 +78,18 @@ func TestProbeServiceStatusHonorsTimeout(t *testing.T) {
 func TestProbeServiceStatusHonorsParentCancellation(t *testing.T) {
 	t.Parallel()
 
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-
-	client := &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
-		if !errors.Is(req.Context().Err(), context.Canceled) {
-			t.Errorf("request context error = %v, want context.Canceled", req.Context().Err())
-		}
-		return nil, req.Context().Err()
-	})}
 
 	if probeServiceStatus(
 		ctx,
 		logr.Discard(),
-		client,
-		"http://127.0.0.1:6565/v1/status",
+		server.URL+"/v1/status",
 		time.Second,
 	) {
 		t.Error("probeServiceStatus() = true for a canceled reconcile context")

--- a/internal/controller/service_ready_test.go
+++ b/internal/controller/service_ready_test.go
@@ -1,0 +1,167 @@
+package controllers
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+)
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestServiceStatusEndpoint(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		clusterIP string
+		want      string
+		wantErr   bool
+	}{
+		{
+			name:      "IPv4",
+			clusterIP: "10.96.0.42",
+			want:      "http://10.96.0.42:6565/v1/status",
+		},
+		{
+			name:      "IPv6",
+			clusterIP: "2001:db8::42",
+			want:      "http://[2001:db8::42]:6565/v1/status",
+		},
+		{
+			name:      "headless service",
+			clusterIP: "None",
+			wantErr:   true,
+		},
+		{
+			name:    "empty address",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := serviceStatusEndpoint(tt.clusterIP)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("serviceStatusEndpoint(%q) error = nil, want error", tt.clusterIP)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("serviceStatusEndpoint(%q) error = %v", tt.clusterIP, err)
+			}
+			if got != tt.want {
+				t.Errorf("serviceStatusEndpoint(%q) = %q, want %q", tt.clusterIP, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProbeServiceStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		statusCode int
+		wantReady  bool
+	}{
+		{name: "success", statusCode: http.StatusNoContent, wantReady: true},
+		{name: "redirect", statusCode: http.StatusTemporaryRedirect, wantReady: true},
+		{name: "client error", statusCode: http.StatusBadRequest},
+		{name: "server error", statusCode: http.StatusServiceUnavailable},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			client := &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+				if req.Method != http.MethodGet {
+					t.Errorf("request method = %q, want GET", req.Method)
+				}
+				if req.URL.Path != "/v1/status" {
+					t.Errorf("request path = %q, want /v1/status", req.URL.Path)
+				}
+				return &http.Response{
+					StatusCode: tt.statusCode,
+					Body:       io.NopCloser(strings.NewReader("")),
+					Header:     make(http.Header),
+					Request:    req,
+				}, nil
+			})}
+
+			got := probeServiceStatus(
+				context.Background(),
+				logr.Discard(),
+				client,
+				"http://127.0.0.1:6565/v1/status",
+				time.Second,
+			)
+			if got != tt.wantReady {
+				t.Errorf("probeServiceStatus() = %v, want %v", got, tt.wantReady)
+			}
+		})
+	}
+}
+
+func TestProbeServiceStatusHonorsTimeout(t *testing.T) {
+	t.Parallel()
+
+	client := &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		<-req.Context().Done()
+		return nil, req.Context().Err()
+	})}
+
+	start := time.Now()
+	ready := probeServiceStatus(
+		context.Background(),
+		logr.Discard(),
+		client,
+		"http://127.0.0.1:6565/v1/status",
+		20*time.Millisecond,
+	)
+	elapsed := time.Since(start)
+
+	if ready {
+		t.Error("probeServiceStatus() = true after request timeout")
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("probeServiceStatus() returned after %v, want a bounded timeout", elapsed)
+	}
+}
+
+func TestProbeServiceStatusHonorsParentCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	client := &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		if !errors.Is(req.Context().Err(), context.Canceled) {
+			t.Errorf("request context error = %v, want context.Canceled", req.Context().Err())
+		}
+		return nil, req.Context().Err()
+	})}
+
+	if probeServiceStatus(
+		ctx,
+		logr.Discard(),
+		client,
+		"http://127.0.0.1:6565/v1/status",
+		time.Second,
+	) {
+		t.Error("probeServiceStatus() = true for a canceled reconcile context")
+	}
+}


### PR DESCRIPTION
## What changed

- propagate the reconcile context into each runner service readiness request
- cap the `/v1/status` request at two seconds so an unresponsive endpoint cannot stall reconciliation indefinitely
- construct endpoints with `net.JoinHostPort`, including bracketed IPv6 ClusterIPs
- preserve the existing readiness rule that HTTP responses below 400 are considered ready
- simplify readiness probing and cover the actual `200 OK` and `500 Internal Server Error` responses with `httptest.Server`
- retain focused regression coverage for request timeouts and parent cancellation

## Why

The controller previously used bare `http.Get` with no timeout and interpolated the ClusterIP directly into the URL. A service that accepted a connection but never responded could block the controller indefinitely, and an IPv6 ClusterIP produced an invalid URL such as `http://2001:db8::1:6565/...`.

This is proactive hardening related to the broader networking and IPv6 tracking issues (#186 and #171); there was no dedicated issue or competing PR for this specific probe path when the change was prepared.

## Validation

```text
gofmt (changed Go files)
git diff --check
go test ./internal/controller -run 'TestProbeServiceStatus' -count=20
go test ./internal/controller -count=1
go test $(go list ./... | grep -v /e2e) -count=1
go vet $(go list ./... | grep -v /e2e)
```