### PR TITLE
CI: bump helm-charts workflow + enable renovate on it

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -118,7 +118,7 @@ jobs:
     needs:
       - decide
       - generate-chart-schema
-    uses: grafana/helm-charts/.github/workflows/update-helm-repo.yaml@8ac07d41b2fa02ca16dc0fc084d8f145cb690988
+    uses: grafana/helm-charts/.github/workflows/update-helm-repo.yaml@657512bfa4b278832766f91e69807e6ef99cfe33 # main
     with:
       charts_dir: charts
       cr_configfile: charts/cr.yaml


### PR DESCRIPTION
History context: this workflow wasn't actually updated for the last month-two. It was initially imported directly as `@main`, which worked best; then that form was "forbidden" / not recommended, so it was switched to digest. But Renovate needs a comment to recognize it or it skips it.