### PR TITLE
fix(controller): return error on start job create failure

### DIFF
--- a/internal/controller/k6_stop.go
+++ b/internal/controller/k6_stop.go
@@ -51,7 +51,7 @@ func StopJobs(ctx context.Context, log logr.Logger, k6 *v1alpha1.TestRun, r *Tes
 	created, err := createJobIfNotExists(ctx, r.Client, stopJob)
 	if err != nil {
 		log.Error(err, "Failed to launch k6 test stop job.")
-		return res, nil
+		return res, err
 	}
 
 	if created {


### PR DESCRIPTION
Fixes same issue as #876 for the StartJobs path. When creating the starter job fails, the error was swallowed and the reconciler returned success, leaving the TestRun permanently stuck.