### PR TITLE
fix(plz): prevent setup() from running twice on PLZ test runs

### DIFF
--- a/api/v1alpha1/k6conditions.go
+++ b/api/v1alpha1/k6conditions.go
@@ -20,6 +20,10 @@ const (
 	// This condition can be used only in PLZ test runs.
 	TeardownExecuted = "TeardownExecuted"
 
+	// SetupExecuted indicates whether the `setup()` has been executed on one of the runners.
+	// This condition can be used only in PLZ test runs.
+	SetupExecuted = "SetupExecuted"
+
 	// CloudTestRun indicates if this test run is supposed to be a cloud test run
 	// (i.e. with `--out cloud` option).
 	// - if empty / Unknown, the type of test is unknown yet
@@ -80,6 +84,13 @@ func Initialize(k6 *TestRun) {
 			Status:             metav1.ConditionFalse,
 			LastTransitionTime: t,
 			Reason:             "TeardownExecutedFalse",
+			Message:            "",
+		},
+		metav1.Condition{
+			Type:               SetupExecuted,
+			Status:             metav1.ConditionFalse,
+			LastTransitionTime: t,
+			Reason:             "SetupExecutedFalse",
 			Message:            "",
 		},
 	}

--- a/internal/controller/k6_start.go
+++ b/internal/controller/k6_start.go
@@ -95,18 +95,21 @@ func StartJobs(ctx context.Context, log logr.Logger, k6 *v1alpha1.TestRun, r *Te
 	// setup
 
 	if v1alpha1.IsTrue(k6, v1alpha1.CloudPLZTestRun) {
-		if err, retry := runSetup(ctx, hostnames, log); err != nil {
-			if retry {
-				return ctrl.Result{}, err
+		if !v1alpha1.IsTrue(k6, v1alpha1.TestRunSetupExecuted) {
+			if err, retry := runSetup(ctx, hostnames, log); err != nil {
+				if retry {
+					return ctrl.Result{}, err
+				}
+
+				log.Error(err, "Setup function failed, requesting abort.")
+				events := cloud.ErrorEvent(cloud.SetupError).
+					WithDetail(fmt.Sprintf("setup function failed: %v", err)).
+					WithAbort()
+				cloud.SendTestRunEvents(cloudClient, k6.TestRunID(), log, events)
+
+				return ctrl.Result{Requeue: false}, nil
 			}
-
-			log.Error(err, "Setup function failed, requesting abort.")
-			events := cloud.ErrorEvent(cloud.SetupError).
-				WithDetail(fmt.Sprintf("setup function failed: %v", err)).
-				WithAbort()
-			cloud.SendTestRunEvents(cloudClient, k6.TestRunID(), log, events)
-
-			return ctrl.Result{Requeue: false}, nil
+			v1alpha1.UpdateCondition(k6, v1alpha1.SetupExecuted, metav1.ConditionTrue)
 		}
 	}
 


### PR DESCRIPTION
The runSetup() call in StartJobs had no guard, so concurrent
reconcile loops could execute setup() multiple times before the
status updated to 'started'.

Add a SetupExecuted condition (mirroring the existing TeardownExecuted
pattern) and check it before calling runSetup(). Set the condition
to true after successful setup completion.

fixes #871